### PR TITLE
🐛 fix(glmCodingPlan): update default URL and add GLM-5.1 model

### DIFF
--- a/packages/model-bank/src/aiModels/glmCodingPlan.ts
+++ b/packages/model-bank/src/aiModels/glmCodingPlan.ts
@@ -8,6 +8,25 @@ const glmCodingPlanChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
     },
+    contextWindowTokens: 204_800,
+    description:
+      "GLM-5.1 is Zhipu's latest flagship model, an enhanced iteration of GLM-5 with improved agentic engineering capabilities for complex systems engineering and long-horizon tasks.",
+    displayName: 'GLM-5.1',
+    enabled: true,
+    id: 'GLM-5.1',
+    maxOutput: 131_072,
+    organization: 'Zhipu',
+    releasedAt: '2026-03-27',
+    settings: {
+      extendParams: ['enableReasoning'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
     contextWindowTokens: 200_000,
     description:
       "GLM-5 is Zhipu's next-generation flagship foundation model, purpose-built for Agentic Engineering. It delivers reliable productivity in complex systems engineering and long-horizon agentic tasks. In coding and agent capabilities, GLM-5 achieves state-of-the-art performance among open-source models.",

--- a/packages/model-bank/src/modelProviders/glmCodingPlan.ts
+++ b/packages/model-bank/src/modelProviders/glmCodingPlan.ts
@@ -14,7 +14,7 @@ const GLMCodingPlan: ModelProviderCard = {
   settings: {
     disableBrowserRequest: true,
     proxyUrl: {
-      placeholder: 'https://api.z.ai/api/paas/v4',
+      placeholder: 'https://open.bigmodel.cn/api/coding/paas/v4',
     },
     responseAnimation: {
       speed: 2,

--- a/packages/model-runtime/src/providers/glmCodingPlan/index.test.ts
+++ b/packages/model-runtime/src/providers/glmCodingPlan/index.test.ts
@@ -5,7 +5,7 @@ import { testProvider } from '../../providerTestUtils';
 import { LobeGLMCodingPlanAI } from './index';
 
 const provider = ModelProvider.GLMCodingPlan;
-const defaultBaseURL = 'https://api.z.ai/api/paas/v4';
+const defaultBaseURL = 'https://open.bigmodel.cn/api/coding/paas/v4';
 
 testProvider({
   Runtime: LobeGLMCodingPlanAI,

--- a/packages/model-runtime/src/providers/glmCodingPlan/index.ts
+++ b/packages/model-runtime/src/providers/glmCodingPlan/index.ts
@@ -4,7 +4,7 @@ import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactor
 import { processMultiProviderModelList } from '../../utils/modelParse';
 
 export const LobeGLMCodingPlanAI = createOpenAICompatibleRuntime({
-  baseURL: 'https://api.z.ai/api/paas/v4',
+  baseURL: 'https://open.bigmodel.cn/api/coding/paas/v4',
   chatCompletion: {
     handlePayload: (payload) => {
       const { model, thinking, ...rest } = payload;


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Fix: correct default API URL to `open.bigmodel.cn/api/coding/paas/v4` for GLM Coding Plan (previous URL was incorrect)
- Add GLM-5.1 model configuration with:
  - 200K context window tokens
  - 128K max output tokens
  - Function call and reasoning abilities
  - Released on 2026-03-27

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

N/A (configuration changes only)

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->