### PR TITLE
🐛 fix(editor): add ReactMentionPlugin to ChatInput for mention node rendering

### DIFF
--- a/src/features/ChatInput/InputEditor/plugins.ts
+++ b/src/features/ChatInput/InputEditor/plugins.ts
@@ -5,6 +5,7 @@ import {
   ReactLinkHighlightPlugin,
   ReactListPlugin,
   ReactMathPlugin,
+  ReactMentionPlugin,
   ReactVirtualBlockPlugin,
 } from '@lobehub/editor';
 import { type Editor } from '@lobehub/editor/react';
@@ -22,6 +23,7 @@ interface CreateChatInputRichPluginsOptions {
 export const CHAT_INPUT_EMBED_PLUGINS: EditorPlugins = [
   ReactActionTagPlugin,
   ReactReferTopicPlugin,
+  ReactMentionPlugin,
 ];
 
 export const createChatInputRichPlugins = ({

--- a/src/features/EditorModal/EditorCanvas.tsx
+++ b/src/features/EditorModal/EditorCanvas.tsx
@@ -1,5 +1,5 @@
 import { type IEditor } from '@lobehub/editor';
-import { ReactLinkPlugin, ReactMentionPlugin, ReactTablePlugin } from '@lobehub/editor';
+import { ReactLinkPlugin, ReactTablePlugin } from '@lobehub/editor';
 import { Editor } from '@lobehub/editor/react';
 import { Flexbox } from '@lobehub/ui';
 import { type FC, useMemo } from 'react';
@@ -17,7 +17,6 @@ interface EditorCanvasProps {
 const EDITOR_PLUGINS = [
   ...createChatInputRichPlugins({ linkPlugin: ReactLinkPlugin }),
   ReactTablePlugin,
-  ReactMentionPlugin,
 ];
 
 const EditorCanvas: FC<EditorCanvasProps> = ({ defaultValue, editor, editorData }) => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-6270

#### 🔀 Description of Change

The ChatInput editor plugins did not include `ReactMentionPlugin`, so mention nodes inserted via `@` were invisible in the editor. Only the `EditorCanvas` (full-screen editor modal) had this plugin, while the regular ChatInput (including Home page) did not.

**Changes:**
- Add `ReactMentionPlugin` to `CHAT_INPUT_EMBED_PLUGINS` in `plugins.ts` so all ChatInput instances render mention nodes
- Remove the now-duplicate `ReactMentionPlugin` entry from `EditorCanvas.tsx` (it inherits via `createChatInputRichPlugins`)

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Go to the Home page
2. Click the chat input and type `@`
3. Select an agent from the mention menu
4. Verify the mention node renders as a styled tag (e.g. `@测试专用`) instead of being invisible

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Mention node invisible after selection | Mention node renders as blue tag `@测试专用` |

#### 📝 Additional Information

Root cause: `CHAT_INPUT_EMBED_PLUGINS` array in `plugins.ts` listed `ReactActionTagPlugin` and `ReactReferTopicPlugin` but was missing `ReactMentionPlugin`. The `INSERT_MENTION_COMMAND` successfully inserted the node into Lexical state, but without the rendering plugin, no visual output appeared.