### PR TITLE
🐛 fix(desktop): use Electron net.fetch for remote server requests

### DIFF
--- a/apps/desktop/src/main/controllers/AuthCtr.ts
+++ b/apps/desktop/src/main/controllers/AuthCtr.ts
@@ -12,6 +12,7 @@ import { BrowserWindow, shell } from 'electron';
 import GatewayConnectionService from '@/services/gatewayConnectionSrv';
 import { appendVercelCookie } from '@/utils/http-headers';
 import { createLogger } from '@/utils/logger';
+import { netFetch } from '@/utils/net-fetch';
 
 import { ControllerModule, IpcMethod } from './index';
 import RemoteServerConfigCtr from './RemoteServerConfigCtr';
@@ -360,10 +361,10 @@ export default class AuthCtr extends ControllerModule {
 
       logger.debug(`Polling for credentials: ${url.toString()}`);
 
-      // Send HTTP request directly
+      // Use Electron net.fetch to respect system CA store (self-signed/private CA certs)
       const headers: Record<string, string> = { 'Content-Type': 'application/json' };
       appendVercelCookie(headers);
-      const response = await fetch(url.toString(), { headers, method: 'GET' });
+      const response = await netFetch(url.toString(), { headers, method: 'GET' });
 
       // Check response status
       if (response.status === 404) {
@@ -481,7 +482,7 @@ export default class AuthCtr extends ControllerModule {
         'Content-Type': 'application/x-www-form-urlencoded',
       };
       appendVercelCookie(tokenHeaders);
-      const response = await fetch(tokenUrl.toString(), {
+      const response = await netFetch(tokenUrl.toString(), {
         body,
         headers: tokenHeaders,
         method: 'POST',

--- a/apps/desktop/src/main/controllers/LocalFileCtr.ts
+++ b/apps/desktop/src/main/controllers/LocalFileCtr.ts
@@ -48,6 +48,7 @@ import { type FileResult, type SearchOptions } from '@/modules/fileSearch';
 import ContentSearchService from '@/services/contentSearchSrv';
 import FileSearchService from '@/services/fileSearchSrv';
 import { createLogger } from '@/utils/logger';
+import { netFetch } from '@/utils/net-fetch';
 
 import { ControllerModule, IpcMethod } from './index';
 
@@ -341,7 +342,7 @@ export default class LocalFileCtr extends ControllerModule {
     }
 
     try {
-      const response = await fetch(url);
+      const response = await netFetch(url);
       if (!response.ok) {
         throw new Error(
           `Failed to download skill package: ${response.status} ${response.statusText}`,

--- a/apps/desktop/src/main/controllers/RemoteServerConfigCtr.ts
+++ b/apps/desktop/src/main/controllers/RemoteServerConfigCtr.ts
@@ -9,6 +9,7 @@ import { OFFICIAL_CLOUD_SERVER } from '@/const/env';
 import GatewayConnectionService from '@/services/gatewayConnectionSrv';
 import { appendVercelCookie } from '@/utils/http-headers';
 import { createLogger } from '@/utils/logger';
+import { netFetch } from '@/utils/net-fetch';
 
 import { ControllerModule, IpcMethod } from './index';
 
@@ -485,7 +486,7 @@ export default class RemoteServerConfigCtr extends ControllerModule {
         'Content-Type': 'application/x-www-form-urlencoded',
       };
       appendVercelCookie(headers);
-      const response = await fetch(tokenUrl.toString(), { body, headers, method: 'POST' });
+      const response = await netFetch(tokenUrl.toString(), { body, headers, method: 'POST' });
 
       if (!response.ok) {
         // Try to parse error response

--- a/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.test.ts
@@ -5,11 +5,14 @@ import { type App } from '@/core/App';
 
 import LocalFileCtr from '../LocalFileCtr';
 
-const { ipcMainHandleMock } = vi.hoisted(() => ({
+const { ipcMainHandleMock, fetchMock } = vi.hoisted(() => ({
   ipcMainHandleMock: vi.fn(),
+  fetchMock: vi.fn(),
 }));
 
-const fetchMock = vi.fn();
+vi.mock('@/utils/net-fetch', () => ({
+  netFetch: fetchMock,
+}));
 
 // Mock logger
 vi.mock('@/utils/logger', () => ({
@@ -36,8 +39,6 @@ vi.mock('electron', () => ({
     openPath: vi.fn(),
   },
 }));
-
-vi.stubGlobal('fetch', fetchMock);
 
 // Mock node:fs/promises and node:fs
 vi.mock('node:fs/promises', () => ({

--- a/apps/desktop/src/main/controllers/__tests__/RemoteServerConfigCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/RemoteServerConfigCtr.test.ts
@@ -5,8 +5,13 @@ import type { App } from '@/core/App';
 
 import RemoteServerConfigCtr from '../RemoteServerConfigCtr';
 
-const { ipcMainHandleMock } = vi.hoisted(() => ({
+const { ipcMainHandleMock, mockFetch } = vi.hoisted(() => ({
   ipcMainHandleMock: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock('@/utils/net-fetch', () => ({
+  netFetch: mockFetch,
 }));
 
 // Mock logger
@@ -420,13 +425,6 @@ describe('RemoteServerConfigCtr', () => {
   });
 
   describe('refreshAccessToken', () => {
-    let mockFetch: ReturnType<typeof vi.fn>;
-
-    beforeEach(() => {
-      mockFetch = vi.fn();
-      global.fetch = mockFetch;
-    });
-
     it('should return error when remote server is not active', async () => {
       mockStoreManager.get.mockImplementation((key) => {
         if (key === 'dataSyncConfig') {

--- a/apps/desktop/src/main/core/infrastructure/BackendProxyProtocolManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/BackendProxyProtocolManager.ts
@@ -4,6 +4,7 @@ import { BrowserWindow, type Session } from 'electron';
 import { isDev } from '@/const/env';
 import { appendVercelCookie } from '@/utils/http-headers';
 import { createLogger } from '@/utils/logger';
+import { netFetch } from '@/utils/net-fetch';
 
 interface BackendProxyProtocolManagerOptions {
   getAccessToken: () => Promise<string | undefined | null>;
@@ -137,7 +138,7 @@ export class BackendProxyProtocolManager {
 
         let upstreamResponse: Response;
         try {
-          upstreamResponse = await fetch(rewrittenUrl, requestInit);
+          upstreamResponse = await netFetch(rewrittenUrl, requestInit);
         } catch (error) {
           this.logger.error(`${logPrefix} upstream fetch failed: ${rewrittenUrl}`, error);
 

--- a/apps/desktop/src/main/utils/net-fetch.ts
+++ b/apps/desktop/src/main/utils/net-fetch.ts
@@ -1,0 +1,14 @@
+import { net } from 'electron';
+
+/**
+ * Fetch using Electron's net module (Chromium networking stack).
+ *
+ * Unlike Node.js `fetch`, `net.fetch` respects the OS certificate store
+ * (e.g. macOS Keychain, Windows Certificate Store), so self-signed or
+ * private-CA certificates trusted at the system level work automatically.
+ *
+ * This must be called only after `app.whenReady()` has resolved.
+ */
+export const netFetch: typeof globalThis.fetch = (input, init?) => {
+  return net.fetch(input as any, init as any);
+};


### PR DESCRIPTION
## Summary

- Switch from Node.js `fetch()` to Electron's `net.fetch()` for all HTTP requests from the desktop app to user-configured remote servers
- Node.js `fetch` uses a bundled Mozilla CA list and **ignores the OS certificate store**, so self-hosted instances behind a reverse proxy with a private CA (e.g. Caddy, mkcert, corporate PKI) silently fail every request — TLS errors are swallowed and the user sees only a timeout
- `net.fetch` uses Chromium's networking stack, which respects the macOS Keychain, Windows Certificate Store, and system CA bundles on Linux

These changes allowed me to connect (from macos) to my self-hosted lobehub server with a self-signed cert.

I did think the app would pop up and take focus, but it did not. It did log in and appear to work, however. Without these changes, the browser says `Authentication Successful` but the desktop app just times out.

## Affected code paths

| File | Request |
|------|---------|
| `AuthCtr.ts` | OIDC handoff polling + token exchange |
| `RemoteServerConfigCtr.ts` | Token refresh |
| `LocalFileCtr.ts` | Skill package download |
| `BackendProxyProtocolManager.ts` | Backend API proxy |

The network proxy tester (`tester.ts`) intentionally stays on undici's
`fetch` because it requires the `dispatcher` option for proxy agent testing.

## Root cause

Self-hosted desktop auth (Connect → enter server URL → browser login) never completes: the handoff record is created server-side but the desktop app's polling requests fail at the TLS handshake because Node.js doesn't trust the host's CA certificate. The error is caught and discarded in a `logger.debug()` call, so the app silently spins until the 2-minute timeout.

Fixes #9684, fixes #13128

## Test plan

- [x] Self-hosted instance with private CA cert trusted at OS level
- [x] Desktop app → Connect → enter server URL → browser login → app receives callback
- [ ] Token refresh works after initial auth
- [ ] Skill package install from self-hosted server works
- [ ] Official cloud (lobehub.com) still works (public CA, no change in behavior)