### PR TITLE
👷 build(model-bank): add release workflow

### DIFF
--- a/.github/workflows/release-model-bank.yml
+++ b/.github/workflows/release-model-bank.yml
@@ -76,70 +76,9 @@ jobs:
       - name: Build package
         run: pnpm --filter model-bank build
 
-      - name: Prepare publish package
-        env:
-          MODEL_BANK_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          rm -rf "$RUNNER_TEMP/model-bank-publish"
-          mkdir -p "$RUNNER_TEMP/model-bank-publish"
-          cp -R packages/model-bank/dist "$RUNNER_TEMP/model-bank-publish/dist"
-          cp LICENSE "$RUNNER_TEMP/model-bank-publish/LICENSE"
-          node --input-type=module <<'NODE'
-          import { readFile, writeFile } from 'node:fs/promises';
-          import { join } from 'node:path';
-
-          const workspacePackagePath = join(process.cwd(), 'packages/model-bank/package.json');
-          const publishPackagePath = join(process.env.RUNNER_TEMP, 'model-bank-publish/package.json');
-          const packageJson = JSON.parse(await readFile(workspacePackagePath, 'utf8'));
-
-          const rewriteExportTarget = (value) => {
-            if (typeof value !== 'string') return value;
-
-            const target = value.replace('./src/', './dist/').replace(/\.ts$/, '.mjs');
-
-            return {
-              import: target,
-              types: target.replace(/\.mjs$/, '.d.mts'),
-            };
-          };
-
-          const exports = Object.fromEntries(
-            Object.entries(packageJson.exports ?? {}).map(([key, value]) => [key, rewriteExportTarget(value)]),
-          );
-          const dependencies = Object.fromEntries(
-            Object.entries(packageJson.dependencies ?? {}).filter(([name]) => name !== '@lobechat/business-const'),
-          );
-
-          const publishPackageJson = {
-            author: 'LobeHub <i@lobehub.com>',
-            dependencies,
-            exports,
-            files: ['dist', 'LICENSE'],
-            homepage: 'https://github.com/lobehub/lobehub',
-            license: 'MIT',
-            main: './dist/index.mjs',
-            module: './dist/index.mjs',
-            name: '@lobehub/model-bank',
-            peerDependencies: packageJson.peerDependencies,
-            publishConfig: {
-              access: 'public',
-              registry: 'https://registry.npmjs.org',
-            },
-            repository: {
-              type: 'git',
-              url: 'https://github.com/lobehub/lobehub.git',
-            },
-            type: 'module',
-            types: './dist/index.d.mts',
-            version: process.env.MODEL_BANK_VERSION,
-          };
-
-          await writeFile(publishPackagePath, `${JSON.stringify(publishPackageJson, null, 2)}\n`);
-          NODE
-
       - name: Publish to npm
         run: npm publish --provenance
-        working-directory: ${{ runner.temp }}/model-bank-publish
+        working-directory: packages/model-bank
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release-model-bank.yml
+++ b/.github/workflows/release-model-bank.yml
@@ -106,10 +106,13 @@ jobs:
           const exports = Object.fromEntries(
             Object.entries(packageJson.exports ?? {}).map(([key, value]) => [key, rewriteExportTarget(value)]),
           );
