### PR TITLE
⬆️ chore: bump Lexical to 0.42 and align editor imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "better-call": "1.1.8",
     "drizzle-orm": "^0.45.1",
     "fast-xml-parser": "5.4.2",
+    "lexical": "0.42.0",
     "pdfjs-dist": "5.4.530",
     "stylelint-config-clean-order": "7.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "@huggingface/inference": "^4.13.10",
     "@icons-pack/react-simple-icons": "^13.8.0",
     "@khmyznikov/pwa-install": "0.3.9",
-    "@lexical/utils": "^0.39.0",
+    "@lexical/utils": "^0.42.0",
     "@lobechat/agent-runtime": "workspace:*",
     "@lobechat/agent-templates": "workspace:*",
     "@lobechat/builtin-agent-onboarding": "workspace:*",
@@ -340,7 +340,7 @@
     "klavis": "^2.15.0",
     "langfuse": "^3.38.6",
     "langfuse-core": "^3.38.6",
-    "lexical": "^0.39.0",
+    "lexical": "^0.42.0",
     "lucide-react": "^0.562.0",
     "mammoth": "^1.11.0",
     "marked": "^17.0.1",
@@ -540,6 +540,7 @@
       "better-call": "1.1.8",
       "drizzle-orm": "^0.45.1",
       "fast-xml-parser": "5.4.2",
+      "lexical": "0.42.0",
       "pdfjs-dist": "5.4.530",
       "stylelint-config-clean-order": "7.0.0"
     }

