### PR TITLE
🐛 fix: support multiple artifacts rendering in the same message

### DIFF
--- a/src/features/Conversation/Markdown/plugins/LobeArtifact/Render/index.tsx
+++ b/src/features/Conversation/Markdown/plugins/LobeArtifact/Render/index.tsx
@@ -66,7 +66,7 @@ const Render = memo<ArtifactProps>(({ identifier, title, type, language, childre
   const [isGenerating, isArtifactTagClosed, openArtifact, closeArtifact] = useChatStore((s) => {
     return [
       messageStateSelectors.isMessageGenerating(id)(s),
-      chatPortalSelectors.isArtifactTagClosed(id)(s),
+      chatPortalSelectors.isArtifactTagClosed(id, identifier)(s),
       s.openArtifact,
       s.closeArtifact,
     ];
@@ -88,10 +88,10 @@ const Render = memo<ArtifactProps>(({ identifier, title, type, language, childre
       gap={16}
       width={'100%'}
       onClick={() => {
-        const currentArtifactMessageId = chatPortalSelectors.artifactMessageId(
-          useChatStore.getState(),
-        );
-        if (currentArtifactMessageId === id) {
+        const state = useChatStore.getState();
+        const currentArtifactMessageId = chatPortalSelectors.artifactMessageId(state);
+        const currentArtifactIdentifier = chatPortalSelectors.artifactIdentifier(state);
+        if (currentArtifactMessageId === id && currentArtifactIdentifier === identifier) {
           closeArtifact();
         } else {
           openArtifactUI();

--- a/src/features/Conversation/Markdown/plugins/LobeArtifact/rehypePlugin.test.ts
+++ b/src/features/Conversation/Markdown/plugins/LobeArtifact/rehypePlugin.test.ts
@@ -122,4 +122,97 @@ describe('rehypePlugin', () => {
 
     expect(tree).toEqual(expectedTree);
   });
+
+  it('should transform multiple <lobeArtifact> tags in the same tree', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'p',
+          children: [{ type: 'text', value: 'Here are two artifacts:' }],
+        },
+        {
+          type: 'element',
+          tagName: 'p',
+          children: [
+            {
+              type: 'raw',
+              value:
+                '<lobeArtifact identifier="first" type="text/markdown" title="First Artifact">',
+            },
+            { type: 'text', value: 'First content' },
+            { type: 'raw', value: '</lobeArtifact>' },
+          ],
+        },
+        {
+          type: 'element',
+          tagName: 'p',
+          children: [
+            {
+              type: 'raw',
+              value:
+                '<lobeArtifact identifier="second" type="text/markdown" title="Second Artifact">',
+            },
+            { type: 'text', value: 'Second content' },
+            { type: 'raw', value: '</lobeArtifact>' },
+          ],
+        },
+        {
+          type: 'element',
+          tagName: 'p',
+          children: [{ type: 'text', value: 'Done.' }],
+        },
+      ],
+    };
+
+    const plugin = rehypePlugin();
+    plugin(tree);
+
+    // Both artifacts should be transformed
+    expect(tree.children).toHaveLength(4);
+    expect(tree.children[1]).toEqual({
+      type: 'element',
+      tagName: 'lobeArtifact',
+      properties: {
+        identifier: 'first',
+        type: 'text/markdown',
+        title: 'First Artifact',
+      },
+      children: [{ type: 'text', value: 'First content' }],
+    });
+    expect(tree.children[2]).toEqual({
+      type: 'element',
+      tagName: 'lobeArtifact',
+      properties: {
+        identifier: 'second',
+        type: 'text/markdown',
+        title: 'Second Artifact',
+      },
+      children: [{ type: 'text', value: 'Second content' }],
+    });
+  });
+
+  it('should transform multiple raw <lobeArtifact> nodes (without wrapping <p>)', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'raw',
+          value: '<lobeArtifact identifier="raw-1" type="text/html" title="Raw First">',
+        },
+        {
+          type: 'raw',
+          value: '<lobeArtifact identifier="raw-2" type="text/html" title="Raw Second">',
+        },
+      ],
+    };
+
+    const plugin = rehypePlugin();
+    plugin(tree);
+
+    expect(tree.children).toHaveLength(2);
+    expect(tree.children[0].tagName).toBe('lobeArtifact');
+    expect(tree.children[1].tagName).toBe('lobeArtifact');
+  });
 });

--- a/src/features/Conversation/Markdown/plugins/LobeArtifact/rehypePlugin.test.ts
+++ b/src/features/Conversation/Markdown/plugins/LobeArtifact/rehypePlugin.test.ts
@@ -212,7 +212,7 @@ describe('rehypePlugin', () => {
     plugin(tree);
 
     expect(tree.children).toHaveLength(2);
-    expect(tree.children[0].tagName).toBe('lobeArtifact');
-    expect(tree.children[1].tagName).toBe('lobeArtifact');
+    expect((tree.children[0] as any).tagName).toBe('lobeArtifact');
+    expect((tree.children[1] as any).tagName).toBe('lobeArtifact');
   });
 });

