### PR TITLE
🐛 fix: set context before replaceMessages in StoreUpdater layout effect

### DIFF
--- a/src/features/Conversation/StoreUpdater.tsx
+++ b/src/features/Conversation/StoreUpdater.tsx
@@ -81,9 +81,10 @@ const StoreUpdater = memo<StoreUpdaterProps>(
         prevContextKeyRef.current = contextKey;
         prevMessagesRef.current = undefined;
 
-        // Atomically reset all stale data so ChatList shows skeleton (messagesInit=false)
-        // instead of old topic messages during the transition
+        // Update context first so replaceMessages uses the correct context
+        // when calling onMessagesChange (otherwise writes to the old topic key)
         storeApi.setState({
+          context,
           dbMessages: messages ?? [],
           displayMessages: [],
           messagesInit: false,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up to #13420

#### 🔀 Description of Change

In the `useLayoutEffect` that resets store state on context change, `replaceMessages` was called before `context` was updated in the store. Since `replaceMessages` internally calls `onMessagesChange(messages, get().context)`, it would write the new topic's messages to the **old** topic's key in ChatStore, corrupting cached data until a refetch.

Fix: include `context` in the initial `setState` call so the store has the correct context before `replaceMessages` runs.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Switch between topics that have cached messages
2. Switch back — verify messages are correct (not corrupted by the other topic's data)