### PR TITLE
🐛 fix(auth): throw Unauthorized when no valid auth method found

### DIFF
--- a/src/app/(backend)/middleware/auth/utils.test.ts
+++ b/src/app/(backend)/middleware/auth/utils.test.ts
@@ -23,7 +23,15 @@ describe('checkAuthMethod', () => {
     ).not.toThrow();
   });
 
-  it('should pass with no auth params', () => {
-    expect(() => checkAuthMethod({})).not.toThrow();
+  it('should throw Unauthorized with no auth params', () => {
+    expect(() => checkAuthMethod({})).toThrow();
+  });
+
+  it('should throw Unauthorized when betterAuthAuthorized is false and no apiKey', () => {
+    expect(() =>
+      checkAuthMethod({
+        betterAuthAuthorized: false,
+      }),
+    ).toThrow();
   });
 });

--- a/src/app/(backend)/middleware/auth/utils.ts
+++ b/src/app/(backend)/middleware/auth/utils.ts
@@ -1,3 +1,6 @@
+import { AgentRuntimeError } from '@lobechat/model-runtime';
+import { ChatErrorType } from '@lobechat/types';
+
 interface CheckAuthParams {
   apiKey?: string;
   betterAuthAuthorized?: boolean;
@@ -10,6 +13,7 @@ interface CheckAuthParams {
  * @param {string} [params.apiKey] - The user API key.
  * @param {boolean} [params.betterAuthAuthorized] - Whether the Better Auth session exists.
  * @param {boolean} [params.nextAuthAuthorized] - Whether the OAuth 2 header is provided (legacy, kept for compatibility).
+ * @throws {AgentRuntimeError} If no valid authentication method is found.
  */
 export const checkAuthMethod = (params: CheckAuthParams) => {
   const { apiKey, betterAuthAuthorized } = params;
@@ -19,4 +23,6 @@ export const checkAuthMethod = (params: CheckAuthParams) => {
 
   // if apiKey exist
   if (apiKey) return;
+
+  throw AgentRuntimeError.createError(ChatErrorType.Unauthorized);
 };


### PR DESCRIPTION
## Summary

`checkAuthMethod` in `src/app/(backend)/middleware/auth/utils.ts` silently returned when neither Better Auth session nor API key was present. This was a regression introduced in #11711 (Clerk removal) — the Clerk branch had the only `throw` statement, and removing it left the function without a fallback rejection.

This allowed requests with only a JWT auth header (but no valid session) to pass through authentication, bypassing ban enforcement and session revocation.

## Fix

Add `throw AgentRuntimeError.createError(ChatErrorType.Unauthorized)` at the end of `checkAuthMethod` when no auth method succeeds.

## Test plan

- [ ] Verify requests with valid Better Auth session still work
- [ ] Verify requests with valid API key still work
- [ ] Verify requests with only JWT header (no session, no API key) get 401
- [ ] Verify banned users with revoked sessions get 401