### PR TITLE
🐛 fix(model-runtime): allow Gemini 3+ to combine search tools with function declarations

### DIFF
--- a/packages/model-runtime/src/providers/google/index.test.ts
+++ b/packages/model-runtime/src/providers/google/index.test.ts
@@ -751,6 +751,100 @@ describe('buildGoogleToolsWithSearch', () => {
     const config = callArgs[0].config as any;
     expect(config.tools).toEqual([{ googleSearch: {} }]);
   });
+
+  it('should combine search tools with function declarations for Gemini 3+ models', async () => {
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          text: 'test',
+          candidates: [
+            {
+              content: { parts: [{ text: 'test' }], role: 'model' },
+              finishReason: 'STOP',
+              index: 0,
+            },
+          ],
+          usageMetadata: { promptTokenCount: 1, totalTokenCount: 2 },
+          modelVersion: 'gemini-3.1-pro-preview',
+        });
+        controller.close();
+      },
+    });
+    vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(
+      mockStream as any,
+    );
+
+    await instance.chat({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'gemini-3.1-pro-preview',
+      temperature: 0,
+      enabledSearch: true,
+      urlContext: true,
+      tools: [
+        { type: 'function', function: { name: 'test_tool', description: 'A test tool' } },
+      ],
+    });
+
+    const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
+    const config = callArgs[0].config as any;
+    expect(config.tools).toEqual([
+      { urlContext: {} },
+      { googleSearch: {} },
+      {
+        functionDeclarations: [
+          {
+            name: 'test_tool',
+            description: 'A test tool',
+            parameters: {
+              description: undefined,
+              properties: { dummy: { type: 'string' } },
+              required: undefined,
+              type: 'OBJECT',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should exclude function declarations when search is enabled for pre-Gemini 3 models', async () => {
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          text: 'test',
+          candidates: [
+            {
+              content: { parts: [{ text: 'test' }], role: 'model' },
+              finishReason: 'STOP',
+              index: 0,
+            },
+          ],
+          usageMetadata: { promptTokenCount: 1, totalTokenCount: 2 },
+          modelVersion: 'gemini-2.5-pro',
+        });
+        controller.close();
+      },
+    });
+    vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(
+      mockStream as any,
+    );
+
+    await instance.chat({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'gemini-2.5-pro',
+      temperature: 0,
+      enabledSearch: true,
+      urlContext: true,
+      tools: [
+        { type: 'function', function: { name: 'test_tool', description: 'A test tool' } },
+      ],
+    });
+
+    const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
+    const config = callArgs[0].config as any;
+    // Pre-Gemini 3 models should only have search tools, no functionDeclarations
+    expect(config.tools).toEqual([{ urlContext: {} }, { googleSearch: {} }]);
+  });
 });
 
 describe('models', () => {

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -46,6 +46,15 @@ const modelsWithModalities = new Set([
 
 const modelsWithImageSearch = new Set(['gemini-3.1-flash-image-preview']);
 
+// Gemini 3+ models support combined tools (search + urlContext + functionDeclarations)
+const isGemini3OrAbove = (model?: string): boolean => {
+  if (!model) return false;
+  // Match gemini-X or gemini-X.Y patterns, extract major version
+  const match = /gemini-(\d+)/.exec(model);
+  if (!match) return false;
+  return Number.parseInt(match[1], 10) >= 3;
+};
+
 const modelsDisableInstuction = new Set([
   'gemini-2.0-flash-exp',
   'gemini-2.0-flash-exp-image-generation',
@@ -458,15 +467,8 @@ export class LobeGoogleAI implements LobeRuntimeAI {
     tools: ChatCompletionTool[] | undefined,
     payload?: ChatStreamPayload,
   ): GoogleFunctionCallTool[] | undefined {
-    const hasToolCalls = payload?.messages?.some((m) => m.tool_calls?.length);
     const hasSearch = payload?.enabledSearch;
     const hasUrlContext = payload?.urlContext;
-    const hasFunctionTools = tools && tools.length > 0;
-
-    // If tool_calls already exist, prioritize handling function declarations
-    if (hasToolCalls && hasFunctionTools) {
-      return buildGoogleTools(tools);
-    }
 
     // Build GoogleSearch tool config with optional image search support
     const googleSearchTool = hasSearch
@@ -477,7 +479,26 @@ export class LobeGoogleAI implements LobeRuntimeAI {
         }
       : undefined;
 
-    // Build and return search-related tools (search tools cannot be used with FunctionCall simultaneously)
+    // Gemini 3+ models support combined tools (search + urlContext + functionDeclarations)
+    if (isGemini3OrAbove(payload?.model)) {
+      const result: GoogleFunctionCallTool[] = [];
+
+      if (hasUrlContext) {
+        result.push({ urlContext: {} });
+      }
+      if (googleSearchTool) {
+        result.push(googleSearchTool);
+      }
+
+      const functionTools = buildGoogleTools(tools);
+      if (functionTools) {
+        result.push(...functionTools);
+      }
+
+      return result.length > 0 ? result : undefined;
+    }
+
+    // For older models, search tools cannot be used with FunctionCall simultaneously
     if (hasUrlContext && hasSearch) {
       return [{ urlContext: {} }, googleSearchTool!];
     }
@@ -488,7 +509,6 @@ export class LobeGoogleAI implements LobeRuntimeAI {
       return [googleSearchTool!];
     }
 
-    // Finally consider function declarations
     return buildGoogleTools(tools);
   }
 }

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -498,7 +498,16 @@ export class LobeGoogleAI implements LobeRuntimeAI {
       return result.length > 0 ? result : undefined;
     }
 
-    // For older models, search tools cannot be used with FunctionCall simultaneously
+    // For older models, search tools cannot be used with FunctionCall simultaneously.
+    // If tool_calls already exist in conversation, prioritize function declarations
+    // to maintain multi-turn tool-calling sessions.
+    const hasToolCalls = payload?.messages?.some((m) => m.tool_calls?.length);
+    const hasFunctionTools = tools && tools.length > 0;
+
+    if (hasToolCalls && hasFunctionTools) {
+      return buildGoogleTools(tools);
+    }
+
     if (hasUrlContext && hasSearch) {
       return [{ urlContext: {} }, googleSearchTool!];
     }


### PR DESCRIPTION
## Summary

- **Fix**: Gemini 3+ models now support `urlContext`, `googleSearch`, and `functionDeclarations` coexisting in the `tools` array
- **Problem**: Enabling search or urlContext would exclude MCP tools/skills (functionDeclarations), causing them to silently fail
- **Scope**: Only Gemini 3+ models get combined tools; older models retain the existing mutual exclusion behavior

Closes #13360
Fixes LOBE-6450

## Test plan

- [x] Existing 27 tests pass
- [x] Added test: Gemini 3+ model combines urlContext + googleSearch + functionDeclarations
- [x] Added test: Pre-Gemini 3 model excludes functionDeclarations when search is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)