### PR TITLE
✨ feat: add businessElement and getFetchOptions plumbing to signin page

### DIFF
--- a/src/app/[variants]/(auth)/signin/SignInEmailStep.tsx
+++ b/src/app/[variants]/(auth)/signin/SignInEmailStep.tsx
@@ -24,6 +24,7 @@ export const EMAIL_REGEX = /^[^\s@]+@[^\s@][^\s.@]*\.[^\s@]+$/;
 export const USERNAME_REGEX = /^\w+$/;
 
 export interface SignInEmailStepProps {
+  businessElement?: React.ReactNode;
   disableEmailPassword?: boolean;
   form: FormInstance<{ email: string }>;
   isSocialOnly: boolean;
@@ -38,6 +39,7 @@ export interface SignInEmailStepProps {
 }
 
 export const SignInEmailStep = ({
+  businessElement,
   disableEmailPassword,
   form,
   isSocialOnly,
@@ -155,6 +157,7 @@ export const SignInEmailStep = ({
               button
             );
           })}
+          {businessElement}
           {!disableEmailPassword && divider}
         </Flexbox>
       )}

--- a/src/app/[variants]/(auth)/signin/page.tsx
+++ b/src/app/[variants]/(auth)/signin/page.tsx
@@ -10,6 +10,7 @@ import { useSignIn } from './useSignIn';
 
 const SignInPage = () => {
   const {
+    businessElement,
     disableEmailPassword,
     email,
     form,
@@ -31,6 +32,7 @@ const SignInPage = () => {
     <Suspense fallback={<Loading debugId={'Signin'} />}>
       {step === 'email' ? (
         <SignInEmailStep
+          businessElement={businessElement}
           disableEmailPassword={disableEmailPassword}
           form={form as any}
           isSocialOnly={isSocialOnly}

--- a/src/app/[variants]/(auth)/signin/useSignIn.ts
+++ b/src/app/[variants]/(auth)/signin/useSignIn.ts
@@ -231,7 +231,7 @@ export const useSignIn = () => {
             fetchOptions,
             providerId: normalizedProvider,
           });
-      if (result?.error) throw result.error;
+      if (result && 'error' in result) throw result.error;
     } catch (error) {
       console.error(`${normalizedProvider} sign in error:`, error);
       message.error(t('betterAuth.signin.socialError'));

--- a/src/app/[variants]/(auth)/signin/useSignIn.ts
+++ b/src/app/[variants]/(auth)/signin/useSignIn.ts
@@ -51,7 +51,13 @@ export const useSignIn = () => {
   });
   const serverConfigInit = useAuthServerConfigStore((s) => s.serverConfigInit);
   const oAuthSSOProviders = useAuthServerConfigStore((s) => s.serverConfig.oAuthSSOProviders) || [];
-  const { ssoProviders, preSocialSigninCheck, getAdditionalData } = useBusinessSignin();
+  const {
+    businessElement,
+    ssoProviders,
+    preSocialSigninCheck,
+    getAdditionalData,
+    getFetchOptions,
+  } = useBusinessSignin();
 
   useEffect(() => {
     const emailParam = searchParams.get('email');
@@ -211,15 +217,18 @@ export const useSignIn = () => {
 
       const callbackUrl = searchParams.get('callbackUrl') || '/';
       const additionalData = await getAdditionalData();
+      const fetchOptions = await getFetchOptions();
       const result = isBuiltinProvider(normalizedProvider)
         ? await signIn.social({
             additionalData,
             callbackURL: callbackUrl,
+            fetchOptions,
             provider: normalizedProvider,
           })
         : await signIn.oauth2({
             additionalData,
             callbackURL: callbackUrl,
+            fetchOptions,
             providerId: normalizedProvider,
           });
       if (result?.error) throw result.error;
@@ -268,6 +277,7 @@ export const useSignIn = () => {
     : resolvedProviders;
 
   return {
+    businessElement,
     disableEmailPassword,
     email,
     form,

--- a/src/business/client/hooks/useBusinessSignin.ts
+++ b/src/business/client/hooks/useBusinessSignin.ts
@@ -1,8 +1,12 @@
+import type { ReactNode } from 'react';
+
 export const useBusinessSignin = () => {
   return {
+    businessElement: null as ReactNode,
     getAdditionalData: async () => {
       return {};
     },
+    getFetchOptions: async () => undefined as Record<string, any> | undefined,
     preSocialSigninCheck: async () => {
       return true;
     },


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Add extension points to the signin flow so downstream overrides can inject custom UI elements and modify fetch options for social sign-in requests.

- Add `businessElement` slot to `SignInEmailStep` component
- Pass `getFetchOptions` to `signIn.social()` and `signIn.oauth2()` calls
- Add `businessElement` and `getFetchOptions` defaults to `useBusinessSignin`

These are generic plumbing changes — no business logic exposed.

#### 🧪 How to Test

- [x] No tests needed — purely additive with null/undefined defaults