--- a/src/features/Conversation/utils/markdown.test.ts
+++ b/src/features/Conversation/utils/markdown.test.ts
@@ -275,6 +275,53 @@ This code provides a basic calculator that can perform addition, subtraction, mu
 
 This code provides a basic calculator that can perform addition, subtraction, multiplication, and division.`);
   });
+
+  it('should remove line breaks from multiple artifact tags in the same message', () => {
+    const input = `Here are two artifacts:
+
+<lobeArtifact identifier="first-artifact" type="text/markdown" title="First">
+Line 1
+Line 2
+</lobeArtifact>
+
+<lobeArtifact identifier="second-artifact" type="text/markdown" title="Second">
+Line A
+Line B
+</lobeArtifact>
+
+Done.`;
+
+    const output = processWithArtifact(input);
+
+    // Both artifacts should have their newlines removed
+    expect(output).toEqual(`Here are two artifacts:
+
+<lobeArtifact identifier="first-artifact" type="text/markdown" title="First">Line 1Line 2</lobeArtifact>
+
+<lobeArtifact identifier="second-artifact" type="text/markdown" title="Second">Line ALine B</lobeArtifact>
+
+Done.`);
+  });
+
+  it('should handle multiple artifacts where second is still generating (unclosed)', () => {
+    const input = `Two artifacts:
+
+<lobeArtifact identifier="done" type="text/markdown" title="Done">
+Content 1
+</lobeArtifact>
+
+<lobeArtifact identifier="generating" type="text/markdown" title="Generating">
+Content 2 still going`;
+
+    const output = processWithArtifact(input);
+
+    // Both artifacts should have newlines removed, even the unclosed one
+    expect(output).toEqual(`Two artifacts:
+
+<lobeArtifact identifier="done" type="text/markdown" title="Done">Content 1</lobeArtifact>
+
+<lobeArtifact identifier="generating" type="text/markdown" title="Generating">Content 2 still going`);
+  });
 });
 
 describe('outer code block removal', () => {

--- a/src/features/Conversation/utils/markdown.ts
+++ b/src/features/Conversation/utils/markdown.ts
@@ -1,4 +1,4 @@
-import { ARTIFACT_TAG_REGEX, ARTIFACT_THINKING_TAG_REGEX } from '@lobechat/const';
+import { ARTIFACT_THINKING_TAG_REGEX } from '@lobechat/const';
 
 /**
  * Replace all line breaks in the matched `lobeArtifact` tag with an empty string
@@ -46,11 +46,13 @@ export const processWithArtifact = (input: string = '') => {
     },
   );
 
-  const match = ARTIFACT_TAG_REGEX.exec(output);
-  // If the input contains the `lobeArtifact` tag, replace all line breaks with an empty string
-  if (match) {
-    output = output.replace(ARTIFACT_TAG_REGEX, (match) => match.replaceAll(/\r?\n|\r/g, ''));
-  }
+  // If the input contains `lobeArtifact` tags, replace all line breaks with an empty string
+  // Use global regex to handle multiple artifacts in the same message
+  const ARTIFACT_TAG_REGEX_GLOBAL =
+    /<lobeArtifact\b[^>]*>(?<content>[\S\s]*?)(?:<\/lobeArtifact>|$)/g;
+  output = output.replaceAll(ARTIFACT_TAG_REGEX_GLOBAL, (match) =>
+    match.replaceAll(/\r?\n|\r/g, ''),
+  );
 
   // if not match, check if it's start with <lobeArtifact but not closed
   const regex = /<lobeArtifact\b(?:(?!\/?>)[\s\S])*$/;

--- a/src/features/Portal/Artifacts/Body/index.tsx
+++ b/src/features/Portal/Artifacts/Body/index.tsx
@@ -19,15 +19,16 @@ const ArtifactsUI = memo(() => {
     isArtifactTagClosed,
   ] = useChatStore((s) => {
     const messageId = chatPortalSelectors.artifactMessageId(s) || '';
+    const identifier = chatPortalSelectors.artifactIdentifier(s);
 
     return [
       messageId,
       s.portalArtifactDisplayMode,
       messageStateSelectors.isMessageGenerating(messageId)(s),
       chatPortalSelectors.artifactType(s),
-      chatPortalSelectors.artifactCode(messageId)(s),
+      chatPortalSelectors.artifactCode(messageId, identifier)(s),
       chatPortalSelectors.artifactCodeLanguage(s),
-      chatPortalSelectors.isArtifactTagClosed(messageId)(s),
+      chatPortalSelectors.isArtifactTagClosed(messageId, identifier)(s),
     ];
   });
 

--- a/src/features/Portal/Artifacts/Title.tsx
+++ b/src/features/Portal/Artifacts/Title.tsx
@@ -16,12 +16,13 @@ const Title = () => {
   const [displayMode, artifactType, artifactTitle, isArtifactTagClosed, closeArtifact] =
     useChatStore((s) => {
       const messageId = chatPortalSelectors.artifactMessageId(s) || '';
+      const identifier = chatPortalSelectors.artifactIdentifier(s);
 
       return [
         s.portalArtifactDisplayMode,
         chatPortalSelectors.artifactType(s),
         chatPortalSelectors.artifactTitle(s),
-        chatPortalSelectors.isArtifactTagClosed(messageId)(s),
+        chatPortalSelectors.isArtifactTagClosed(messageId, identifier)(s),
         s.closeArtifact,
       ];
     });

--- a/src/store/chat/slices/portal/action.test.ts
+++ b/src/store/chat/slices/portal/action.test.ts
@@ -227,6 +227,100 @@ describe('chatDockSlice', () => {
     });
   });
 
+  describe('openArtifact', () => {
+    it('should push Artifact view and open portal', () => {
+      const { result } = renderHook(() => useChatStore());
+
+      act(() => {
+        result.current.openArtifact({
+          id: 'msg-1',
+          identifier: 'artifact-1',
+          title: 'First Artifact',
+          type: 'text/markdown',
+        });
+      });
+
+      expect(result.current.portalStack).toHaveLength(1);
+      expect(result.current.portalStack[0]).toEqual({
+        type: PortalViewType.Artifact,
+        artifact: {
+          id: 'msg-1',
+          identifier: 'artifact-1',
+          title: 'First Artifact',
+          type: 'text/markdown',
+        },
+      });
+      expect(result.current.showPortal).toBe(true);
+    });
+
+    it('should replace artifact view when switching to different artifact from same message', () => {
+      const { result } = renderHook(() => useChatStore());
+
+      act(() => {
+        result.current.openArtifact({
+          id: 'msg-1',
+          identifier: 'artifact-1',
+          title: 'First Artifact',
+          type: 'text/markdown',
+        });
+      });
+
+      act(() => {
+        result.current.openArtifact({
+          id: 'msg-1',
+          identifier: 'artifact-2',
+          title: 'Second Artifact',
+          type: 'text/html',
+        });
+      });
+
+      // Should replace, not stack (same view type)
+      expect(result.current.portalStack).toHaveLength(1);
+      expect(result.current.portalStack[0]).toEqual({
+        type: PortalViewType.Artifact,
+        artifact: {
+          id: 'msg-1',
+          identifier: 'artifact-2',
+          title: 'Second Artifact',
+          type: 'text/html',
+        },
+      });
+    });
+
+    it('should replace artifact view when switching to artifact from different message', () => {
+      const { result } = renderHook(() => useChatStore());
+
+      act(() => {
+        result.current.openArtifact({
+          id: 'msg-1',
+          identifier: 'artifact-1',
+          title: 'First',
+          type: 'text/markdown',
+        });
+      });
+
+      act(() => {
+        result.current.openArtifact({
+          id: 'msg-2',
+          identifier: 'artifact-x',
+          title: 'Other',
+          type: 'text/html',
+        });
+      });
+
+      expect(result.current.portalStack).toHaveLength(1);
+      expect(result.current.portalStack[0]).toEqual({
+        type: PortalViewType.Artifact,
+        artifact: {
+          id: 'msg-2',
+          identifier: 'artifact-x',
+          title: 'Other',
+          type: 'text/html',
+        },
+      });
+    });
+  });
+
   describe('openToolUI', () => {
     it('should push ToolUI view and open portal', () => {
       const { result } = renderHook(() => useChatStore());

--- a/src/store/chat/slices/portal/selectors.test.ts
+++ b/src/store/chat/slices/portal/selectors.test.ts
@@ -345,6 +345,27 @@ ${htmlContent}
       expect(chatPortalSelectors.artifactCode('test-id', 'wip')(state)).toBe('Still generating...');
     });
 
+    it('should handle identifiers with regex special characters', () => {
+      const state = createState({
+        dbMessagesMap: {
+          'test-id_null': [
+            {
+              id: 'test-id',
+              content: `<lobeArtifact identifier="test+id(1)[2]" type="text">Special content</lobeArtifact>`,
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+              role: 'user',
+              sessionId: 'test-id',
+            } as UIChatMessage,
+          ],
+        },
+      });
+      expect(chatPortalSelectors.artifactCode('test-id', 'test+id(1)[2]')(state)).toBe(
+        'Special content',
+      );
+      expect(chatPortalSelectors.isArtifactTagClosed('test-id', 'test+id(1)[2]')(state)).toBe(true);
+    });
+
     it('should return first artifact content when no identifier provided (backward compat)', () => {
       const content1 = 'First';
       const state = createState({

--- a/src/store/chat/slices/portal/selectors.test.ts
+++ b/src/store/chat/slices/portal/selectors.test.ts
@@ -308,6 +308,43 @@ ${htmlContent}
       expect(chatPortalSelectors.artifactCode('test-id', 'second')(state)).toBe(content2);
     });
 
+    it('should return empty string for non-existent identifier', () => {
+      const state = createState({
+        dbMessagesMap: {
+          'test-id_null': [
+            {
+              id: 'test-id',
+              content: `<lobeArtifact identifier="real" type="text">Real content</lobeArtifact>`,
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+              role: 'user',
+              sessionId: 'test-id',
+            } as UIChatMessage,
+          ],
+        },
+      });
+      expect(chatPortalSelectors.artifactCode('test-id', 'nonexistent')(state)).toBe('');
+    });
+
+    it('should extract content from unclosed artifact by identifier', () => {
+      const state = createState({
+        dbMessagesMap: {
+          'test-id_null': [
+            {
+              id: 'test-id',
+              content: `<lobeArtifact identifier="done" type="text">Done</lobeArtifact>\n\n<lobeArtifact identifier="wip" type="text">Still generating...`,
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+              role: 'user',
+              sessionId: 'test-id',
+            } as UIChatMessage,
+          ],
+        },
+      });
+      expect(chatPortalSelectors.artifactCode('test-id', 'done')(state)).toBe('Done');
+      expect(chatPortalSelectors.artifactCode('test-id', 'wip')(state)).toBe('Still generating...');
+    });
+
     it('should return first artifact content when no identifier provided (backward compat)', () => {
       const content1 = 'First';
       const state = createState({
@@ -381,6 +418,44 @@ ${htmlContent}
         },
       });
       expect(chatPortalSelectors.isArtifactTagClosed('test-id')(state)).toBe(false);
+    });
+
+    it('should check specific artifact by identifier when both artifacts are closed', () => {
+      const state = createState({
+        dbMessagesMap: {
+          'test-id_null': [
+            {
+              id: 'test-id',
+              content:
+                '<lobeArtifact identifier="a" type="text">A</lobeArtifact>\n\n<lobeArtifact identifier="b" type="text">B</lobeArtifact>',
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+              role: 'user',
+              sessionId: 'test-id',
+            } as UIChatMessage,
+          ],
+        },
+      });
+      expect(chatPortalSelectors.isArtifactTagClosed('test-id', 'a')(state)).toBe(true);
+      expect(chatPortalSelectors.isArtifactTagClosed('test-id', 'b')(state)).toBe(true);
+    });
+
+    it('should return false for non-existent identifier', () => {
+      const state = createState({
+        dbMessagesMap: {
+          'test-id_null': [
+            {
+              id: 'test-id',
+              content: '<lobeArtifact identifier="exists" type="text">Content</lobeArtifact>',
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+              role: 'user',
+              sessionId: 'test-id',
+            } as UIChatMessage,
+          ],
+        },
+      });
+      expect(chatPortalSelectors.isArtifactTagClosed('test-id', 'nonexistent')(state)).toBe(false);
     });
 
     it('should check specific artifact by identifier when first is closed but second is not', () => {

--- a/src/store/chat/slices/portal/selectors.test.ts
+++ b/src/store/chat/slices/portal/selectors.test.ts
@@ -286,6 +286,46 @@ ${htmlContent}
       });
       expect(chatPortalSelectors.artifactCode('test-id')(state)).toBe(htmlContent);
     });
+
+    it('should extract specific artifact content by identifier', () => {
+      const content1 = 'First artifact content';
+      const content2 = 'Second artifact content';
+      const state = createState({
+        dbMessagesMap: {
+          'test-id_null': [
+            {
+              id: 'test-id',
+              content: `<lobeArtifact identifier="first" type="text">${content1}</lobeArtifact>\n\n<lobeArtifact identifier="second" type="text">${content2}</lobeArtifact>`,
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+              role: 'user',
+              sessionId: 'test-id',
+            } as UIChatMessage,
+          ],
+        },
+      });
+      expect(chatPortalSelectors.artifactCode('test-id', 'first')(state)).toBe(content1);
+      expect(chatPortalSelectors.artifactCode('test-id', 'second')(state)).toBe(content2);
+    });
+
+    it('should return first artifact content when no identifier provided (backward compat)', () => {
+      const content1 = 'First';
+      const state = createState({
+        dbMessagesMap: {
+          'test-id_null': [
+            {
+              id: 'test-id',
+              content: `<lobeArtifact identifier="a" type="text">${content1}</lobeArtifact>\n\n<lobeArtifact identifier="b" type="text">Second</lobeArtifact>`,
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+              role: 'user',
+              sessionId: 'test-id',
+            } as UIChatMessage,
+          ],
+        },
+      });
+      expect(chatPortalSelectors.artifactCode('test-id')(state)).toBe(content1);
+    });
   });
 
   describe('isArtifactTagClosed', () => {
@@ -341,6 +381,29 @@ ${htmlContent}
         },
       });
       expect(chatPortalSelectors.isArtifactTagClosed('test-id')(state)).toBe(false);
+    });
+
+    it('should check specific artifact by identifier when first is closed but second is not', () => {
+      const state = createState({
+        dbMessagesMap: {
+          'test-id_null': [
+            {
+              id: 'test-id',
+              content:
+                '<lobeArtifact identifier="done" type="text">Content 1</lobeArtifact>\n\n<lobeArtifact identifier="generating" type="text">Content 2 still going',
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+              role: 'user',
+              sessionId: 'test-id',
+            } as UIChatMessage,
+          ],
+        },
+      });
+      // Without identifier, returns true because first artifact is closed
+      expect(chatPortalSelectors.isArtifactTagClosed('test-id')(state)).toBe(true);
+      // With identifier, correctly distinguishes between closed and unclosed
+      expect(chatPortalSelectors.isArtifactTagClosed('test-id', 'done')(state)).toBe(true);
+      expect(chatPortalSelectors.isArtifactTagClosed('test-id', 'generating')(state)).toBe(false);
     });
   });
 });

--- a/src/store/chat/slices/portal/selectors.ts
+++ b/src/store/chat/slices/portal/selectors.ts
@@ -63,6 +63,9 @@ const artifactMessageId = (s: ChatStoreState) => currentArtifact(s)?.id;
 const artifactType = (s: ChatStoreState) => currentArtifact(s)?.type;
 const artifactCodeLanguage = (s: ChatStoreState) => currentArtifact(s)?.language;
 
+// Escape special regex characters in a string
+const escapeRegExp = (str: string) => str.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+
 const artifactMessageContent = (id: string) => (s: ChatStoreState) => {
   const message = dbMessageSelectors.getDbMessageById(id)(s);
   return message?.content || '';
@@ -73,7 +76,7 @@ const artifactCode = (id: string, identifier?: string) => (s: ChatStoreState) =>
 
   const regex = identifier
     ? new RegExp(
-        `<lobeArtifact\\b[^>]*identifier="${identifier}"[^>]*>(?<content>[\\S\\s]*?)(?:<\\/lobeArtifact>|$)`,
+        `<lobeArtifact\\b[^>]*identifier="${escapeRegExp(identifier)}"[^>]*>(?<content>[\\S\\s]*?)(?:<\\/lobeArtifact>|$)`,
       )
     : ARTIFACT_TAG_REGEX;
 
@@ -92,7 +95,7 @@ const isArtifactTagClosed = (id: string, identifier?: string) => (s: ChatStoreSt
   if (identifier) {
     // Check if the specific artifact (by identifier) is closed
     const regex = new RegExp(
-      `<lobeArtifact\\b[^>]*identifier="${identifier}"[^>]*>[\\S\\s]*?<\\/lobeArtifact>`,
+      `<lobeArtifact\\b[^>]*identifier="${escapeRegExp(identifier)}"[^>]*>[\\S\\s]*?<\\/lobeArtifact>`,
     );
     return regex.test(content || '');
   }

--- a/src/store/chat/slices/portal/selectors.ts
+++ b/src/store/chat/slices/portal/selectors.ts
@@ -68,10 +68,16 @@ const artifactMessageContent = (id: string) => (s: ChatStoreState) => {
   return message?.content || '';
 };
 
-const artifactCode = (id: string) => (s: ChatStoreState) => {
+const artifactCode = (id: string, identifier?: string) => (s: ChatStoreState) => {
   const messageContent = artifactMessageContent(id)(s);
-  const result = messageContent.match(ARTIFACT_TAG_REGEX);
 
+  const regex = identifier
+    ? new RegExp(
+        `<lobeArtifact\\b[^>]*identifier="${identifier}"[^>]*>(?<content>[\\S\\s]*?)(?:<\\/lobeArtifact>|$)`,
+      )
+    : ARTIFACT_TAG_REGEX;
+
+  const result = messageContent.match(regex);
   let content = result?.groups?.content || '';
 
   // Remove markdown code block if content is wrapped
@@ -80,8 +86,16 @@ const artifactCode = (id: string) => (s: ChatStoreState) => {
   return content;
 };
 
-const isArtifactTagClosed = (id: string) => (s: ChatStoreState) => {
+const isArtifactTagClosed = (id: string, identifier?: string) => (s: ChatStoreState) => {
   const content = artifactMessageContent(id)(s);
+
+  if (identifier) {
+    // Check if the specific artifact (by identifier) is closed
+    const regex = new RegExp(
+      `<lobeArtifact\\b[^>]*identifier="${identifier}"[^>]*>[\\S\\s]*?<\\/lobeArtifact>`,
+    );
+    return regex.test(content || '');
+  }
 
   return ARTIFACT_TAG_CLOSED_REGEX.test(content || '');
 };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes #8019, Fixes #4618
Fixes LOBE-6539

#### 🔀 Description of Change

When a message contains multiple `<lobeArtifact>` tags, only the first one rendered correctly. The rest stayed in loading state, showed incorrect content, or had their code spill out.

**Root causes fixed:**

1. **`processWithArtifact`** (`markdown.ts`) — `ARTIFACT_TAG_REGEX` had no `g` flag, so only the first artifact tag's newlines were removed. Subsequent artifacts retained newlines, breaking the markdown parser.
2. **`artifactCode` selector** (`selectors.ts`) — `.match(ARTIFACT_TAG_REGEX)` only returned the first artifact's content. The Portal panel always showed the first artifact regardless of which one was clicked.
3. **`isArtifactTagClosed` selector** (`selectors.ts`) — `ARTIFACT_TAG_CLOSED_REGEX.test()` returned `true` if ANY artifact in the message was closed, so all artifact cards lost their loading spinner once the first artifact finished generating.
4. **Render `onClick`** (`Render/index.tsx`) — Compared only `messageId`, so clicking a different artifact from the same message would close the Portal instead of switching to it.

**Changes:**

- Use global regex in `processWithArtifact` to handle all artifact tags
- Add `identifier` parameter to `artifactCode` and `isArtifactTagClosed` selectors for per-artifact state tracking
- Pass current artifact's `identifier` to selectors in Portal Body, Title, and Render components
- Compare both `messageId` and `identifier` in Render onClick to enable switching between artifacts

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

**Unit tests:** 5 new test cases added
- `processWithArtifact`: multiple closed artifacts, multiple with one unclosed
- `artifactCode`: extract specific artifact by identifier, backward compat without identifier
- `isArtifactTagClosed`: per-identifier closed detection (first closed, second still generating)

**Electron test:**
1. Inject a message with two `<lobeArtifact>` tags
2. Both artifact cards render correctly (title, identifier, char count, no loading spinner)
3. Click first artifact → Portal opens with correct content
4. Click second artifact → Portal switches (not closes) to second artifact's content

#### 📝 Additional Information

No breaking changes. The `identifier` parameter on `artifactCode` and `isArtifactTagClosed` is optional — existing callers without it continue to work as before (matching the first artifact).