### PR TITLE
🐛 fix: Expose tool discovery config to context engine and inject available tools

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -9,6 +9,7 @@ import {
   type InstructionExecutor,
   UsageCounter,
 } from '@lobechat/agent-runtime';
+import { LobeActivatorIdentifier } from '@lobechat/builtin-tool-activator';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
 import {
   AGENT_DOCUMENT_INJECTION_POSITIONS,
@@ -145,6 +146,27 @@ const executeToolWithRetry = async (
   throw new Error('Tool execution retry loop exited unexpectedly');
 };
 
+const buildToolDiscoveryConfig = (
+  operationToolSet: OperationToolSet,
+  enabledToolIds: string[],
+) => {
+  const enabledToolSet = new Set(enabledToolIds);
+
+  if (!enabledToolSet.has(LobeActivatorIdentifier)) return undefined;
+
+  const availableTools = Object.entries(operationToolSet.manifestMap)
+    .filter(([identifier]) => !enabledToolSet.has(identifier))
+    .map(([identifier, manifest]) => ({
+      description: manifest.meta?.description || '',
+      identifier,
+      name: manifest.meta?.title || identifier,
+    }));
+
+  if (availableTools.length === 0) return undefined;
+
+  return { availableTools }
+};
+
 const formatErrorEventData = (error: unknown, phase: string) => {
   let errorMessage = 'Unknown error';
   let errorType: string | undefined;
@@ -250,6 +272,7 @@ export const createRuntimeExecutors = (
     );
 
     const tools = resolved.tools.length > 0 ? resolved.tools : undefined;
+    const toolDiscoveryConfig = buildToolDiscoveryConfig(operationToolSet, resolved.enabledToolIds);
 
     if (stepDelta.activatedTools.length > 0) {
       log(
@@ -428,6 +451,7 @@ export const createRuntimeExecutors = (
           model,
           provider,
           systemRole: agentConfig.systemRole ?? undefined,
+          toolDiscoveryConfig,
           toolsConfig: {
             manifests: Object.values(resolved.manifestMap),
             tools: resolved.enabledToolIds,

--- a/src/server/modules/Mecha/ContextEngineering/index.ts
+++ b/src/server/modules/Mecha/ContextEngineering/index.ts
@@ -61,6 +61,7 @@ export const serverMessagesEngine = async ({
   knowledge,
   agentDocuments,
   skillsConfig,
+  toolDiscoveryConfig,
   toolsConfig,
   capabilities,
   userMemory,
@@ -119,6 +120,7 @@ export const serverMessagesEngine = async ({
     timezone: userTimezone,
 
     // Tools configuration
+    toolDiscoveryConfig,
     toolsConfig: {
       manifests: toolsConfig?.manifests,
       tools: toolsConfig?.tools,

--- a/src/server/modules/Mecha/ContextEngineering/types.ts
+++ b/src/server/modules/Mecha/ContextEngineering/types.ts
@@ -10,6 +10,7 @@ import type {
   KnowledgeBaseInfo,
   LobeToolManifest,
   SkillMeta,
+  ToolDiscoveryConfig,
   TopicReferenceItem,
   UserMemoryData,
 } from '@lobechat/context-engine';
@@ -124,6 +125,8 @@ export interface ServerMessagesEngineParams {
   // ========== Skills ==========
   /** Skills configuration for <available_skills> injection */
   skillsConfig?: { enabledSkills?: SkillMeta[] };
+  /** Tool discovery configuration for <available_tools> injection */
+  toolDiscoveryConfig?: ToolDiscoveryConfig;
   // ========== Tools ==========
   /** Tools configuration */
   toolsConfig?: ServerToolsConfig;


### PR DESCRIPTION
### Motivation

- Enable injection of an `<available_tools>` variable into server-side context when the activator is enabled so the agent can surface discoverable tools. 
- Compute a lightweight list of available tools from the operation tool set without exposing already-enabled tools.

### Description

- Add `buildToolDiscoveryConfig` to compute `availableTools` from `OperationToolSet` and `resolved.enabledToolIds`, gated by `LobeActivatorIdentifier` presence. 
- Import `LobeActivatorIdentifier` and wire `toolDiscoveryConfig` into the LLM call flow by passing it into `serverMessagesEngine` and into the `MessagesEngine` constructor. 
- Expose `toolDiscoveryConfig` in the `ServerMessagesEngineParams` types as `ToolDiscoveryConfig` for context engineering. 
- Keep existing tool/skill resolution behavior and only provide discovery data when there are additional tools available.

### Testing

- Ran TypeScript type-check and project build via `tsc`/build, which succeeded. 
- Ran unit test suite via `yarn test`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c761089150832aa89c915b15d81fd2)