### PR TITLE
♻️ refactor: serve Vite SPA static assets under /_spa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ bun.lockb
 
 # Build outputs
 dist/
+public/_spa/
 public/spa/
 es/
 lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ COPY --from=base /distroless/ /
 COPY --from=builder /app/.next/standalone /app/
 COPY --from=builder /app/.next/static /app/.next/static
 # Copy SPA assets (Vite build output)
-COPY --from=builder /app/public/spa /app/public/spa
+COPY --from=builder /app/public/_spa /app/public/_spa
 # Copy database migrations
 COPY --from=builder /app/packages/database/migrations /app/migrations
 COPY --from=builder /app/scripts/migrateServerDB/docker.cjs /app/docker.cjs

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,7 +11,7 @@ const vercelConfig = {
       'node_modules/.pnpm/@napi-rs+canvas-*-musl*',
       'node_modules/.pnpm/@img+sharp-libvips-*musl*',
       // Exclude SPA/desktop/mobile build artifacts from serverless functions
-      'public/spa/**',
+      'public/_spa/**',
       'dist/desktop/**',
       'dist/mobile/**',
       'apps/desktop/**',

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "build:spa": "cross-env NODE_OPTIONS=--max-old-space-size=7168 pnpm run build:spa:raw",
     "build:spa:copy": "tsx scripts/copySpaBuild.mts && tsx scripts/generateSpaTemplates.mts",
     "build:spa:mobile": "cross-env NODE_OPTIONS=--max-old-space-size=8192 MOBILE=true vite build",
-    "build:spa:raw": "rm -rf public/spa && vite build",
+    "build:spa:raw": "rm -rf public/_spa && vite build",
     "build:vercel": "cross-env-shell NODE_OPTIONS=--max-old-space-size=6144 \"bun run build:raw && bun run db:migrate\"",
     "build-migrate-db": "bun run db:migrate",
     "build-sitemap": "tsx ./scripts/buildSitemapIndex/index.ts",

--- a/scripts/copySpaBuild.mts
+++ b/scripts/copySpaBuild.mts
@@ -2,7 +2,7 @@ import { cpSync, existsSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
 
 const root = path.resolve(import.meta.dirname, '..');
-const spaDir = path.resolve(root, 'public/spa');
+const spaDir = path.resolve(root, 'public/_spa');
 const distDirs = ['desktop', 'mobile'] as const;
 const copyDirs = ['assets', 'i18n', 'vendor'] as const;
 
@@ -16,6 +16,6 @@ for (const distDir of distDirs) {
     if (!existsSync(sourceDir)) continue;
 
     cpSync(sourceDir, targetDir, { recursive: true });
-    console.log(`Copied dist/${distDir}/${dir} -> public/spa/${dir}`);
+    console.log(`Copied dist/${distDir}/${dir} -> public/_spa/${dir}`);
   }
 }

--- a/src/libs/next/config/define-config.ts
+++ b/src/libs/next/config/define-config.ts
@@ -36,7 +36,7 @@ export function defineConfig(config: CustomNextConfig) {
         ...(buildWithDocker
           ? [
               // Exclude SPA/desktop/mobile build artifacts from serverless functions
-              'public/spa/**',
+              'public/_spa/**',
               'dist/desktop/**',
               'dist/mobile/**',
 

--- a/src/libs/pdfjs/index.tsx
+++ b/src/libs/pdfjs/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-// Use Vite's ?url import to get the correct hashed asset path (e.g. /spa/assets/pdf.worker-xxx.mjs)
+// Use Vite's ?url import to get the correct hashed asset path (e.g. /_spa/assets/pdf.worker-xxx.mjs)
 // This overrides react-pdf's auto-detected bare filename which breaks under SPA routing.
 import pdfjsWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
 import { type ComponentProps } from 'react';

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "buildCommand": "bun run build:vercel",
   "headers": [
     {
-      "source": "/spa/assets/(.*)",
+      "source": "/_spa/(.*)",
       "headers": [
         {
           "key": "Cache-Control",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ const isDev = process.env.NODE_ENV !== 'production';
 const platform = isMobile ? 'mobile' : 'web';
 
 export default defineConfig({
-  base: isDev ? '/' : process.env.VITE_CDN_BASE || '/spa/',
+  base: isDev ? '/' : process.env.VITE_CDN_BASE || '/_spa/',
   build: {
     outDir: isMobile ? 'dist/mobile' : 'dist/desktop',
     rollupOptions: {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Default Vite production `base` is `/_spa/` (still overridable via `VITE_CDN_BASE`).
- Copy SPA build output to `public/_spa` so hashed assets (assets/i18n/vendor) no longer share the `/spa/[variants]/...` HTML catch-all namespace; missing files return real 404s.
- Extend Vercel cache headers to `/_spa/(.*)`.
- Docker and Next watch paths updated accordingly.

#### 🧪 How to Test

- [x] No tests needed

Cloud repo will bump the submodule pointer after this merges.

Made with [Cursor](https://cursor.com)