+          const dependencies = Object.fromEntries(
+            Object.entries(packageJson.dependencies ?? {}).filter(([name]) => name !== '@lobechat/business-const'),
+          );
 
           const publishPackageJson = {
             author: 'LobeHub <i@lobehub.com>',
-            dependencies: packageJson.dependencies,
+            dependencies,
             exports,
             files: ['dist', 'LICENSE'],
             homepage: 'https://github.com/lobehub/lobehub',

--- a/.github/workflows/release-model-bank.yml
+++ b/.github/workflows/release-model-bank.yml
@@ -1,0 +1,151 @@
+name: Release ModelBank
+
+permissions:
+  contents: write
+  id-token: write
+
+on:
+  push:
+    branches:
+      - canary
+    paths:
+      - packages/model-bank/**
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build ModelBank
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.11.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.20.0
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build package
+        run: pnpm --filter model-bank build
+
+  publish:
+    name: Publish ModelBank
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.11.1
+          registry-url: https://registry.npmjs.org
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.20.0
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Bump patch version
+        id: version
+        run: |
+          npm version patch --no-git-tag-version --prefix packages/model-bank
+          echo "version=$(node -p 'require(\"./packages/model-bank/package.json\").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Build package
+        run: pnpm --filter model-bank build
+
+      - name: Prepare publish package
+        env:
+          MODEL_BANK_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          rm -rf "$RUNNER_TEMP/model-bank-publish"
+          mkdir -p "$RUNNER_TEMP/model-bank-publish"
+          cp -R packages/model-bank/dist "$RUNNER_TEMP/model-bank-publish/dist"
+          cp LICENSE "$RUNNER_TEMP/model-bank-publish/LICENSE"
+          node --input-type=module <<'NODE'
+          import { readFile, writeFile } from 'node:fs/promises';
+          import { join } from 'node:path';
+
+          const workspacePackagePath = join(process.cwd(), 'packages/model-bank/package.json');
+          const publishPackagePath = join(process.env.RUNNER_TEMP, 'model-bank-publish/package.json');
+          const packageJson = JSON.parse(await readFile(workspacePackagePath, 'utf8'));
+
+          const rewriteExportTarget = (value) => {
+            if (typeof value !== 'string') return value;
+
+            const target = value.replace('./src/', './dist/').replace(/\.ts$/, '.mjs');
+
+            return {
+              import: target,
+              types: target.replace(/\.mjs$/, '.d.mts'),
+            };
+          };
+
+          const exports = Object.fromEntries(
+            Object.entries(packageJson.exports ?? {}).map(([key, value]) => [key, rewriteExportTarget(value)]),
+          );
+
+          const publishPackageJson = {
+            author: 'LobeHub <i@lobehub.com>',
+            dependencies: packageJson.dependencies,
+            exports,
+            files: ['dist', 'LICENSE'],
+            homepage: 'https://github.com/lobehub/lobehub',
+            license: 'MIT',
+            main: './dist/index.mjs',
+            module: './dist/index.mjs',
+            name: '@lobehub/model-bank',
+            peerDependencies: packageJson.peerDependencies,
+            publishConfig: {
+              access: 'public',
+              registry: 'https://registry.npmjs.org',
+            },
+            repository: {
+              type: 'git',
+              url: 'https://github.com/lobehub/lobehub.git',
+            },
+            type: 'module',
+            types: './dist/index.d.mts',
+            version: process.env.MODEL_BANK_VERSION,
+          };
+
+          await writeFile(publishPackagePath, `${JSON.stringify(publishPackageJson, null, 2)}\n`);
+          NODE
+
+      - name: Publish to npm
+        run: npm publish --provenance
+        working-directory: ${{ runner.temp }}/model-bank-publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Commit version bump
+        env:
+          MODEL_BANK_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packages/model-bank/package.json
+          git commit -m "🔖 chore(model-bank): release v${MODEL_BANK_VERSION}"
+          git push

--- a/packages/model-bank/package.json
+++ b/packages/model-bank/package.json
@@ -87,12 +87,17 @@
     "./types": "./src/types/index.ts"
   },
   "scripts": {
+    "build": "tsdown",
     "test": "vitest",
     "test:coverage": "vitest --coverage --silent='passed-only'"
   },
   "dependencies": {
     "@lobechat/business-const": "workspace:*",
     "type-fest": "^5.2.0"
+  },
+  "devDependencies": {
+    "tsdown": "^0.21.4",
+    "typescript": "^5.9.3"
   },
   "peerDependencies": {
     "zod": "^3.25.76"

--- a/packages/model-bank/tsconfig.json
+++ b/packages/model-bank/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "rootDir": "../../"
+  },
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/model-bank/tsdown.config.ts
+++ b/packages/model-bank/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  clean: true,
+  dts: true,
+  entry: [
+    'src/index.ts',
+    'src/modelProviders/index.ts',
+    'src/modelProviders/lobehub.ts',
+    'src/types/index.ts',
+    'src/aiModels/*.ts',
+    'src/aiModels/lobehub/index.ts',
+  ],
+  fixedExtension: false,
+  format: ['esm'],
+  outDir: 'dist',
+  platform: 'neutral',
+  target: 'es2022',
+  tsconfig: './tsconfig.json',
+});

--- a/packages/model-bank/tsdown.config.ts
+++ b/packages/model-bank/tsdown.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   clean: true,
+  deps: {
+    alwaysBundle: ['@lobechat/business-const'],
+  },
   dts: true,
   entry: [
     'src/index.ts',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- add a dedicated GitHub Actions workflow to build and publish `packages/model-bank`
- restrict automatic workflow triggers to changes under `packages/model-bank/**`
- support manual `workflow_dispatch` publishing with automatic patch version bumps
- prepare an npm publish manifest that releases the package as `@lobehub/model-bank`
- add `tsdown` build configuration for the package and generate distributable ESM outputs

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Local verification:
- `pnpm --filter model-bank build`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-model-bank.yml"); puts "workflow ok"'`
- validated local publish export mapping for generated `dist/*.mjs` and `dist/*.d.mts`

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

The workflow keeps the workspace package name as `model-bank` inside the monorepo and generates a temporary publish manifest so the published npm package name becomes `@lobehub/model-bank`.
