### PR TITLE
🐛 fix(utils): auto-reload on chunk load error

### DIFF
--- a/src/utils/chunkError.ts
+++ b/src/utils/chunkError.ts
@@ -23,9 +23,18 @@ export function isChunkLoadError(error: unknown): boolean {
   return CHUNK_ERROR_PATTERNS.some((p) => combined.includes(p));
 }
 
+const RELOAD_KEY = 'lobe-chunk-reload';
+
 /**
- * Show user notification for chunk load error (no reload).
+ * Auto-reload on chunk load error. Uses sessionStorage to prevent infinite reload loops.
  */
 export function notifyChunkError(): void {
-  toast.info('Web app has been updated so it needs to be reloaded.');
+  const reloaded = sessionStorage.getItem(RELOAD_KEY);
+  if (reloaded) {
+    sessionStorage.removeItem(RELOAD_KEY);
+    toast.error('There is a new version for the web app. Refresh the page to update');
+    return;
+  }
+  sessionStorage.setItem(RELOAD_KEY, '1');
+  window.location.reload();
 }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-6572

#### 🔀 Description of Change

When a dynamically imported chunk fails to load (e.g. after a deployment), the old version is already unusable. Instead of just showing a toast message asking the user to refresh, the page now auto-reloads.

A `sessionStorage` guard prevents infinite reload loops — if the reload itself triggers the same error, a fallback toast is shown instead.

#### 🧪 How to Test

- [x] No tests needed

Simulate a chunk load error (e.g. clear Vite build cache while the app is running) and verify the page auto-reloads. On second failure, verify a fallback error toast appears.

#### 📝 Additional Information

The companion Toast alignment fix (icon not aligned with description-only text) is in a separate lobe-ui PR.