### PR TITLE
♻️ refactor(styles): migrate remaining createStyles to createStaticStyles

### DIFF
--- a/packages/builtin-tool-gtd/src/client/Intervention/CreatePlan.tsx
+++ b/packages/builtin-tool-gtd/src/client/Intervention/CreatePlan.tsx
@@ -12,17 +12,17 @@ import {
 } from '@lobehub/editor';
 import { Editor, useEditor } from '@lobehub/editor/react';
 import { Flexbox, TextArea } from '@lobehub/ui';
-import { createStyles } from 'antd-style';
+import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { CreatePlanParams } from '../../types';
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   description: css`
     font-size: 14px;
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
   `,
   title: css`
     font-size: 28px;
@@ -33,8 +33,6 @@ const useStyles = createStyles(({ css, token }) => ({
 const CreatePlanIntervention = memo<BuiltinInterventionProps<CreatePlanParams>>(
   ({ args, onArgsChange, registerBeforeApprove }) => {
     const { t } = useTranslation('tool');
-    const { styles } = useStyles();
-
     const [goal, setGoal] = useState(args?.goal || '');
     const [description, setDescription] = useState(args?.description || '');
 

--- a/packages/builtin-tool-gtd/src/client/Render/CreatePlan/PlanCard.tsx
+++ b/packages/builtin-tool-gtd/src/client/Render/CreatePlan/PlanCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Block, Flexbox, Icon, Markdown, Text } from '@lobehub/ui';
-import { createStyles } from 'antd-style';
+import { createStaticStyles } from 'antd-style';
 import { ListChecksIcon } from 'lucide-react';
 import { memo } from 'react';
 
@@ -11,15 +11,15 @@ import type { Plan } from '../../../types';
 
 const MAX_CONTENT_HEIGHT = 100;
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   content: css`
     overflow: hidden auto;
 
     max-height: ${MAX_CONTENT_HEIGHT}px;
     padding: 12px;
-    border-radius: ${token.borderRadius}px;
+    border-radius: ${cssVar.borderRadius};
 
-    background: ${token.colorFillQuaternary};
+    background: ${cssVar.colorFillQuaternary};
   `,
   header: css`
     cursor: pointer;
