### PR TITLE
🛡️ fix: pin axios to 1.13.6 to prevent supply chain attack

### DIFF
--- a/package.json
+++ b/package.json
@@ -536,6 +536,7 @@
     ],
     "overrides": {
       "@types/react": "19.2.13",
+      "axios": "1.13.6",
       "better-auth": "1.4.6",
       "better-call": "1.1.8",
       "drizzle-orm": "^0.45.1",


### PR DESCRIPTION
## Summary
- Pin `axios` to `1.13.6` via pnpm overrides to prevent resolving to compromised `1.14.1`
- `axios@1.14.1` was compromised on 2026-03-30 with malicious dependency `plain-crypto-js@4.2.1` (postinstall C2 backdoor)
- axios is an indirect dependency via `@lobehub/chat-plugin-sdk → swagger-client → @swagger-api/apidom-reference` (range `^1.12.2`)

## References
- https://socket.dev/blog/axios-npm-package-compromised

## Test plan
- [ ] Verify `pnpm ls axios` resolves to `1.13.6` after install
- [ ] Verify build passes with pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)