### PR TITLE
♻️  refactor(context engine): tool message normalization

### DIFF
--- a/packages/context-engine/src/processors/ToolMessageReorder.ts
+++ b/packages/context-engine/src/processors/ToolMessageReorder.ts
@@ -27,7 +27,6 @@ const DEFAULT_TOOL_FAILURE_CONTENT = JSON.stringify({
  */
 export class ToolMessageReorder extends BaseProcessor {
   readonly name = 'ToolMessageReorder';
-  private removedInvalidTools = 0;
 
   constructor(options: ProcessorOptions = {}) {
     super(options);
@@ -36,23 +35,27 @@ export class ToolMessageReorder extends BaseProcessor {
   protected async doProcess(context: PipelineContext): Promise<PipelineContext> {
     const clonedContext = this.cloneContext(context);
 
-    const reorderedMessages = this.reorderToolMessages(clonedContext.messages);
+    // Reorder messages
+    const { reorderedMessages, removedInvalidTools } = this.reorderToolMessages(
+      clonedContext.messages,
+    );
 
     const originalCount = clonedContext.messages.length;
     const reorderedCount = reorderedMessages.length;
 
     clonedContext.messages = reorderedMessages;
 
+    // Update metadata
     clonedContext.metadata.toolMessageReorder = {
       originalCount,
-      removedInvalidTools: this.removedInvalidTools,
+      removedInvalidTools,
       reorderedCount,
     };
 
-    if (this.removedInvalidTools > 0) {
+    if (removedInvalidTools > 0) {
       log(
         'Tool message reordering completed, removed',
-        this.removedInvalidTools,
+        removedInvalidTools,
         'invalid tool messages',
       );
     } else {
@@ -65,9 +68,11 @@ export class ToolMessageReorder extends BaseProcessor {
   /**
    * Reorder tool messages
    */
-  private reorderToolMessages(messages: any[]): any[] {
-    this.removedInvalidTools = 0;
-
+  private reorderToolMessages(messages: any[]): {
+    removedInvalidTools: number;
+    reorderedMessages: any[];
+  } {
+    let removedInvalidTools = 0;
     const validToolCallIds = new Set<string>();
     const toolMessages = new Map<string, any>();
 
@@ -90,13 +95,15 @@ export class ToolMessageReorder extends BaseProcessor {
     for (const message of messages) {
       if (message.role !== 'tool') continue;
 
+      // Skip invalid tool messages
       if (!message.tool_call_id || !validToolCallIds.has(message.tool_call_id)) {
-        this.removedInvalidTools++;
+        removedInvalidTools++;
         continue;
       }
 
       if (toolMessages.has(message.tool_call_id)) {
-        this.removedInvalidTools++;
+        // Check if this tool message has already been added
+        removedInvalidTools++;
         continue;
       }
 
@@ -132,6 +139,7 @@ export class ToolMessageReorder extends BaseProcessor {
           : { ...message, tool_calls: normalizedToolCalls },
       );
 
+      // If assistant message with tool_calls, add corresponding tool messages
       for (const toolCall of normalizedToolCalls) {
         const matchedToolMessage = toolMessages.get(toolCall.id);
 
@@ -162,7 +170,7 @@ export class ToolMessageReorder extends BaseProcessor {
       }
     }
 
-    return reorderedMessages;
+    return { reorderedMessages, removedInvalidTools };
   }
 
   // Simplified: removed validation/statistics helper methods

--- a/packages/context-engine/src/processors/ToolMessageReorder.ts
+++ b/packages/context-engine/src/processors/ToolMessageReorder.ts
@@ -153,7 +153,7 @@ export class ToolMessageReorder extends BaseProcessor {
             ...matchedToolMessage,
             content:
               typeof matchedToolMessage.content === 'string' &&
-              matchedToolMessage.content.length > 0
+              (matchedToolMessage.content.length > 0 || !pluginErrorMessage)
                 ? matchedToolMessage.content
                 : pluginErrorMessage || DEFAULT_TOOL_FAILURE_CONTENT,
           });

--- a/packages/context-engine/src/processors/ToolMessageReorder.ts
+++ b/packages/context-engine/src/processors/ToolMessageReorder.ts
@@ -168,4 +168,6 @@ export class ToolMessageReorder extends BaseProcessor {
 
     return reorderedMessages;
   }
+
+  // Simplified: removed validation/statistics helper methods
 }

--- a/packages/context-engine/src/processors/ToolMessageReorder.ts
+++ b/packages/context-engine/src/processors/ToolMessageReorder.ts
@@ -19,154 +19,11 @@ declare module '../types' {
 
 const log = debug('context-engine:processor:ToolMessageReorder');
 
-interface AssistantMessageWithToolCalls {
-  [key: string]: unknown;
-  content?: unknown;
-  role: 'assistant';
-  tool_calls: Array<{
-    function?: { arguments?: string; name?: string };
-    id: string;
-    type?: string;
-  }>;
-}
-
-interface ToolMessage {
-  [key: string]: unknown;
-  content: string;
-  name?: string;
-  role: 'tool';
-  tool_call_id: string;
-}
-
-interface NormalizeDiagnostics {
-  dedupedToolCalls: number;
-  droppedDuplicateTools: number;
-  droppedOrphanTools: number;
-  generatedSyntheticTools: number;
-  reorderedTools: number;
-}
-
-interface NormalizeResult {
-  diagnostics: NormalizeDiagnostics;
-  messages: any[];
-}
-
 const DEFAULT_TOOL_FAILURE_CONTENT = JSON.stringify({
   error: 'Tool call failed',
   success: false,
   synthetic: true,
 });
-
-const isAssistantWithToolCalls = (message: any): message is AssistantMessageWithToolCalls =>
-  message?.role === 'assistant' &&
-  Array.isArray(message.tool_calls) &&
-  message.tool_calls.some((toolCall: any) => !!toolCall?.id);
-
-const isToolMessage = (message: any): message is ToolMessage =>
-  message?.role === 'tool' &&
-  typeof message.tool_call_id === 'string' &&
-  message.tool_call_id.length > 0;
-
-const createSyntheticToolMessage = (
-  toolCall: AssistantMessageWithToolCalls['tool_calls'][number],
-): ToolMessage => ({
-  content: DEFAULT_TOOL_FAILURE_CONTENT,
-  ...(toolCall.function?.name && { name: toolCall.function.name }),
-  role: 'tool',
-  tool_call_id: toolCall.id,
-});
-
-export const normalizeToolCallMessages = (messages: any[]): NormalizeResult => {
-  const diagnostics: NormalizeDiagnostics = {
-    dedupedToolCalls: 0,
-    droppedDuplicateTools: 0,
-    droppedOrphanTools: 0,
-    generatedSyntheticTools: 0,
-    reorderedTools: 0,
-  };
-
-  const toolMessagesById = new Map<string, ToolMessage>();
-  const toolOriginalIndexById = new Map<string, number>();
-  const assistantToolCallIds = new Set<string>();
-
-  for (const [index, message] of messages.entries()) {
-    if (message?.role !== 'tool') continue;
-
-    if (!isToolMessage(message)) {
-      diagnostics.droppedOrphanTools++;
-      continue;
-    }
-
-    if (toolMessagesById.has(message.tool_call_id)) {
-      diagnostics.droppedDuplicateTools++;
-      continue;
-    }
-
-    toolMessagesById.set(message.tool_call_id, message);
-    toolOriginalIndexById.set(message.tool_call_id, index);
-  }
-
-  const normalizedMessages: any[] = [];
-
-  for (const [index, message] of messages.entries()) {
-    if (message?.role === 'tool') continue;
-
-    if (!isAssistantWithToolCalls(message)) {
-      normalizedMessages.push(message);
-      continue;
-    }
-
-    const seenToolCallIds = new Set<string>();
-    const normalizedToolCalls = [];
-
-    for (const toolCall of message.tool_calls) {
-      if (!toolCall?.id) continue;
-
-      if (seenToolCallIds.has(toolCall.id)) {
-        diagnostics.dedupedToolCalls++;
-        continue;
-      }
-
-      seenToolCallIds.add(toolCall.id);
-      assistantToolCallIds.add(toolCall.id);
-      normalizedToolCalls.push(toolCall);
-    }
-
-    const normalizedAssistant =
-      normalizedToolCalls.length === message.tool_calls.length
-        ? message
-        : { ...message, tool_calls: normalizedToolCalls };
-
-    normalizedMessages.push(normalizedAssistant);
-
-    for (const toolCall of normalizedToolCalls) {
-      const matchedToolMessage = toolMessagesById.get(toolCall.id);
-
-      if (matchedToolMessage) {
-        const originalToolIndex = toolOriginalIndexById.get(toolCall.id);
-        if (originalToolIndex !== undefined && originalToolIndex !== index + 1) {
-          diagnostics.reorderedTools++;
-        }
-
-        normalizedMessages.push(matchedToolMessage);
-        toolMessagesById.delete(toolCall.id);
-        toolOriginalIndexById.delete(toolCall.id);
-        continue;
-      }
-
-      diagnostics.generatedSyntheticTools++;
-      normalizedMessages.push(createSyntheticToolMessage(toolCall));
-    }
-  }
-
-  for (const toolCallId of toolMessagesById.keys()) {
-    if (!assistantToolCallIds.has(toolCallId)) {
-      diagnostics.droppedOrphanTools++;
-    }
-  }
-
-  return { diagnostics, messages: normalizedMessages };
-};
 
 /**
  * Reorder tool messages to ensure that tool messages are displayed in the correct order.
@@ -182,7 +39,14 @@ export class ToolMessageReorder extends BaseProcessor {
   protected async doProcess(context: PipelineContext): Promise<PipelineContext> {
     const clonedContext = this.cloneContext(context);
 
-    const { diagnostics, messages } = normalizeToolCallMessages(clonedContext.messages);
+    const diagnostics = {
+      dedupedToolCalls: 0,
+      droppedDuplicateTools: 0,
+      droppedOrphanTools: 0,
+      generatedSyntheticTools: 0,
+      reorderedTools: 0,
+    };
+    const messages = this.reorderToolMessages(clonedContext.messages, diagnostics);
 
     const originalCount = clonedContext.messages.length;
     const reorderedCount = messages.length;
@@ -202,5 +66,121 @@ export class ToolMessageReorder extends BaseProcessor {
     log('Tool message normalization completed %O', clonedContext.metadata.toolMessageReorder);
 
     return this.markAsExecuted(clonedContext);
+  }
+
+  private getToolMessageContent(message: any): string {
+    if (typeof message.content === 'string' && message.content.length > 0) return message.content;
+
+    const pluginErrorMessage =
+      typeof message.pluginError?.message === 'string' ? message.pluginError.message : undefined;
+
+    if (pluginErrorMessage) return pluginErrorMessage;
+
+    return DEFAULT_TOOL_FAILURE_CONTENT;
+  }
+
+  private createSyntheticToolMessage(toolCall: any): any {
+    return {
+      content: DEFAULT_TOOL_FAILURE_CONTENT,
+      ...(toolCall.function?.name && { name: toolCall.function.name }),
+      role: 'tool',
+      tool_call_id: toolCall.id,
+    };
+  }
+
+  private reorderToolMessages(
+    messages: any[],
+    diagnostics: {
+      dedupedToolCalls: number;
+      droppedDuplicateTools: number;
+      droppedOrphanTools: number;
+      generatedSyntheticTools: number;
+      reorderedTools: number;
+    },
+  ): any[] {
+    const validToolCallIds = new Set<string>();
+    const toolMessages = new Map<string, { index: number; message: any }>();
+
+    for (const message of messages) {
+      if (message.role !== 'assistant' || !Array.isArray(message.tool_calls)) continue;
+
+      const seenToolCallIds = new Set<string>();
+      for (const toolCall of message.tool_calls) {
+        if (!toolCall?.id) continue;
+
+        if (seenToolCallIds.has(toolCall.id)) {
+          diagnostics.dedupedToolCalls++;
+          continue;
+        }
+
+        seenToolCallIds.add(toolCall.id);
+        validToolCallIds.add(toolCall.id);
+      }
+    }
+
+    for (const [index, message] of messages.entries()) {
+      if (message.role !== 'tool') continue;
+
+      if (!message.tool_call_id || !validToolCallIds.has(message.tool_call_id)) {
+        diagnostics.droppedOrphanTools++;
+        continue;
+      }
+
+      if (toolMessages.has(message.tool_call_id)) {
+        diagnostics.droppedDuplicateTools++;
+        continue;
+      }
+
+      toolMessages.set(message.tool_call_id, { index, message });
+    }
+
+    const reorderedMessages: any[] = [];
+
+    for (const [index, message] of messages.entries()) {
+      if (message.role === 'tool') continue;
+
+      if (message.role !== 'assistant' || !Array.isArray(message.tool_calls)) {
+        reorderedMessages.push(message);
+        continue;
+      }
+
+      const seenToolCallIds = new Set<string>();
+      const normalizedToolCalls = [];
+
+      for (const toolCall of message.tool_calls) {
+        if (!toolCall?.id) continue;
+
+        if (seenToolCallIds.has(toolCall.id)) continue;
+
+        seenToolCallIds.add(toolCall.id);
+        normalizedToolCalls.push(toolCall);
+      }
+
+      reorderedMessages.push(
+        normalizedToolCalls.length === message.tool_calls.length
+          ? message
+          : { ...message, tool_calls: normalizedToolCalls },
+      );
+
+      for (const toolCall of normalizedToolCalls) {
+        const matchedToolMessage = toolMessages.get(toolCall.id);
+
+        if (matchedToolMessage) {
+          if (matchedToolMessage.index !== index + 1) diagnostics.reorderedTools++;
+
+          reorderedMessages.push({
+            ...matchedToolMessage.message,
+            content: this.getToolMessageContent(matchedToolMessage.message),
+          });
+          toolMessages.delete(toolCall.id);
+          continue;
+        }
+
+        diagnostics.generatedSyntheticTools++;
+        reorderedMessages.push(this.createSyntheticToolMessage(toolCall));
+      }
+    }
+
+    return reorderedMessages;
   }
 }

--- a/packages/context-engine/src/processors/ToolMessageReorder.ts
+++ b/packages/context-engine/src/processors/ToolMessageReorder.ts
@@ -6,12 +6,8 @@ import type { PipelineContext, ProcessorOptions } from '../types';
 declare module '../types' {
   interface PipelineContextMetadataOverrides {
     toolMessageReorder?: {
-      dedupedToolCalls: number;
-      droppedDuplicateTools: number;
-      droppedOrphanTools: number;
-      generatedSyntheticTools: number;
       originalCount: number;
-      reorderedTools: number;
+      removedInvalidTools: number;
       reorderedCount: number;
     };
   }
@@ -24,6 +20,14 @@ const DEFAULT_TOOL_FAILURE_CONTENT = JSON.stringify({
   success: false,
   synthetic: true,
 });
+
+interface ToolMessageReorderDiagnostics {
+  dedupedToolCalls: number;
+  droppedDuplicateTools: number;
+  droppedOrphanTools: number;
+  generatedSyntheticTools: number;
+  reorderedTools: number;
+}
 
 /**
  * Reorder tool messages to ensure that tool messages are displayed in the correct order.
@@ -39,7 +43,7 @@ export class ToolMessageReorder extends BaseProcessor {
   protected async doProcess(context: PipelineContext): Promise<PipelineContext> {
     const clonedContext = this.cloneContext(context);
 
-    const diagnostics = {
+    const diagnostics: ToolMessageReorderDiagnostics = {
       dedupedToolCalls: 0,
       droppedDuplicateTools: 0,
       droppedOrphanTools: 0,
@@ -54,12 +58,8 @@ export class ToolMessageReorder extends BaseProcessor {
     clonedContext.messages = messages;
 
     clonedContext.metadata.toolMessageReorder = {
-      dedupedToolCalls: diagnostics.dedupedToolCalls,
-      droppedDuplicateTools: diagnostics.droppedDuplicateTools,
-      droppedOrphanTools: diagnostics.droppedOrphanTools,
-      generatedSyntheticTools: diagnostics.generatedSyntheticTools,
       originalCount,
-      reorderedTools: diagnostics.reorderedTools,
+      removedInvalidTools: diagnostics.droppedDuplicateTools + diagnostics.droppedOrphanTools,
       reorderedCount,
     };
 
@@ -88,16 +88,7 @@ export class ToolMessageReorder extends BaseProcessor {
     };
   }
 
-  private reorderToolMessages(
-    messages: any[],
-    diagnostics: {
-      dedupedToolCalls: number;
-      droppedDuplicateTools: number;
-      droppedOrphanTools: number;
-      generatedSyntheticTools: number;
-      reorderedTools: number;
-    },
-  ): any[] {
+  private reorderToolMessages(messages: any[], diagnostics: ToolMessageReorderDiagnostics): any[] {
     const validToolCallIds = new Set<string>();
     const toolMessages = new Map<string, { index: number; message: any }>();
 

--- a/packages/context-engine/src/processors/ToolMessageReorder.ts
+++ b/packages/context-engine/src/processors/ToolMessageReorder.ts
@@ -21,14 +21,6 @@ const DEFAULT_TOOL_FAILURE_CONTENT = JSON.stringify({
   synthetic: true,
 });
 
-interface ToolMessageReorderDiagnostics {
-  dedupedToolCalls: number;
-  droppedDuplicateTools: number;
-  droppedOrphanTools: number;
-  generatedSyntheticTools: number;
-  reorderedTools: number;
-}
-
 /**
  * Reorder tool messages to ensure that tool messages are displayed in the correct order.
  * see https://github.com/lobehub/lobe-chat/pull/3155
@@ -43,14 +35,7 @@ export class ToolMessageReorder extends BaseProcessor {
   protected async doProcess(context: PipelineContext): Promise<PipelineContext> {
     const clonedContext = this.cloneContext(context);
 
-    const diagnostics: ToolMessageReorderDiagnostics = {
-      dedupedToolCalls: 0,
-      droppedDuplicateTools: 0,
-      droppedOrphanTools: 0,
-      generatedSyntheticTools: 0,
-      reorderedTools: 0,
-    };
-    const messages = this.reorderToolMessages(clonedContext.messages, diagnostics);
+    const { messages, removedInvalidTools } = this.reorderToolMessages(clonedContext.messages);
 
     const originalCount = clonedContext.messages.length;
     const reorderedCount = messages.length;
@@ -59,7 +44,7 @@ export class ToolMessageReorder extends BaseProcessor {
 
     clonedContext.metadata.toolMessageReorder = {
       originalCount,
-      removedInvalidTools: diagnostics.droppedDuplicateTools + diagnostics.droppedOrphanTools,
+      removedInvalidTools,
       reorderedCount,
     };
 
@@ -88,10 +73,13 @@ export class ToolMessageReorder extends BaseProcessor {
     };
   }
 
-  private reorderToolMessages(messages: any[], diagnostics: ToolMessageReorderDiagnostics): any[] {
+  private reorderToolMessages(messages: any[]): { messages: any[]; removedInvalidTools: number } {
+    let removedInvalidTools = 0;
+
     const validToolCallIds = new Set<string>();
     const toolMessages = new Map<string, { index: number; message: any }>();
 
+    // 1. First collect all valid tool_call_ids from assistant messages
     for (const message of messages) {
       if (message.role !== 'assistant' || !Array.isArray(message.tool_calls)) continue;
 
@@ -99,32 +87,31 @@ export class ToolMessageReorder extends BaseProcessor {
       for (const toolCall of message.tool_calls) {
         if (!toolCall?.id) continue;
 
-        if (seenToolCallIds.has(toolCall.id)) {
-          diagnostics.dedupedToolCalls++;
-          continue;
-        }
+        if (seenToolCallIds.has(toolCall.id)) continue;
 
         seenToolCallIds.add(toolCall.id);
         validToolCallIds.add(toolCall.id);
       }
     }
 
+    // 2. Collect all valid tool messages
     for (const [index, message] of messages.entries()) {
       if (message.role !== 'tool') continue;
 
       if (!message.tool_call_id || !validToolCallIds.has(message.tool_call_id)) {
-        diagnostics.droppedOrphanTools++;
+        removedInvalidTools++;
         continue;
       }
 
       if (toolMessages.has(message.tool_call_id)) {
-        diagnostics.droppedDuplicateTools++;
+        removedInvalidTools++;
         continue;
       }
 
       toolMessages.set(message.tool_call_id, { index, message });
     }
 
+    // 3. Reorder messages
     const reorderedMessages: any[] = [];
 
     for (const [index, message] of messages.entries()) {
@@ -157,8 +144,6 @@ export class ToolMessageReorder extends BaseProcessor {
         const matchedToolMessage = toolMessages.get(toolCall.id);
 
         if (matchedToolMessage) {
-          if (matchedToolMessage.index !== index + 1) diagnostics.reorderedTools++;
-
           reorderedMessages.push({
             ...matchedToolMessage.message,
             content: this.getToolMessageContent(matchedToolMessage.message),
@@ -167,11 +152,10 @@ export class ToolMessageReorder extends BaseProcessor {
           continue;
         }
 
-        diagnostics.generatedSyntheticTools++;
         reorderedMessages.push(this.createSyntheticToolMessage(toolCall));
       }
     }
 
-    return reorderedMessages;
+    return { messages: reorderedMessages, removedInvalidTools };
   }
 }

--- a/packages/context-engine/src/processors/ToolMessageReorder.ts
+++ b/packages/context-engine/src/processors/ToolMessageReorder.ts
@@ -48,7 +48,15 @@ export class ToolMessageReorder extends BaseProcessor {
       reorderedCount,
     };
 
-    log('Tool message normalization completed %O', clonedContext.metadata.toolMessageReorder);
+    if (removedInvalidTools > 0) {
+      log(
+        'Tool message reordering completed, removed',
+        removedInvalidTools,
+        'invalid tool messages',
+      );
+    } else {
+      log('Tool message reordering completed, message order optimized');
+    }
 
     return this.markAsExecuted(clonedContext);
   }

--- a/packages/context-engine/src/processors/ToolMessageReorder.ts
+++ b/packages/context-engine/src/processors/ToolMessageReorder.ts
@@ -27,6 +27,7 @@ const DEFAULT_TOOL_FAILURE_CONTENT = JSON.stringify({
  */
 export class ToolMessageReorder extends BaseProcessor {
   readonly name = 'ToolMessageReorder';
+  private removedInvalidTools = 0;
 
   constructor(options: ProcessorOptions = {}) {
     super(options);
@@ -35,7 +36,7 @@ export class ToolMessageReorder extends BaseProcessor {
   protected async doProcess(context: PipelineContext): Promise<PipelineContext> {
     const clonedContext = this.cloneContext(context);
 
-    const { messages, removedInvalidTools } = this.reorderToolMessages(clonedContext.messages);
+    const messages = this.reorderToolMessages(clonedContext.messages);
 
     const originalCount = clonedContext.messages.length;
     const reorderedCount = messages.length;
@@ -44,14 +45,14 @@ export class ToolMessageReorder extends BaseProcessor {
 
     clonedContext.metadata.toolMessageReorder = {
       originalCount,
-      removedInvalidTools,
+      removedInvalidTools: this.removedInvalidTools,
       reorderedCount,
     };
 
-    if (removedInvalidTools > 0) {
+    if (this.removedInvalidTools > 0) {
       log(
         'Tool message reordering completed, removed',
-        removedInvalidTools,
+        this.removedInvalidTools,
         'invalid tool messages',
       );
     } else {
@@ -59,17 +60,6 @@ export class ToolMessageReorder extends BaseProcessor {
     }
 
     return this.markAsExecuted(clonedContext);
-  }
-
-  private getToolMessageContent(message: any): string {
-    if (typeof message.content === 'string' && message.content.length > 0) return message.content;
-
-    const pluginErrorMessage =
-      typeof message.pluginError?.message === 'string' ? message.pluginError.message : undefined;
-
-    if (pluginErrorMessage) return pluginErrorMessage;
-
-    return DEFAULT_TOOL_FAILURE_CONTENT;
   }
 
   private createSyntheticToolMessage(toolCall: any): any {
@@ -81,8 +71,11 @@ export class ToolMessageReorder extends BaseProcessor {
     };
   }
 
-  private reorderToolMessages(messages: any[]): { messages: any[]; removedInvalidTools: number } {
-    let removedInvalidTools = 0;
+  /**
+   * Reorder tool messages
+   */
+  private reorderToolMessages(messages: any[]): any[] {
+    this.removedInvalidTools = 0;
 
     const validToolCallIds = new Set<string>();
     const toolMessages = new Map<string, { index: number; message: any }>();
@@ -107,12 +100,12 @@ export class ToolMessageReorder extends BaseProcessor {
       if (message.role !== 'tool') continue;
 
       if (!message.tool_call_id || !validToolCallIds.has(message.tool_call_id)) {
-        removedInvalidTools++;
+        this.removedInvalidTools++;
         continue;
       }
 
       if (toolMessages.has(message.tool_call_id)) {
-        removedInvalidTools++;
+        this.removedInvalidTools++;
         continue;
       }
 
@@ -152,9 +145,18 @@ export class ToolMessageReorder extends BaseProcessor {
         const matchedToolMessage = toolMessages.get(toolCall.id);
 
         if (matchedToolMessage) {
+          const pluginErrorMessage =
+            typeof matchedToolMessage.message.pluginError?.message === 'string'
+              ? matchedToolMessage.message.pluginError.message
+              : undefined;
+
           reorderedMessages.push({
             ...matchedToolMessage.message,
-            content: this.getToolMessageContent(matchedToolMessage.message),
+            content:
+              typeof matchedToolMessage.message.content === 'string' &&
+              matchedToolMessage.message.content.length > 0
+                ? matchedToolMessage.message.content
+                : pluginErrorMessage || DEFAULT_TOOL_FAILURE_CONTENT,
           });
           toolMessages.delete(toolCall.id);
           continue;
@@ -164,6 +166,6 @@ export class ToolMessageReorder extends BaseProcessor {
       }
     }
 
-    return { messages: reorderedMessages, removedInvalidTools };
+    return reorderedMessages;
   }
 }

--- a/packages/context-engine/src/processors/ToolMessageReorder.ts
+++ b/packages/context-engine/src/processors/ToolMessageReorder.ts
@@ -6,14 +6,167 @@ import type { PipelineContext, ProcessorOptions } from '../types';
 declare module '../types' {
   interface PipelineContextMetadataOverrides {
     toolMessageReorder?: {
+      dedupedToolCalls: number;
+      droppedDuplicateTools: number;
+      droppedOrphanTools: number;
+      generatedSyntheticTools: number;
       originalCount: number;
-      removedInvalidTools: number;
+      reorderedTools: number;
       reorderedCount: number;
     };
   }
 }
 
 const log = debug('context-engine:processor:ToolMessageReorder');
+
+interface AssistantMessageWithToolCalls {
+  [key: string]: unknown;
+  content?: unknown;
+  role: 'assistant';
+  tool_calls: Array<{
+    function?: { arguments?: string; name?: string };
+    id: string;
+    type?: string;
+  }>;
+}
+
+interface ToolMessage {
+  [key: string]: unknown;
+  content: string;
+  name?: string;
+  role: 'tool';
+  tool_call_id: string;
+}
+
+interface NormalizeDiagnostics {
+  dedupedToolCalls: number;
+  droppedDuplicateTools: number;
+  droppedOrphanTools: number;
+  generatedSyntheticTools: number;
+  reorderedTools: number;
+}
+
+interface NormalizeResult {
+  diagnostics: NormalizeDiagnostics;
+  messages: any[];
+}
+
+const DEFAULT_TOOL_FAILURE_CONTENT = JSON.stringify({
+  error: 'Tool call failed',
+  success: false,
+  synthetic: true,
+});
+
+const isAssistantWithToolCalls = (message: any): message is AssistantMessageWithToolCalls =>
+  message?.role === 'assistant' &&
+  Array.isArray(message.tool_calls) &&
+  message.tool_calls.some((toolCall: any) => !!toolCall?.id);
+
+const isToolMessage = (message: any): message is ToolMessage =>
+  message?.role === 'tool' &&
+  typeof message.tool_call_id === 'string' &&
+  message.tool_call_id.length > 0;
+
+const createSyntheticToolMessage = (
+  toolCall: AssistantMessageWithToolCalls['tool_calls'][number],
+): ToolMessage => ({
+  content: DEFAULT_TOOL_FAILURE_CONTENT,
+  ...(toolCall.function?.name && { name: toolCall.function.name }),
+  role: 'tool',
+  tool_call_id: toolCall.id,
+});
+
+export const normalizeToolCallMessages = (messages: any[]): NormalizeResult => {
+  const diagnostics: NormalizeDiagnostics = {
+    dedupedToolCalls: 0,
+    droppedDuplicateTools: 0,
+    droppedOrphanTools: 0,
+    generatedSyntheticTools: 0,
+    reorderedTools: 0,
+  };
+
+  const toolMessagesById = new Map<string, ToolMessage>();
+  const toolOriginalIndexById = new Map<string, number>();
+  const assistantToolCallIds = new Set<string>();
+
+  for (const [index, message] of messages.entries()) {
+    if (message?.role !== 'tool') continue;
+
+    if (!isToolMessage(message)) {
+      diagnostics.droppedOrphanTools++;
+      continue;
+    }
+
+    if (toolMessagesById.has(message.tool_call_id)) {
+      diagnostics.droppedDuplicateTools++;
+      continue;
+    }
+
+    toolMessagesById.set(message.tool_call_id, message);
+    toolOriginalIndexById.set(message.tool_call_id, index);
+  }
+
+  const normalizedMessages: any[] = [];
+
+  for (const [index, message] of messages.entries()) {
+    if (message?.role === 'tool') continue;
+
+    if (!isAssistantWithToolCalls(message)) {
+      normalizedMessages.push(message);
+      continue;
+    }
+
+    const seenToolCallIds = new Set<string>();
+    const normalizedToolCalls = [];
+
+    for (const toolCall of message.tool_calls) {
+      if (!toolCall?.id) continue;
+
+      if (seenToolCallIds.has(toolCall.id)) {
+        diagnostics.dedupedToolCalls++;
+        continue;
+      }
+
+      seenToolCallIds.add(toolCall.id);
+      assistantToolCallIds.add(toolCall.id);
+      normalizedToolCalls.push(toolCall);
+    }
+
+    const normalizedAssistant =
+      normalizedToolCalls.length === message.tool_calls.length
+        ? message
+        : { ...message, tool_calls: normalizedToolCalls };
+
+    normalizedMessages.push(normalizedAssistant);
+
+    for (const toolCall of normalizedToolCalls) {
+      const matchedToolMessage = toolMessagesById.get(toolCall.id);
+
+      if (matchedToolMessage) {
+        const originalToolIndex = toolOriginalIndexById.get(toolCall.id);
+        if (originalToolIndex !== undefined && originalToolIndex !== index + 1) {
+          diagnostics.reorderedTools++;
+        }
+
+        normalizedMessages.push(matchedToolMessage);
+        toolMessagesById.delete(toolCall.id);
+        toolOriginalIndexById.delete(toolCall.id);
+        continue;
+      }
+
+      diagnostics.generatedSyntheticTools++;
+      normalizedMessages.push(createSyntheticToolMessage(toolCall));
+    }
+  }
+
+  for (const toolCallId of toolMessagesById.keys()) {
+    if (!assistantToolCallIds.has(toolCallId)) {
+      diagnostics.droppedOrphanTools++;
+    }
+  }
+
+  return { diagnostics, messages: normalizedMessages };
+};
 
 /**
  * Reorder tool messages to ensure that tool messages are displayed in the correct order.
@@ -29,95 +182,25 @@ export class ToolMessageReorder extends BaseProcessor {
   protected async doProcess(context: PipelineContext): Promise<PipelineContext> {
     const clonedContext = this.cloneContext(context);
 
-    // Reorder messages
-    const reorderedMessages = this.reorderToolMessages(clonedContext.messages);
+    const { diagnostics, messages } = normalizeToolCallMessages(clonedContext.messages);
 
     const originalCount = clonedContext.messages.length;
-    const reorderedCount = reorderedMessages.length;
+    const reorderedCount = messages.length;
 
-    clonedContext.messages = reorderedMessages;
+    clonedContext.messages = messages;
 
-    // Update metadata
     clonedContext.metadata.toolMessageReorder = {
+      dedupedToolCalls: diagnostics.dedupedToolCalls,
+      droppedDuplicateTools: diagnostics.droppedDuplicateTools,
+      droppedOrphanTools: diagnostics.droppedOrphanTools,
+      generatedSyntheticTools: diagnostics.generatedSyntheticTools,
       originalCount,
-      removedInvalidTools: originalCount - reorderedCount,
+      reorderedTools: diagnostics.reorderedTools,
       reorderedCount,
     };
 
-    if (originalCount !== reorderedCount) {
-      log(
-        'Tool message reordering completed, removed',
-        originalCount - reorderedCount,
-        'invalid tool messages',
-      );
-    } else {
-      log('Tool message reordering completed, message order optimized');
-    }
+    log('Tool message normalization completed %O', clonedContext.metadata.toolMessageReorder);
 
     return this.markAsExecuted(clonedContext);
   }
-
-  /**
-   * Reorder tool messages
-   */
-  private reorderToolMessages(messages: any[]): any[] {
-    // 1. First collect all valid tool_call_ids from assistant messages
-    const validToolCallIds = new Set<string>();
-    messages.forEach((message) => {
-      if (message.role === 'assistant' && message.tool_calls) {
-        message.tool_calls.forEach((toolCall: any) => {
-          validToolCallIds.add(toolCall.id);
-        });
-      }
-    });
-
-    // 2. Collect all valid tool messages
-    const toolMessages: Record<string, any> = {};
-    messages.forEach((message) => {
-      if (
-        message.role === 'tool' &&
-        message.tool_call_id &&
-        validToolCallIds.has(message.tool_call_id)
-      ) {
-        toolMessages[message.tool_call_id] = message;
-      }
-    });
-
-    // 3. Reorder messages
-    const reorderedMessages: any[] = [];
-    messages.forEach((message) => {
-      // Skip invalid tool messages
-      if (
-        message.role === 'tool' &&
-        (!message.tool_call_id || !validToolCallIds.has(message.tool_call_id))
-      ) {
-        log('Skipping invalid tool message:', message.id);
-        return;
-      }
-
-      // Check if this tool message has already been added
-      const hasPushed = reorderedMessages.some(
-        (m) => !!message.tool_call_id && m.tool_call_id === message.tool_call_id,
-      );
-
-      if (hasPushed) return;
-
-      reorderedMessages.push(message);
-
-      // If assistant message with tool_calls, add corresponding tool messages
-      if (message.role === 'assistant' && message.tool_calls) {
-        message.tool_calls.forEach((toolCall: any) => {
-          const correspondingToolMessage = toolMessages[toolCall.id];
-          if (correspondingToolMessage) {
-            reorderedMessages.push(correspondingToolMessage);
-            delete toolMessages[toolCall.id];
-          }
-        });
-      }
-    });
-
-    return reorderedMessages;
-  }
-
-  // Simplified: removed validation/statistics helper methods
 }

--- a/packages/context-engine/src/processors/ToolMessageReorder.ts
+++ b/packages/context-engine/src/processors/ToolMessageReorder.ts
@@ -36,12 +36,12 @@ export class ToolMessageReorder extends BaseProcessor {
   protected async doProcess(context: PipelineContext): Promise<PipelineContext> {
     const clonedContext = this.cloneContext(context);
 
-    const messages = this.reorderToolMessages(clonedContext.messages);
+    const reorderedMessages = this.reorderToolMessages(clonedContext.messages);
 
     const originalCount = clonedContext.messages.length;
-    const reorderedCount = messages.length;
+    const reorderedCount = reorderedMessages.length;
 
-    clonedContext.messages = messages;
+    clonedContext.messages = reorderedMessages;
 
     clonedContext.metadata.toolMessageReorder = {
       originalCount,
@@ -62,15 +62,6 @@ export class ToolMessageReorder extends BaseProcessor {
     return this.markAsExecuted(clonedContext);
   }
 
-  private createSyntheticToolMessage(toolCall: any): any {
-    return {
-      content: DEFAULT_TOOL_FAILURE_CONTENT,
-      ...(toolCall.function?.name && { name: toolCall.function.name }),
-      role: 'tool',
-      tool_call_id: toolCall.id,
-    };
-  }
-
   /**
    * Reorder tool messages
    */
@@ -78,7 +69,7 @@ export class ToolMessageReorder extends BaseProcessor {
     this.removedInvalidTools = 0;
 
     const validToolCallIds = new Set<string>();
-    const toolMessages = new Map<string, { index: number; message: any }>();
+    const toolMessages = new Map<string, any>();
 
     // 1. First collect all valid tool_call_ids from assistant messages
     for (const message of messages) {
@@ -96,7 +87,7 @@ export class ToolMessageReorder extends BaseProcessor {
     }
 
     // 2. Collect all valid tool messages
-    for (const [index, message] of messages.entries()) {
+    for (const message of messages) {
       if (message.role !== 'tool') continue;
 
       if (!message.tool_call_id || !validToolCallIds.has(message.tool_call_id)) {
@@ -109,7 +100,7 @@ export class ToolMessageReorder extends BaseProcessor {
         continue;
       }
 
-      toolMessages.set(message.tool_call_id, { index, message });
+      toolMessages.set(message.tool_call_id, message);
     }
 
     // 3. Reorder messages
@@ -146,23 +137,28 @@ export class ToolMessageReorder extends BaseProcessor {
 
         if (matchedToolMessage) {
           const pluginErrorMessage =
-            typeof matchedToolMessage.message.pluginError?.message === 'string'
-              ? matchedToolMessage.message.pluginError.message
+            typeof matchedToolMessage.pluginError?.message === 'string'
+              ? matchedToolMessage.pluginError.message
               : undefined;
 
           reorderedMessages.push({
-            ...matchedToolMessage.message,
+            ...matchedToolMessage,
             content:
-              typeof matchedToolMessage.message.content === 'string' &&
-              matchedToolMessage.message.content.length > 0
-                ? matchedToolMessage.message.content
+              typeof matchedToolMessage.content === 'string' &&
+              matchedToolMessage.content.length > 0
+                ? matchedToolMessage.content
                 : pluginErrorMessage || DEFAULT_TOOL_FAILURE_CONTENT,
           });
           toolMessages.delete(toolCall.id);
           continue;
         }
 
-        reorderedMessages.push(this.createSyntheticToolMessage(toolCall));
+        reorderedMessages.push({
+          content: DEFAULT_TOOL_FAILURE_CONTENT,
+          ...(toolCall.function?.name && { name: toolCall.function.name }),
+          role: 'tool',
+          tool_call_id: toolCall.id,
+        });
       }
     }
 

--- a/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
+++ b/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
@@ -158,7 +158,7 @@ describe('ToolMessageReorder', () => {
         role: 'tool',
         tool_call_id: 'tool_call_1',
         name: 'test-plugin____testApi',
-        content: 'Tool result',
+        content: '',
       },
       {
         role: 'assistant',
@@ -181,6 +181,7 @@ describe('ToolMessageReorder', () => {
     expect(output[2]).toEqual(
       expect.objectContaining({
         role: 'tool',
+        content: '',
         tool_call_id: 'tool_call_1',
       }),
     );

--- a/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
+++ b/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { PipelineContext } from '../../types';
-import { normalizeToolCallMessages, ToolMessageReorder } from '../ToolMessageReorder';
+import { ToolMessageReorder } from '../ToolMessageReorder';
 
 const createContext = (messages: any[]): PipelineContext => ({
   initialState: { messages: [] } as any,
@@ -193,7 +193,8 @@ describe('ToolMessageReorder', () => {
   });
 
   it('should generate a synthetic tool result when a tool message is missing', async () => {
-    const { messages, diagnostics } = normalizeToolCallMessages([
+    const proc = new ToolMessageReorder();
+    const ctx = createContext([
       { id: 'u1', role: 'user', content: 'hi' },
       {
         id: 'a1',
@@ -209,7 +210,9 @@ describe('ToolMessageReorder', () => {
       },
     ]);
 
-    expect(messages).toEqual([
+    const result = await proc.process(ctx);
+
+    expect(result.messages).toEqual([
       { id: 'u1', role: 'user', content: 'hi' },
       {
         id: 'a1',
@@ -230,11 +233,12 @@ describe('ToolMessageReorder', () => {
         tool_call_id: 'call_missing',
       },
     ]);
-    expect(diagnostics.generatedSyntheticTools).toBe(1);
+    expect(result.metadata.toolMessageReorder?.generatedSyntheticTools).toBe(1);
   });
 
   it('should dedupe duplicate tool calls and keep the first real tool result', async () => {
-    const { messages, diagnostics } = normalizeToolCallMessages([
+    const proc = new ToolMessageReorder();
+    const ctx = createContext([
       {
         id: 'a1',
         role: 'assistant',
@@ -251,7 +255,9 @@ describe('ToolMessageReorder', () => {
       { id: 'orphan', role: 'tool', content: '{"ok":4}', tool_call_id: 'call_3' },
     ]);
 
-    expect(messages).toEqual([
+    const result = await proc.process(ctx);
+
+    expect(result.messages).toEqual([
       {
         id: 'a1',
         role: 'assistant',
@@ -264,12 +270,54 @@ describe('ToolMessageReorder', () => {
       { id: 't1-first', role: 'tool', content: '{"ok":1}', tool_call_id: 'call_1' },
       { id: 't2', role: 'tool', content: '{"ok":2}', tool_call_id: 'call_2' },
     ]);
-    expect(diagnostics).toEqual(
+    expect(result.metadata.toolMessageReorder).toEqual(
       expect.objectContaining({
         dedupedToolCalls: 1,
         droppedDuplicateTools: 1,
         droppedOrphanTools: 1,
       }),
     );
+  });
+
+  it('should prefer a real error tool result over a synthetic fallback', async () => {
+    const proc = new ToolMessageReorder();
+    const ctx = createContext([
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'calling',
+        tool_calls: [
+          { function: { arguments: '{}', name: 'test' }, id: 'call_1', type: 'function' },
+        ],
+      },
+      {
+        id: 't1',
+        role: 'tool',
+        content: '',
+        pluginError: { message: 'Manifest not found for tool: test' },
+        tool_call_id: 'call_1',
+      },
+    ]);
+
+    const result = await proc.process(ctx);
+
+    expect(result.messages).toEqual([
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'calling',
+        tool_calls: [
+          { function: { arguments: '{}', name: 'test' }, id: 'call_1', type: 'function' },
+        ],
+      },
+      {
+        id: 't1',
+        role: 'tool',
+        content: 'Manifest not found for tool: test',
+        pluginError: { message: 'Manifest not found for tool: test' },
+        tool_call_id: 'call_1',
+      },
+    ]);
+    expect(result.metadata.toolMessageReorder?.generatedSyntheticTools).toBe(0);
   });
 });

--- a/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
+++ b/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { PipelineContext } from '../../types';
-import { ToolMessageReorder } from '../ToolMessageReorder';
+import { normalizeToolCallMessages, ToolMessageReorder } from '../ToolMessageReorder';
 
 const createContext = (messages: any[]): PipelineContext => ({
   initialState: { messages: [] } as any,
@@ -11,7 +11,7 @@ const createContext = (messages: any[]): PipelineContext => ({
 });
 
 describe('ToolMessageReorder', () => {
-  it('should place tool messages right after their assistant calls and drop invalid tools', async () => {
+  it('should place tool messages right after their assistant calls and drop orphan tools', async () => {
     const proc = new ToolMessageReorder();
     const messages = [
       { id: 'u1', role: 'user', content: 'hi' },
@@ -31,6 +31,12 @@ describe('ToolMessageReorder', () => {
     const res = await proc.process(ctx);
 
     expect(res.messages.map((m) => m.id)).toEqual(['u1', 'a1', 't1']);
+    expect(res.metadata.toolMessageReorder).toEqual(
+      expect.objectContaining({
+        droppedOrphanTools: 1,
+        generatedSyntheticTools: 0,
+      }),
+    );
   });
 
   it('should reorderToolMessages', async () => {
@@ -148,7 +154,7 @@ describe('ToolMessageReorder', () => {
     ]);
   });
 
-  it('should correctly reorder when a tool message appears before the assistant message', async () => {
+  it('should reorder a tool message that appears before its assistant', async () => {
     const messages = [
       {
         role: 'system',
@@ -175,12 +181,95 @@ describe('ToolMessageReorder', () => {
 
     const { messages: output } = await proc.process(ctx);
 
-    // Verify reordering logic works and covers line 688 hasPushed check
-    // In this test, tool messages are duplicated but the second occurrence is skipped
-    expect(output.length).toBe(4); // Original has 3, assistant will add corresponding tool message again
+    expect(output.length).toBe(3);
     expect(output[0].role).toBe('system');
-    expect(output[1].role).toBe('tool');
-    expect(output[2].role).toBe('assistant');
-    expect(output[3].role).toBe('tool'); // Tool message added by assistant's tool_calls
+    expect(output[1].role).toBe('assistant');
+    expect(output[2]).toEqual(
+      expect.objectContaining({
+        role: 'tool',
+        tool_call_id: 'tool_call_1',
+      }),
+    );
+  });
+
+  it('should generate a synthetic tool result when a tool message is missing', async () => {
+    const { messages, diagnostics } = normalizeToolCallMessages([
+      { id: 'u1', role: 'user', content: 'hi' },
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'calling',
+        tool_calls: [
+          {
+            function: { arguments: '{}', name: 'test-plugin____testApi' },
+            id: 'call_missing',
+            type: 'function',
+          },
+        ],
+      },
+    ]);
+
+    expect(messages).toEqual([
+      { id: 'u1', role: 'user', content: 'hi' },
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'calling',
+        tool_calls: [
+          {
+            function: { arguments: '{}', name: 'test-plugin____testApi' },
+            id: 'call_missing',
+            type: 'function',
+          },
+        ],
+      },
+      {
+        content: '{"error":"Tool call failed","success":false,"synthetic":true}',
+        name: 'test-plugin____testApi',
+        role: 'tool',
+        tool_call_id: 'call_missing',
+      },
+    ]);
+    expect(diagnostics.generatedSyntheticTools).toBe(1);
+  });
+
+  it('should dedupe duplicate tool calls and keep the first real tool result', async () => {
+    const { messages, diagnostics } = normalizeToolCallMessages([
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'calling',
+        tool_calls: [
+          { function: { arguments: '{}', name: 'test' }, id: 'call_1', type: 'function' },
+          { function: { arguments: '{}', name: 'test' }, id: 'call_1', type: 'function' },
+          { function: { arguments: '{}', name: 'test2' }, id: 'call_2', type: 'function' },
+        ],
+      },
+      { id: 't2', role: 'tool', content: '{"ok":2}', tool_call_id: 'call_2' },
+      { id: 't1-first', role: 'tool', content: '{"ok":1}', tool_call_id: 'call_1' },
+      { id: 't1-second', role: 'tool', content: '{"ok":3}', tool_call_id: 'call_1' },
+      { id: 'orphan', role: 'tool', content: '{"ok":4}', tool_call_id: 'call_3' },
+    ]);
+
+    expect(messages).toEqual([
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'calling',
+        tool_calls: [
+          { function: { arguments: '{}', name: 'test' }, id: 'call_1', type: 'function' },
+          { function: { arguments: '{}', name: 'test2' }, id: 'call_2', type: 'function' },
+        ],
+      },
+      { id: 't1-first', role: 'tool', content: '{"ok":1}', tool_call_id: 'call_1' },
+      { id: 't2', role: 'tool', content: '{"ok":2}', tool_call_id: 'call_2' },
+    ]);
+    expect(diagnostics).toEqual(
+      expect.objectContaining({
+        dedupedToolCalls: 1,
+        droppedDuplicateTools: 1,
+        droppedOrphanTools: 1,
+      }),
+    );
   });
 });

--- a/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
+++ b/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
@@ -31,12 +31,6 @@ describe('ToolMessageReorder', () => {
     const res = await proc.process(ctx);
 
     expect(res.messages.map((m) => m.id)).toEqual(['u1', 'a1', 't1']);
-    expect(res.metadata.toolMessageReorder).toEqual(
-      expect.objectContaining({
-        droppedOrphanTools: 1,
-        generatedSyntheticTools: 0,
-      }),
-    );
   });
 
   it('should reorderToolMessages', async () => {
@@ -233,7 +227,7 @@ describe('ToolMessageReorder', () => {
         tool_call_id: 'call_missing',
       },
     ]);
-    expect(result.metadata.toolMessageReorder?.generatedSyntheticTools).toBe(1);
+    expect(result.metadata.toolMessageReorder?.removedInvalidTools).toBe(0);
   });
 
   it('should dedupe duplicate tool calls and keep the first real tool result', async () => {
@@ -270,13 +264,7 @@ describe('ToolMessageReorder', () => {
       { id: 't1-first', role: 'tool', content: '{"ok":1}', tool_call_id: 'call_1' },
       { id: 't2', role: 'tool', content: '{"ok":2}', tool_call_id: 'call_2' },
     ]);
-    expect(result.metadata.toolMessageReorder).toEqual(
-      expect.objectContaining({
-        dedupedToolCalls: 1,
-        droppedDuplicateTools: 1,
-        droppedOrphanTools: 1,
-      }),
-    );
+    expect(result.metadata.toolMessageReorder?.removedInvalidTools).toBe(2);
   });
 
   it('should prefer a real error tool result over a synthetic fallback', async () => {
@@ -318,6 +306,5 @@ describe('ToolMessageReorder', () => {
         tool_call_id: 'call_1',
       },
     ]);
-    expect(result.metadata.toolMessageReorder?.generatedSyntheticTools).toBe(0);
   });
 });

--- a/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
+++ b/packages/context-engine/src/processors/__tests__/ToolMessageReorder.test.ts
@@ -11,7 +11,7 @@ const createContext = (messages: any[]): PipelineContext => ({
 });
 
 describe('ToolMessageReorder', () => {
-  it('should place tool messages right after their assistant calls and drop orphan tools', async () => {
+  it('should place tool messages right after their assistant calls and drop invalid tools', async () => {
     const proc = new ToolMessageReorder();
     const messages = [
       { id: 'u1', role: 'user', content: 'hi' },
@@ -148,7 +148,7 @@ describe('ToolMessageReorder', () => {
     ]);
   });
 
-  it('should reorder a tool message that appears before its assistant', async () => {
+  it('should correctly reorder when a tool message appears before the assistant message', async () => {
     const messages = [
       {
         role: 'system',
@@ -227,7 +227,6 @@ describe('ToolMessageReorder', () => {
         tool_call_id: 'call_missing',
       },
     ]);
-    expect(result.metadata.toolMessageReorder?.removedInvalidTools).toBe(0);
   });
 
   it('should dedupe duplicate tool calls and keep the first real tool result', async () => {
@@ -264,7 +263,6 @@ describe('ToolMessageReorder', () => {
       { id: 't1-first', role: 'tool', content: '{"ok":1}', tool_call_id: 'call_1' },
       { id: 't2', role: 'tool', content: '{"ok":2}', tool_call_id: 'call_2' },
     ]);
-    expect(result.metadata.toolMessageReorder?.removedInvalidTools).toBe(2);
   });
 
   it('should prefer a real error tool result over a synthetic fallback', async () => {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

改造目的是为 context-engine 在整理 tool 调用消息时进行“归一化”的闭环：确保每个保留下来的 tool_call 在最终消息序列里都对应一条可消费的 tool 结果。即使上游含有错误信息，进入 context-engine 后的消息链路仍然是稳定、完整、可继续消费的。

>  以一次带 tool_calls 的 assistant 消息为例：
>  - Processor 会先扫描上下文，收集所有合法的 tool_call_id，并只保留每个  tool_call 的首个有效 tool 结果；
>  - 随后按 assistant 的 tool_calls 顺序回填对应的 tool message。
>  - 若真实 tool message 缺失，  则自动补一条 synthetic 的失败结果；若真实 tool message 没有正文但带有 pluginError.message，则优先把该错误信息回填到 content，而不是退回默认失败文案。
> 最终输出既能清掉重复和脏数据，也能保证下游总能看到与 tool_call 一一对应的结果消息。

  - packages/context-engine/src/processors/ToolMessageReorder.ts：重写 tool message 重排逻辑，改为显式返回
    reorderedMessages 与 removedInvalidTools；先去重 assistant 侧重复 tool_calls，再过滤无效或重复的 tool message，并按
    tool_call 顺序回填结果。
  - packages/context-engine/src/processors/ToolMessageReorder.ts：为缺失的 tool message 增加 synthetic 失败兜底内容，确保
    每个合法 tool_call 都能生成对应的 tool 结果；同时在真实 tool 返回为空时，优先透出 pluginError.message。
  - packages/context-engine/src/processors/ToolMessageReorder.ts：metadata 中的 removedInvalidTools 改为基于实际清理数量
    统计，不再依赖重排前后消息总数差值，日志语义也随之对齐到“移除了多少无效 tool message”。
  - packages/context-engine/src/processors/tests/ToolMessageReorder.test.ts：补充缺失 tool message 自动合成、重复
    tool_call 去重、重复 / 孤儿 tool message 清理、真实错误结果优先于 synthetic fallback 等场景覆盖，并同步更新原有断言。


#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