@@ -38,7 +38,6 @@ interface PlanCardProps {
 }
 
 const PlanCard = memo<PlanCardProps>(({ plan }) => {
-  const { styles } = useStyles();
   const openDocument = useChatStore((s) => s.openDocument);
 
   const handleHeaderClick = () => {

--- a/src/features/ChatInput/InputEditor/MentionMenu/CategoryView.tsx
+++ b/src/features/ChatInput/InputEditor/MentionMenu/CategoryView.tsx
@@ -4,7 +4,7 @@ import type { MouseEvent } from 'react';
 import { memo } from 'react';
 
 import MenuItem from './MenuItem';
-import { useStyles } from './style';
+import { styles } from './style';
 import type { MentionCategory } from './types';
 
 interface CategoryViewProps {
@@ -15,7 +15,6 @@ interface CategoryViewProps {
 }
 
 const CategoryView = memo<CategoryViewProps>(({ category, activeKey, onSelectItem, onBack }) => {
-  const { styles } = useStyles();
   const handleMouseDown = (event: MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
   };

--- a/src/features/ChatInput/InputEditor/MentionMenu/HomeView.tsx
+++ b/src/features/ChatInput/InputEditor/MentionMenu/HomeView.tsx
@@ -3,7 +3,7 @@ import { ChevronRight } from 'lucide-react';
 import { memo } from 'react';
 
 import MenuItem from './MenuItem';
-import { useStyles } from './style';
+import { styles } from './style';
 import { isCategoryEntry } from './types';
 
 interface HomeViewProps {
@@ -14,8 +14,6 @@ interface HomeViewProps {
 }
 
 const HomeView = memo<HomeViewProps>(({ visibleItems, activeKey, onSelectItem, dividerIndex }) => {
-  const { styles } = useStyles();
-
   return (
     <div className={styles.scrollArea}>
       {visibleItems.map((item, idx) => {

--- a/src/features/ChatInput/InputEditor/MentionMenu/MenuItem.tsx
+++ b/src/features/ChatInput/InputEditor/MentionMenu/MenuItem.tsx
@@ -3,7 +3,7 @@ import { cx } from 'antd-style';
 import { createElement, isValidElement, type MouseEvent, type ReactNode } from 'react';
 import { memo } from 'react';
 
-import { useStyles } from './style';
+import { styles } from './style';
 
 interface MenuItemProps {
   active?: boolean;
@@ -13,7 +13,6 @@ interface MenuItemProps {
 }
 
 const MenuItem = memo<MenuItemProps>(({ item, active, extra, onClick }) => {
-  const { styles } = useStyles();
   const handleMouseDown = (event: MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
   };

--- a/src/features/ChatInput/InputEditor/MentionMenu/SearchView.tsx
+++ b/src/features/ChatInput/InputEditor/MentionMenu/SearchView.tsx
@@ -2,7 +2,7 @@ import type { ISlashMenuOption } from '@lobehub/editor';
 import { memo } from 'react';
 
 import MenuItem from './MenuItem';
-import { useStyles } from './style';
+import { styles } from './style';
 
 interface SearchViewProps {
   activeKey: string | null;
@@ -11,8 +11,6 @@ interface SearchViewProps {
 }
 
 const SearchView = memo<SearchViewProps>(({ options, activeKey, onSelectItem }) => {
-  const { styles } = useStyles();
-
   if (options.length === 0) {
     return <div className={styles.empty}>No results</div>;
   }

--- a/src/features/ChatInput/InputEditor/MentionMenu/index.tsx
+++ b/src/features/ChatInput/InputEditor/MentionMenu/index.tsx
@@ -7,7 +7,7 @@ import { createPortal } from 'react-dom';
 import CategoryView from './CategoryView';
 import HomeView from './HomeView';
 import SearchView from './SearchView';
-import { useStyles } from './style';
+import { styles } from './style';
 import type { MentionCategory, MentionCategoryId, MentionMenuState } from './types';
 import { CATEGORY_KEY_PREFIX, getCategoryIdFromKey, isCategoryEntry } from './types';
 import { useKeyboardNav } from './useKeyboardNav';
@@ -50,7 +50,6 @@ export const createMentionMenu = (
 ): FC<MenuRenderProps> => {
   const MentionMenu: FC<MenuRenderProps> = memo(
     ({ activeKey, onSelect, open, options, setActiveKey }) => {
-      const { styles } = useStyles();
       const menuRef = useRef<HTMLDivElement>(null);
       const [viewMode, setViewMode] = useState<'home' | 'category'>('home');
       const [selectedCategoryId, setSelectedCategoryId] = useState<MentionCategoryId | null>(null);

--- a/src/features/ChatInput/InputEditor/MentionMenu/style.ts
+++ b/src/features/ChatInput/InputEditor/MentionMenu/style.ts
@@ -1,6 +1,6 @@
-import { createStyles } from 'antd-style';
+import { createStaticStyles } from 'antd-style';
 
-export const useStyles = createStyles(({ css, token, isDarkMode }) => ({
+export const styles = createStaticStyles(({ css, cssVar }) => ({
   backHeader: css`
     cursor: pointer;
 
@@ -13,10 +13,10 @@ export const useStyles = createStyles(({ css, token, isDarkMode }) => ({
 
     font-size: 13px;
     font-weight: 500;
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
 
     &:hover {
-      color: ${token.colorText};
+      color: ${cssVar.colorText};
     }
   `,
   categoryExtra: css`
@@ -26,7 +26,7 @@ export const useStyles = createStyles(({ css, token, isDarkMode }) => ({
     align-items: center;
 
     font-size: 12px;
-    color: ${token.colorTextQuaternary};
+    color: ${cssVar.colorTextQuaternary};
   `,
   container: css`
     position: fixed;
@@ -39,24 +39,24 @@ export const useStyles = createStyles(({ css, token, isDarkMode }) => ({
     max-width: 360px;
     max-height: 360px;
     padding: 4px;
-    border: 1px solid ${token.colorBorderSecondary};
+    border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: 10px;
 
-    background: ${isDarkMode ? token.colorBgElevated : token.colorBgContainer};
-    box-shadow: ${token.boxShadowSecondary};
+    background: ${cssVar.colorBgElevated};
+    box-shadow: ${cssVar.boxShadowSecondary};
   `,
   divider: css`
     height: 1px;
     margin-block: 4px;
     margin-inline: 8px;
-    background: ${token.colorBorder};
+    background: ${cssVar.colorBorder};
   `,
   empty: css`
     padding-block: 16px;
     padding-inline: 12px;
 
     font-size: 13px;
-    color: ${token.colorTextQuaternary};
+    color: ${cssVar.colorTextQuaternary};
     text-align: center;
   `,
   item: css`
@@ -75,11 +75,11 @@ export const useStyles = createStyles(({ css, token, isDarkMode }) => ({
     transition: background 0.1s;
 
     &:hover {
-      background: ${token.colorFillTertiary};
+      background: ${cssVar.colorFillTertiary};
     }
   `,
   itemActive: css`
-    background: ${token.colorFillSecondary};
+    background: ${cssVar.colorFillSecondary};
   `,
   itemIcon: css`
     display: flex;

--- a/src/features/Conversation/components/Reaction/ReactionDisplay.tsx
+++ b/src/features/Conversation/components/Reaction/ReactionDisplay.tsx
@@ -2,14 +2,14 @@
 
 import type { EmojiReaction } from '@lobechat/types';
 import { Flexbox } from '@lobehub/ui';
-import { createStyles } from 'antd-style';
+import { createStaticStyles, cx } from 'antd-style';
 import { memo } from 'react';
 
 import ReactionPicker from './ReactionPicker';
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   active: css`
-    background: ${token.colorFillTertiary};
+    background: ${cssVar.colorFillTertiary};
   `,
   container: css`
     display: flex;
@@ -18,7 +18,7 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
   count: css`
     font-size: 12px;
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
   `,
   reactionTag: css`
     cursor: pointer;
@@ -35,12 +35,12 @@ const useStyles = createStyles(({ css, token }) => ({
     font-size: 14px;
     line-height: 1;
 
-    background: ${token.colorFillSecondary};
+    background: ${cssVar.colorFillSecondary};
 
     transition: all 0.2s;
 
     &:hover {
-      background: ${token.colorFillTertiary};
+      background: ${cssVar.colorFillTertiary};
     }
   `,
 }));
@@ -66,8 +66,6 @@ interface ReactionDisplayProps {
 
 const ReactionDisplay = memo<ReactionDisplayProps>(
   ({ reactions, onReactionClick, messageId, isActive }) => {
-    const { styles, cx } = useStyles();
-
     if (reactions.length === 0) return null;
 
     return (

--- a/src/features/Conversation/components/Reaction/ReactionPicker.tsx
+++ b/src/features/Conversation/components/Reaction/ReactionPicker.tsx
@@ -4,7 +4,7 @@ import data from '@emoji-mart/data';
 import Picker from '@emoji-mart/react';
 import { ActionIcon, Flexbox, Tooltip } from '@lobehub/ui';
 import { Popover } from 'antd';
-import { createStyles, useTheme } from 'antd-style';
+import { createStaticStyles, useTheme } from 'antd-style';
 import { PlusIcon, SmilePlus } from 'lucide-react';
 import { type FC, memo, type ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -16,7 +16,7 @@ import { useConversationStore } from '../../store';
 
 const QUICK_REACTIONS = ['👍', '👎', '❤️', '😄', '😂', '😅', '🎉', '😢', '🤔', '🚀'];
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   emojiButton: css`
     cursor: pointer;
 
@@ -26,7 +26,7 @@ const useStyles = createStyles(({ css, token }) => ({
 
     width: 32px;
     height: 32px;
-    border-radius: ${token.borderRadius}px;
+    border-radius: ${cssVar.borderRadius};
 
     font-size: 18px;
 
@@ -34,7 +34,7 @@ const useStyles = createStyles(({ css, token }) => ({
 
     &:hover {
       transform: scale(1.1);
-      background: ${token.colorFillSecondary};
+      background: ${cssVar.colorFillSecondary};
     }
   `,
   moreButton: css`
@@ -46,15 +46,15 @@ const useStyles = createStyles(({ css, token }) => ({
 
     width: 32px;
     height: 32px;
-    border-radius: ${token.borderRadius}px;
+    border-radius: ${cssVar.borderRadius};
 
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
 
     transition: all 0.2s;
 
     &:hover {
-      color: ${token.colorText};
-      background: ${token.colorFillSecondary};
+      color: ${cssVar.colorText};
+      background: ${cssVar.colorFillSecondary};
     }
   `,
   pickerContainer: css`
@@ -68,7 +68,6 @@ interface ReactionPickerProps {
 }
 
 const ReactionPicker: FC<ReactionPickerProps> = memo(({ messageId, trigger }) => {
-  const { styles } = useStyles();
   const { t } = useTranslation('chat');
   const theme = useTheme();
   const locale = useGlobalStore(globalGeneralSelectors.currentLanguage);

--- a/src/features/Electron/connection/DeviceGateway.tsx
+++ b/src/features/Electron/connection/DeviceGateway.tsx
@@ -1,7 +1,7 @@
 import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
 import { ActionIcon, Flexbox } from '@lobehub/ui';
 import { Input, Popover, Switch } from 'antd';
-import { createStyles, cssVar } from 'antd-style';
+import { createStaticStyles } from 'antd-style';
 import { HardDrive } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { useElectronStore } from '@/store/electron';
 import { electronSyncSelectors } from '@/store/electron/selectors';
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   fieldLabel: css`
     font-size: 12px;
     color: ${cssVar.colorTextDescription};
@@ -28,11 +28,11 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
   input: css`
     border: none;
-    background: ${token.colorFillTertiary};
+    background: ${cssVar.colorFillTertiary};
 
     &:hover,
     &:focus {
-      background: ${token.colorFillSecondary};
+      background: ${cssVar.colorFillSecondary};
     }
   `,
   popoverContent: css`
@@ -49,8 +49,6 @@ const useStyles = createStyles(({ css, token }) => ({
 
 const DeviceGateway = memo(() => {
   const { t } = useTranslation('electron');
-  const { styles } = useStyles();
-
   const [
     gatewayStatus,
     connectGateway,

--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -1,6 +1,6 @@
 import { TooltipGroup } from '@lobehub/ui';
 import { Select, type SelectProps } from '@lobehub/ui/base-ui';
-import { createStaticStyles, createStyles } from 'antd-style';
+import { createStaticStyles } from 'antd-style';
 import { type ReactNode } from 'react';
 import { memo, useMemo } from 'react';
 
@@ -10,18 +10,10 @@ import { type EnabledProviderWithModels } from '@/types/aiProvider';
 
 const prefixCls = 'ant';
 
-const useStyles = createStyles(({ css }, { popupWidth }: { popupWidth?: number | string }) => ({
-  popup: css`
-    width: ${popupWidth
-      ? typeof popupWidth === 'number'
-        ? `${popupWidth}px`
-        : popupWidth
-      : 'max(360px, var(--anchor-width))'};
-  `,
-}));
-
 const styles = createStaticStyles(({ css }) => ({
   popup: css`
+    width: max(360px, var(--anchor-width));
+
     &.${prefixCls}-select-dropdown .${prefixCls}-select-item-option-grouped {
       padding-inline-start: 12px;
     }
@@ -47,7 +39,7 @@ interface ModelSelectProps extends Pick<SelectProps, 'loading' | 'size' | 'style
   defaultValue?: { model: string; provider?: string };
   initialWidth?: boolean;
   onChange?: (props: { model: string; provider: string }) => void;
-  popupWidth?: number | string;
+  popupWidth?: number;
   requiredAbilities?: (keyof EnabledProviderWithModels['children'][number]['abilities'])[];
   showAbility?: boolean;
   value?: { model: string; provider?: string };
@@ -66,7 +58,6 @@ const ModelSelect = memo<ModelSelectProps>(
     initialWidth = false,
     popupWidth,
   }) => {
-    const { styles: dynamicStyles } = useStyles({ popupWidth });
     const enabledList = useEnabledChatModels();
 
     const options = useMemo<SelectProps['options']>(() => {
@@ -119,8 +110,8 @@ const ModelSelect = memo<ModelSelectProps>(
           defaultValue={`${value?.provider}/${value?.model}`}
           loading={loading}
           options={options}
-          popupClassName={popupWidth ? `${styles.popup} ${dynamicStyles.popup}` : styles.popup}
-          popupMatchSelectWidth={false}
+          popupClassName={styles.popup}
+          popupMatchSelectWidth={popupWidth === undefined ? false : popupWidth}
           size={size}
           value={`${value?.provider}/${value?.model}`}
           variant={variant}

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/cases/[caseId]/features/CaseBanner/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/cases/[caseId]/features/CaseBanner/index.tsx
@@ -4,7 +4,7 @@ import type { EvalRunTopicResult } from '@lobechat/types';
 import { formatCost, formatShortenNumber } from '@lobechat/utils';
 import { ActionIcon, Flexbox, Tag } from '@lobehub/ui';
 import { Typography } from 'antd';
-import { createStyles } from 'antd-style';
+import { createStaticStyles } from 'antd-style';
 import {
   ArrowLeft,
   ChevronLeft,
@@ -17,29 +17,29 @@ import {
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   backLink: css`
     cursor: pointer;
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
 
     &:hover {
-      color: ${token.colorText};
+      color: ${cssVar.colorText};
     }
   `,
   header: css`
     padding-inline: 16px;
-    border-block-end: 1px solid ${token.colorBorderSecondary};
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
   `,
   metricCard: css`
     gap: 8px;
 
     padding-block: 6px;
     padding-inline: 8px 16px;
-    border-radius: ${token.borderRadiusSM}px;
+    border-radius: ${cssVar.borderRadiusSM};
 
     font-size: 12px;
 
-    background: ${token.colorFillQuaternary};
+    background: ${cssVar.colorFillQuaternary};
   `,
   metricIcon: css`
     display: flex;
@@ -48,23 +48,23 @@ const useStyles = createStyles(({ css, token }) => ({
 
     width: 28px;
     height: 28px;
-    border-radius: ${token.borderRadiusSM}px;
+    border-radius: ${cssVar.borderRadiusSM};
 
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
 
-    background: ${token.colorFillTertiary};
+    background: ${cssVar.colorFillTertiary};
   `,
   metricLabel: css`
     font-size: 11px;
     line-height: 1;
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
   `,
   metricValue: css`
     font-family: monospace;
     font-size: 14px;
     font-weight: 500;
     line-height: 1.4;
-    color: ${token.colorText};
+    color: ${cssVar.colorText};
   `,
 }));
 
@@ -81,8 +81,6 @@ interface CaseHeaderProps {
 const CaseHeader = memo<CaseHeaderProps>(
   ({ passed, caseNumber, runName, evalResult, onBack, onPrev, onNext }) => {
     const { t } = useTranslation('eval');
-    const { styles } = useStyles();
-
     const metrics = [
       {
         icon: Clock,

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/cases/[caseId]/features/InfoSidebar/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/cases/[caseId]/features/InfoSidebar/index.tsx
@@ -4,14 +4,14 @@ import type { EvalRubricScore } from '@lobechat/types';
 import { formatCost, formatShortenNumber } from '@lobechat/utils';
 import { Flexbox, Tag, Text } from '@lobehub/ui';
 import { Collapse, Divider, Progress, Typography } from 'antd';
-import { createStyles } from 'antd-style';
+import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   container: css`
-    border-inline-start: 1px solid ${token.colorBorderSecondary};
-    background: ${token.colorBgContainer};
+    border-inline-start: 1px solid ${cssVar.colorBorderSecondary};
+    background: ${cssVar.colorBgContainer};
   `,
   infoItem: css`
     display: flex;
@@ -23,12 +23,12 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
   infoLabel: css`
     font-size: 13px;
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
   `,
   infoValue: css`
     font-family: monospace;
     font-size: 13px;
-    color: ${token.colorText};
+    color: ${cssVar.colorText};
   `,
   rubricItem: css`
     padding-block: 8px;
@@ -41,19 +41,19 @@ const useStyles = createStyles(({ css, token }) => ({
   rubricReason: css`
     font-size: 12px;
     line-height: 1.5;
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
   `,
   rubricScore: css`
     font-family: monospace;
     font-size: 12px;
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
   `,
   sectionTitle: css`
     margin: 0;
 
     font-size: 12px;
     font-weight: 600;
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
     text-transform: uppercase;
     letter-spacing: 0.5px;
   `,
@@ -105,8 +105,6 @@ const isDeterministicMode = (rubricId: string): boolean => {
 
 const InfoSidebar = memo<InfoSidebarProps>(({ testCase, evalResult, passed, score }) => {
   const { t } = useTranslation('eval');
-  const { styles } = useStyles();
-
   const rubricScores = evalResult?.rubricScores;
   const hasRubricScores = rubricScores && rubricScores.length > 0;
 

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/IdleState/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/IdleState/index.tsx
@@ -2,14 +2,14 @@
 
 import { Button, Icon } from '@lobehub/ui';
 import { App } from 'antd';
-import { createStyles } from 'antd-style';
+import { createStaticStyles, cx } from 'antd-style';
 import { Brain, ChartBar, MessageSquare, Play } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useEvalStore } from '@/store/eval';
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   center: css`
     position: absolute;
     inset: 0;
@@ -23,9 +23,9 @@ const useStyles = createStyles(({ css, token }) => ({
     margin: auto;
     border-radius: 50%;
 
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
 
-    background: ${token.colorFillTertiary};
+    background: ${cssVar.colorFillTertiary};
   `,
   container: css`
     position: relative;
@@ -40,7 +40,7 @@ const useStyles = createStyles(({ css, token }) => ({
   hint: css`
     margin-block-start: 24px;
     font-size: 13px;
-    color: ${token.colorTextQuaternary};
+    color: ${cssVar.colorTextQuaternary};
   `,
   icon: css`
     position: absolute;
@@ -57,27 +57,27 @@ const useStyles = createStyles(({ css, token }) => ({
   icon1: css`
     inset-block-start: 15px;
     inset-inline-start: 100px;
-    color: ${token.geekblue};
-    background: ${token.geekblue1};
+    color: ${cssVar.geekblue};
+    background: ${cssVar.geekblue1};
   `,
   icon2: css`
     inset-block-start: 143px;
     inset-inline-start: 174px;
-    color: ${token.colorSuccess};
-    background: ${token.colorSuccessBg};
+    color: ${cssVar.colorSuccess};
+    background: ${cssVar.colorSuccessBg};
   `,
   icon3: css`
     inset-block-start: 143px;
     inset-inline-start: 26px;
-    color: ${token.purple};
-    background: ${token.purple1};
+    color: ${cssVar.purple};
+    background: ${cssVar.purple1};
   `,
   orbit: css`
     position: absolute;
     inset: 0;
 
     margin: auto;
-    border: 1px solid ${token.colorBorderSecondary};
+    border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: 50%;
   `,
   orbit1: css`
@@ -105,7 +105,6 @@ interface IdleStateProps {
 
 const IdleState = memo<IdleStateProps>(({ run }) => {
   const { t } = useTranslation('eval');
-  const { cx, styles } = useStyles();
   const { modal, message } = App.useApp();
   const startRun = useEvalStore((s) => s.startRun);
   const [starting, setStarting] = useState(false);

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/PendingState/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/PendingState/index.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import { Icon } from '@lobehub/ui';
-import { createStyles } from 'antd-style';
+import { createStaticStyles, cx } from 'antd-style';
 import { Brain, ChartBar, Clock, MessageSquare } from 'lucide-react';
 import { memo } from 'react';
-import { useTranslation } from 'react-i18next';
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   center: css`
     position: absolute;
     inset: 0;
@@ -20,9 +19,9 @@ const useStyles = createStyles(({ css, token }) => ({
     margin: auto;
     border-radius: 50%;
 
-    color: ${token.colorWarning};
+    color: ${cssVar.colorWarning};
 
-    background: ${token.colorWarningBg};
+    background: ${cssVar.colorWarningBg};
   `,
   container: css`
     position: relative;
@@ -37,7 +36,7 @@ const useStyles = createStyles(({ css, token }) => ({
   hint: css`
     margin-block-start: 24px;
     font-size: 13px;
-    color: ${token.colorTextQuaternary};
+    color: ${cssVar.colorTextQuaternary};
   `,
   icon: css`
     position: absolute;
@@ -54,27 +53,27 @@ const useStyles = createStyles(({ css, token }) => ({
   icon1: css`
     inset-block-start: 15px;
     inset-inline-start: 100px;
-    color: ${token.geekblue};
-    background: ${token.geekblue1};
+    color: ${cssVar.geekblue};
+    background: ${cssVar.geekblue1};
   `,
   icon2: css`
     inset-block-start: 143px;
     inset-inline-start: 174px;
-    color: ${token.colorSuccess};
-    background: ${token.colorSuccessBg};
+    color: ${cssVar.colorSuccess};
+    background: ${cssVar.colorSuccessBg};
   `,
   icon3: css`
     inset-block-start: 143px;
     inset-inline-start: 26px;
-    color: ${token.purple};
-    background: ${token.purple1};
+    color: ${cssVar.purple};
+    background: ${cssVar.purple1};
   `,
   orbit: css`
     position: absolute;
     inset: 0;
 
     margin: auto;
-    border: 1px dashed ${token.colorBorderSecondary};
+    border: 1px dashed ${cssVar.colorBorderSecondary};
     border-radius: 50%;
   `,
   orbit1: css`
@@ -97,9 +96,6 @@ const useStyles = createStyles(({ css, token }) => ({
 }));
 
 const PendingState = memo(({ hint }: { hint?: string }) => {
-  const { t } = useTranslation('eval');
-  const { cx, styles } = useStyles();
-
   return (
     <div className={styles.container}>
       <div className={styles.orbitGroup}>

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunHeader/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunHeader/index.tsx
@@ -4,7 +4,7 @@ import { AGENT_PROFILE_URL } from '@lobechat/const';
 import type { AgentEvalRunDetail } from '@lobechat/types';
 import { ActionIcon, Avatar, copyToClipboard, Flexbox, Highlighter, Markdown } from '@lobehub/ui';
 import { App, Button, Card, Tag, Typography } from 'antd';
-import { createStyles } from 'antd-style';
+import { createStaticStyles } from 'antd-style';
 import {
   ArrowLeft,
   ChevronDown,
@@ -23,7 +23,7 @@ import RunEditModal from '@/routes/(main)/eval/bench/[benchmarkId]/features/RunE
 import StatusBadge from '@/routes/(main)/eval/features/StatusBadge';
 import { useEvalStore } from '@/store/eval';
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   backLink: css`
     display: inline-flex;
     gap: 4px;
@@ -32,13 +32,13 @@ const useStyles = createStyles(({ css, token }) => ({
     width: fit-content;
 
     font-size: 14px;
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
     text-decoration: none;
 
     transition: color 0.2s;
 
     &:hover {
-      color: ${token.colorText};
+      color: ${cssVar.colorText};
     }
   `,
   configSection: css`
@@ -48,7 +48,7 @@ const useStyles = createStyles(({ css, token }) => ({
     margin-block-end: 8px;
     font-size: 12px;
     font-weight: 500;
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
   `,
   systemRole: css`
     overflow: auto;
@@ -59,7 +59,7 @@ const useStyles = createStyles(({ css, token }) => ({
 
     font-size: 13px;
 
-    background: ${token.colorFillQuaternary};
+    background: ${cssVar.colorFillQuaternary};
   `,
   configToggle: css`
     cursor: pointer;
@@ -72,14 +72,14 @@ const useStyles = createStyles(({ css, token }) => ({
     border: none;
 
     font-size: 12px;
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
 
     background: transparent;
 
     transition: color 0.2s;
 
     &:hover {
-      color: ${token.colorText};
+      color: ${cssVar.colorText};
     }
   `,
   datasetLink: css`
@@ -87,20 +87,20 @@ const useStyles = createStyles(({ css, token }) => ({
     text-decoration: none;
 
     &:hover {
-      color: ${token.colorPrimary};
+      color: ${cssVar.colorPrimary};
     }
   `,
   metaRow: css`
     flex-wrap: wrap;
     font-size: 13px;
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
   `,
   modelText: css`
     font-family: monospace;
     font-size: 12px;
   `,
   separator: css`
-    color: ${token.colorBorder};
+    color: ${cssVar.colorBorder};
   `,
   titleRow: css`
     margin-block-end: 16px;
@@ -115,7 +115,6 @@ interface RunHeaderProps {
 
 const RunHeader = memo<RunHeaderProps>(({ run, benchmarkId, hideStart }) => {
   const { t } = useTranslation('eval');
-  const { styles } = useStyles();
   const { modal, message } = App.useApp();
   const navigate = useNavigate();
   const abortRun = useEvalStore((s) => s.abortRun);

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunningState/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunningState/index.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { Icon } from '@lobehub/ui';
-import { createStyles } from 'antd-style';
+import { createStaticStyles, cx } from 'antd-style';
 import { Brain, ChartBar, Loader2, MessageSquare } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   center: css`
     position: absolute;
     inset: 0;
@@ -20,9 +20,9 @@ const useStyles = createStyles(({ css, token }) => ({
     margin: auto;
     border-radius: 50%;
 
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
 
-    background: ${token.colorFillTertiary};
+    background: ${cssVar.colorFillTertiary};
   `,
   container: css`
     position: relative;
@@ -37,7 +37,7 @@ const useStyles = createStyles(({ css, token }) => ({
   hint: css`
     margin-block-start: 24px;
     font-size: 13px;
-    color: ${token.colorTextQuaternary};
+    color: ${cssVar.colorTextQuaternary};
   `,
   icon: css`
     position: absolute;
@@ -54,27 +54,27 @@ const useStyles = createStyles(({ css, token }) => ({
   icon1: css`
     inset-block-start: 15px;
     inset-inline-start: 100px;
-    color: ${token.geekblue};
-    background: ${token.geekblue1};
+    color: ${cssVar.geekblue};
+    background: ${cssVar.geekblue1};
   `,
   icon2: css`
     inset-block-start: 143px;
     inset-inline-start: 174px;
-    color: ${token.colorSuccess};
-    background: ${token.colorSuccessBg};
+    color: ${cssVar.colorSuccess};
+    background: ${cssVar.colorSuccessBg};
   `,
   icon3: css`
     inset-block-start: 143px;
     inset-inline-start: 26px;
-    color: ${token.purple};
-    background: ${token.purple1};
+    color: ${cssVar.purple};
+    background: ${cssVar.purple1};
   `,
   orbit: css`
     position: absolute;
     inset: 0;
 
     margin: auto;
-    border: 1px dashed ${token.colorBorderSecondary};
+    border: 1px dashed ${cssVar.colorBorderSecondary};
     border-radius: 50%;
   `,
   orbit1: css`
@@ -123,7 +123,6 @@ const useStyles = createStyles(({ css, token }) => ({
 
 const RunningState = memo(() => {
   const { t } = useTranslation('eval');
-  const { cx, styles } = useStyles();
 
   return (
     <div className={styles.container}>

--- a/src/routes/(main)/settings/provider/features/ProviderConfig/OAuthDeviceFlowAuth/index.tsx
+++ b/src/routes/(main)/settings/provider/features/ProviderConfig/OAuthDeviceFlowAuth/index.tsx
@@ -4,7 +4,7 @@ import { CheckCircleFilled } from '@ant-design/icons';
 import { ProviderIcon } from '@lobehub/icons';
 import { CopyButton, Flexbox, Icon } from '@lobehub/ui';
 import { App, Avatar, Button, Typography } from 'antd';
-import { createStyles, cssVar } from 'antd-style';
+import { createStaticStyles, cssVar } from 'antd-style';
 import { ExternalLinkIcon, Loader2Icon, LogOutIcon, UnplugIcon } from 'lucide-react';
 import { type ReactNode } from 'react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
@@ -16,13 +16,13 @@ import { useOAuthDeviceFlow } from './useOAuthDeviceFlow';
 
 const { Text, Link } = Typography;
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   card: css`
     overflow: hidden;
 
     width: 100%;
     margin-block-end: 24px;
-    border: 1px solid ${token.colorBorderSecondary};
+    border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: 12px;
   `,
   codeBox: css`
@@ -40,7 +40,7 @@ const useStyles = createStyles(({ css, token }) => ({
     font-weight: 600;
     letter-spacing: 6px;
 
-    background: ${token.colorFillTertiary};
+    background: ${cssVar.colorFillTertiary};
   `,
   content: css`
     display: flex;
@@ -52,7 +52,7 @@ const useStyles = createStyles(({ css, token }) => ({
     padding-inline: 48px;
   `,
   errorText: css`
-    color: ${token.colorError};
+    color: ${cssVar.colorError};
   `,
   header: css`
     display: flex;
@@ -61,7 +61,7 @@ const useStyles = createStyles(({ css, token }) => ({
 
     padding-block: 16px;
     padding-inline: 24px;
-    border-block-end: 1px solid ${token.colorBorderSecondary};
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
   `,
   hero: css`
     display: flex;
@@ -85,13 +85,13 @@ const useStyles = createStyles(({ css, token }) => ({
     border-radius: 8px;
 
     font-size: 13px;
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
 
-    background: ${token.colorFillQuaternary};
+    background: ${cssVar.colorFillQuaternary};
   `,
   serviceNote: css`
     font-size: 13px;
-    color: ${token.colorTextDescription};
+    color: ${cssVar.colorTextDescription};
     text-align: center;
   `,
   successBadge: css`
@@ -100,11 +100,11 @@ const useStyles = createStyles(({ css, token }) => ({
     align-items: center;
 
     font-size: 13px;
-    color: ${token.colorSuccess};
+    color: ${cssVar.colorSuccess};
   `,
   userAvatar: css`
-    border: 2px solid ${token.colorBorderSecondary};
-    box-shadow: 0 4px 12px ${token.colorFillSecondary};
+    border: 2px solid ${cssVar.colorBorderSecondary};
+    box-shadow: 0 4px 12px ${cssVar.colorFillSecondary};
   `,
   userInfo: css`
     display: flex;
@@ -115,7 +115,7 @@ const useStyles = createStyles(({ css, token }) => ({
   username: css`
     font-size: 16px;
     font-weight: 600;
-    color: ${token.colorText};
+    color: ${cssVar.colorText};
   `,
 }));
 
@@ -131,8 +131,6 @@ const OAuthDeviceFlowAuth = memo<OAuthDeviceFlowAuthProps>(
   ({ providerId, name, onAuthChange, title, extra }) => {
     const { t } = useTranslation('modelProvider');
     const { modal } = App.useApp();
-    const { styles } = useStyles();
-
     const [isAuthenticating, setIsAuthenticating] = useState(false);
     const hasAutoClosedRef = useRef(false);
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Migrates the last `createStyles` (hook) usages to `createStaticStyles` with `cssVar` tokens so styles are computed once at module load instead of every render.

Touches reactions, mention menu, eval bench run/case UI, OAuth device flow auth, Electron device gateway, GTD create-plan surfaces, and `ModelSelect`.

**ModelSelect:** `@lobehub/ui` base-ui `Select` does not expose Ant Design `styles.popup`; numeric `popupWidth` is applied via `popupMatchSelectWidth`. The prop is narrowed to `number` (only call site was a numeric width).

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Type-check: `bun run type-check`

#### 📸 Screenshots / Videos

N/A (visual parity intended; token/cssVar mapping only)

#### 📝 Additional Information

- Mention menu container background uses `cssVar.colorBgElevated` for floating surface (replaces `isDarkMode`-branch on tokens).
- `PendingState` dropped unused `useTranslation`.


Made with [Cursor](https://cursor.com)