### PR TITLE
♻️ refactor(tool): decouple topic-reference executor from app TRPC client

### DIFF
--- a/packages/builtin-tool-topic-reference/src/executor/index.ts
+++ b/packages/builtin-tool-topic-reference/src/executor/index.ts
@@ -1,8 +1,6 @@
 import type { BuiltinToolContext, BuiltinToolResult } from '@lobechat/types';
 import { BaseExecutor } from '@lobechat/types';
 
-import { lambdaClient } from '@/libs/trpc/client';
-
 import { TopicReferenceIdentifier } from '../types';
 
 const TopicReferenceApiName = {
@@ -13,28 +11,24 @@ interface GetTopicContextParams {
   topicId: string;
 }
 
-class TopicReferenceExecutor extends BaseExecutor<typeof TopicReferenceApiName> {
+interface TopicReferenceExecutionRuntime {
+  getTopicContext: (params: GetTopicContextParams) => Promise<BuiltinToolResult>;
+}
+
+export class TopicReferenceExecutor extends BaseExecutor<typeof TopicReferenceApiName> {
   readonly identifier = TopicReferenceIdentifier;
   protected readonly apiEnum = TopicReferenceApiName;
+  private runtime: TopicReferenceExecutionRuntime;
+
+  constructor(runtime: TopicReferenceExecutionRuntime) {
+    super();
+    this.runtime = runtime;
+  }
 
   getTopicContext = async (
     params: GetTopicContextParams,
     _ctx: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
-    const { topicId } = params;
-
-    if (!topicId) {
-      return { content: 'topicId is required', success: false };
-    }
-
-    try {
-      const result = await lambdaClient.topic.getTopicContext.query({ topicId });
-      return { content: result.content, success: result.success };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      return { content: `Failed to fetch topic context: ${errorMessage}`, success: false };
-    }
+    return this.runtime.getTopicContext(params);
   };
 }
-
-export const topicReferenceExecutor = new TopicReferenceExecutor();

--- a/src/store/tool/slices/builtin/executors/index.ts
+++ b/src/store/tool/slices/builtin/executors/index.ts
@@ -15,7 +15,6 @@ import { gtdExecutor } from '@lobechat/builtin-tool-gtd/executor';
 import { knowledgeBaseExecutor } from '@lobechat/builtin-tool-knowledge-base/executor';
 import { localSystemExecutor } from '@lobechat/builtin-tool-local-system/executor';
 import { memoryExecutor } from '@lobechat/builtin-tool-memory/executor';
-import { topicReferenceExecutor } from '@lobechat/builtin-tool-topic-reference/executor';
 
 import type { BuiltinToolContext, BuiltinToolResult, IBuiltinToolExecutor } from '../types';
 import { activatorExecutor } from './lobe-activator';
@@ -25,6 +24,7 @@ import { notebookExecutor } from './lobe-notebook';
 import { pageAgentExecutor } from './lobe-page-agent';
 import { skillStoreExecutor } from './lobe-skill-store';
 import { skillsExecutor } from './lobe-skills';
+import { topicReferenceExecutor } from './lobe-topic-reference';
 import { userInteractionExecutor } from './lobe-user-interaction';
 import { webBrowsing } from './lobe-web-browsing';
 import { webOnboardingExecutor } from './lobe-web-onboarding';

--- a/src/store/tool/slices/builtin/executors/lobe-topic-reference.ts
+++ b/src/store/tool/slices/builtin/executors/lobe-topic-reference.ts
@@ -1,0 +1,30 @@
+import { TopicReferenceExecutor } from '@lobechat/builtin-tool-topic-reference/executor';
+import type { BuiltinToolResult } from '@lobechat/types';
+
+import { lambdaClient } from '@/libs/trpc/client';
+
+interface GetTopicContextParams {
+  topicId: string;
+}
+
+class TopicReferenceExecutionRuntime {
+  getTopicContext = async (params: GetTopicContextParams): Promise<BuiltinToolResult> => {
+    const { topicId } = params;
+
+    if (!topicId) {
+      return { content: 'topicId is required', success: false };
+    }
+
+    try {
+      const result = await lambdaClient.topic.getTopicContext.query({ topicId });
+      return { content: result.content, success: result.success };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return { content: `Failed to fetch topic context: ${errorMessage}`, success: false };
+    }
+  };
+}
+
+const runtime = new TopicReferenceExecutionRuntime();
+
+export const topicReferenceExecutor = new TopicReferenceExecutor(runtime);


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Move `@lobechat/builtin-tool-topic-reference` executor to a runtime-injected design.
- Remove direct `@/libs/trpc/client` dependency from package code.
- Add app-layer adapter at `src/store/tool/slices/builtin/executors/lobe-topic-reference.ts` and register it in builtin executor index.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

This change is internal refactoring to keep package boundaries clean and avoid app alias imports inside package sources.

Made with [Cursor](https://cursor.com)