--- a/packages/editor-runtime/package.json
+++ b/packages/editor-runtime/package.json
@@ -10,7 +10,7 @@
     "@lobechat/prompts": "workspace:*"
   },
   "devDependencies": {
-    "lexical": "^0.39.0"
+    "lexical": "^0.42.0"
   },
   "peerDependencies": {
     "@lobehub/editor": "^4",

--- a/src/features/ChatInput/InputEditor/ActionTag/ActionTagPlugin.ts
+++ b/src/features/ChatInput/InputEditor/ActionTag/ActionTagPlugin.ts
@@ -3,7 +3,6 @@ import {
   ILitexmlService,
   IMarkdownShortCutService,
 } from '@lobehub/editor';
-import type { IEditorPlugin } from '@lobehub/editor/es/types/kernel';
 import type { LexicalEditor, LexicalNode } from 'lexical';
 
 import { $isActionTagNode, ActionTagNode, type SerializedActionTagNode } from './ActionTagNode';
@@ -18,13 +17,7 @@ export interface ActionTagPluginOptions {
   theme?: { actionTag?: string };
 }
 
-/**
- * Editor plugin for ActionTagNode. Implements {@link IEditorPlugin}.
- * - Constructor: registers node, decorator, theme
- * - onInit: called by kernel after Lexical editor creation; registers command, selection observer, markdown/litexml
- * - destroy: cleanup
- */
-export class ActionTagPlugin implements IEditorPlugin<ActionTagPluginOptions> {
+export class ActionTagPlugin {
   static pluginName = 'ActionTagPlugin';
 
   config?: ActionTagPluginOptions;
@@ -82,16 +75,13 @@ export class ActionTagPlugin implements IEditorPlugin<ActionTagPluginOptions> {
     });
 
     xmlService?.registerXMLReader('action', (xmlElement: any) => {
-      try {
-        const { INodeHelper } = require('@lobehub/editor/es/editor-kernel/inode/helper');
-        return INodeHelper.createElementNode(ActionTagNode.getType(), {
-          actionCategory: (xmlElement.getAttribute('category') || 'skill') as ActionTagCategory,
-          actionLabel: xmlElement.getAttribute('label') || '',
-          actionType: (xmlElement.getAttribute('type') || 'translate') as ActionTagType,
-        } satisfies Partial<SerializedActionTagNode>);
-      } catch {
-        return false;
-      }
+      return {
+        actionCategory: (xmlElement.getAttribute('category') || 'skill') as ActionTagCategory,
+        actionLabel: xmlElement.getAttribute('label') || '',
+        actionType: (xmlElement.getAttribute('type') || 'translate') as ActionTagType,
+        type: ActionTagNode.getType(),
+        version: 1,
+      } satisfies SerializedActionTagNode;
     });
   }
 

--- a/src/features/ChatInput/InputEditor/ReferTopic/ReferTopicPlugin.ts
+++ b/src/features/ChatInput/InputEditor/ReferTopic/ReferTopicPlugin.ts
@@ -4,7 +4,6 @@ import {
   ILitexmlService,
   IMarkdownShortCutService,
 } from '@lobehub/editor';
-import type { IEditorPlugin } from '@lobehub/editor/es/types/kernel';
 import {
   $createParagraphNode,
   $insertNodes,
@@ -32,13 +31,7 @@ export interface ReferTopicPluginOptions {
   theme?: { referTopic?: string };
 }
 
-/**
- * Editor plugin for ReferTopicNode. Implements {@link IEditorPlugin}.
- * - Constructor: registers node, decorator, theme
- * - onInit: called by kernel after Lexical editor creation; registers markdown/litexml writers & readers
- * - destroy: cleanup
- */
-export class ReferTopicPlugin implements IEditorPlugin<ReferTopicPluginOptions> {
+export class ReferTopicPlugin {
   static pluginName = 'ReferTopicPlugin';
 
   config?: ReferTopicPluginOptions;
@@ -106,15 +99,12 @@ export class ReferTopicPlugin implements IEditorPlugin<ReferTopicPluginOptions> 
     });
 
     xmlService?.registerXMLReader('referTopic', (xmlElement: any) => {
-      try {
-        const { INodeHelper } = require('@lobehub/editor/es/editor-kernel/inode/helper');
-        return INodeHelper.createElementNode(ReferTopicNode.getType(), {
-          topicId: xmlElement.getAttribute('id') || '',
-          topicTitle: xmlElement.getAttribute('name') || '',
-        } satisfies Partial<SerializedReferTopicNode>);
-      } catch {
-        return false;
-      }
+      return {
+        topicId: xmlElement.getAttribute('id') || '',
+        topicTitle: xmlElement.getAttribute('name') || '',
+        type: ReferTopicNode.getType(),
+        version: 1,
+      } satisfies SerializedReferTopicNode;
     });
   }
 

--- a/src/libs/mcp/__tests__/index.test.ts
+++ b/src/libs/mcp/__tests__/index.test.ts
@@ -1,6 +1,14 @@
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { MCPClient } from '../index';
+
+const require = createRequire(import.meta.url);
+const mcpHelloWorldRoot = dirname(require.resolve('mcp-hello-world/package.json'));
+/** Local stdio entry (see mcp-hello-world `bin`); avoids `npx` so npm never reads this repo's overrides. */
+const mcpHelloWorldStdio = join(mcpHelloWorldRoot, 'build', 'stdio.js');
 
 describe('MCPClient', () => {
   // --- Updated Stdio Transport tests ---
@@ -11,9 +19,8 @@ describe('MCPClient', () => {
       id: 'mcp-hello-world',
       name: 'Stdio SDK Test Connection',
       type: 'stdio' as const,
-      command: 'npx', // Use node to run the compiled mock server
-      // Ensure non-interactive execution to avoid hanging on install confirmation in CI.
-      args: ['--yes', 'mcp-hello-world@1.1.2'],
+      command: process.execPath,
+      args: [mcpHelloWorldStdio],
     };
 
     beforeEach(async () => {

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/MentionList/MentionDropdown.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/MentionList/MentionDropdown.tsx
@@ -1,4 +1,4 @@
-import { type MenuRenderProps } from '@lobehub/editor/es/plugins/slash/react/type';
+import { type MenuRenderProps } from '@lobehub/editor';
 import { Flexbox } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { type ReactNode } from 'react';

--- a/src/routes/(main)/group/profile/features/MemberProfile/MentionList/MentionDropdown.tsx
+++ b/src/routes/(main)/group/profile/features/MemberProfile/MentionList/MentionDropdown.tsx
@@ -1,4 +1,4 @@
-import { type MenuRenderProps } from '@lobehub/editor/es/plugins/slash/react/type';
+import { type MenuRenderProps } from '@lobehub/editor';
 import { Flexbox } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { type ReactNode } from 'react';

--- a/src/store/document/slices/editor/action.ts
+++ b/src/store/document/slices/editor/action.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { IEditor } from '@lobehub/editor/es/types';
+import type { IEditor } from '@lobehub/editor';
 import type { EditorState as LobehubEditorState } from '@lobehub/editor/react';
 import isEqual from 'fast-deep-equal';
 


### PR DESCRIPTION
- Bump lexical and @lexical/utils; pin lexical in pnpm overrides
- Return serialized nodes from ActionTag/ReferTopic XML readers (no INodeHelper require)
- Drop IEditorPlugin implements; import MenuRenderProps and IEditor from @lobehub/editor barrel

Made-with: Cursor
