### PR TITLE
💄 style: show live elapsed timer during tool execution

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ExecutionTime.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ExecutionTime.tsx
@@ -1,0 +1,56 @@
+import { Text } from '@lobehub/ui';
+import { memo, useEffect, useRef, useState } from 'react';
+
+interface ExecutionTimeProps {
+  isExecuting: boolean;
+}
+
+const formatElapsedTime = (ms: number): string => {
+  if (ms < 1000) return `${ms}ms`;
+
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+
+  const minutes = seconds / 60;
+  return `${minutes.toFixed(1)}min`;
+};
+
+const ExecutionTime = memo<ExecutionTimeProps>(({ isExecuting }) => {
+  const [elapsed, setElapsed] = useState(0);
+  const startTimeRef = useRef(Date.now());
+  const rafRef = useRef<number | null>(null);
+  const lastUpdateRef = useRef(0);
+
+  useEffect(() => {
+    if (!isExecuting) {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      return;
+    }
+
+    startTimeRef.current = Date.now();
+
+    const update = (timestamp: number) => {
+      if (timestamp - lastUpdateRef.current >= 100) {
+        setElapsed(Date.now() - startTimeRef.current);
+        lastUpdateRef.current = timestamp;
+      }
+      rafRef.current = requestAnimationFrame(update);
+    };
+
+    rafRef.current = requestAnimationFrame(update);
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [isExecuting]);
+
+  if (!isExecuting) return null;
+
+  return (
+    <Text fontSize={12} style={{ flexShrink: 0, whiteSpace: 'nowrap' }} type="secondary">
+      {formatElapsedTime(elapsed)}
+    </Text>
+  );
+});
+
+export default ExecutionTime;

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ExecutionTime.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ExecutionTime.tsx
@@ -28,6 +28,7 @@ const ExecutionTime = memo<ExecutionTimeProps>(({ isExecuting }) => {
     }
 
     startTimeRef.current = Date.now();
+    setElapsed(0);
 
     const update = (timestamp: number) => {
       if (timestamp - lastUpdateRef.current >= 100) {

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/index.tsx
@@ -1,5 +1,5 @@
 import { getBuiltinInspector } from '@lobechat/builtin-tools/inspectors';
-import { type ToolIntervention } from '@lobechat/types';
+import type { ToolIntervention } from '@lobechat/types';
 import { safeParseJSON, safeParsePartialJSON } from '@lobechat/utils';
 import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
@@ -7,6 +7,7 @@ import { memo } from 'react';
 import SafeBoundary from '@/components/ErrorBoundary';
 import { LOADING_FLAT } from '@/const/message';
 
+import ExecutionTime from './ExecutionTime';
 import StatusIndicator from './StatusIndicator';
 import ToolTitle from './ToolTitle';
 
@@ -56,6 +57,7 @@ const Inspectors = memo<InspectorProps>(
               result={result}
             />
           </SafeBoundary>
+          <ExecutionTime isExecuting={isToolExecuting} />
         </Flexbox>
       );
     }
@@ -74,6 +76,7 @@ const Inspectors = memo<InspectorProps>(
           isLoading={isTitleLoading}
           partialArgs={partialJson || undefined}
         />
+        <ExecutionTime isExecuting={isToolExecuting} />
       </Flexbox>
     );
   },

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/index.tsx
@@ -31,9 +31,11 @@ const Inspectors = memo<InspectorProps>(
 
     const isPending = intervention?.status === 'pending';
     const isAborted = intervention?.status === 'aborted';
+    const isRejected = intervention?.status === 'rejected';
 
     // Distinguish between arguments streaming and tool executing
-    const isToolExecuting = !hasResult && !isPending && !isAborted && !isArgumentsStreaming;
+    const isToolExecuting =
+      !hasResult && !isPending && !isAborted && !isRejected && !isArgumentsStreaming;
     const isTitleLoading = isArgumentsStreaming || isToolExecuting;
 
     // Check for custom inspector renderer


### PR DESCRIPTION
## Summary

- Show a real-time elapsed timer on tool call inspector while the tool is executing
- Timer automatically hides once execution completes
- Supports both custom inspector and default inspector views

Fixes LOBE-6331

## Test plan

- [x] Type check passes
- [x] Electron test: timer shows `1.7s` during search execution
- [x] Electron test: timer disappears after tool completes (green checkmark shown)
- [x] Verified with multiple tool calls (Search pages, Read page content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)