### PR TITLE
🐛 fix(gemini): omit empty thinkingConfig and align thinking levels

### DIFF
--- a/packages/const/src/settings/agent.ts
+++ b/packages/const/src/settings/agent.ts
@@ -1,9 +1,9 @@
 import { DEFAULT_PROVIDER } from '@lobechat/business-const';
-import {
-  type LobeAgentChatConfig,
-  type LobeAgentConfig,
-  type LobeAgentTTSConfig,
-  type UserDefaultAgent,
+import type {
+  LobeAgentChatConfig,
+  LobeAgentConfig,
+  LobeAgentTTSConfig,
+  UserDefaultAgent,
 } from '@lobechat/types';
 
 import { DEFAULT_AGENT_META } from '../meta';
@@ -35,6 +35,11 @@ export const DEFAULT_AGENT_CHAT_CONFIG: LobeAgentChatConfig = {
   reasoningBudgetToken: 1024,
   searchFCModel: DEFAULT_AGENT_SEARCH_FC_MODEL,
   searchMode: 'auto',
+  thinkingLevel: 'high',
+  thinkingLevel2: 'high',
+  thinkingLevel3: 'high',
+  thinkingLevel4: 'high',
+  thinkingLevel5: 'minimal',
 };
 
 export const DEFAULT_AGENT_CONFIG: LobeAgentConfig = {

--- a/packages/model-runtime/src/providers/google/index.test.ts
+++ b/packages/model-runtime/src/providers/google/index.test.ts
@@ -12,6 +12,10 @@ const provider = 'google';
 const bizErrorType = 'ProviderBizError';
 const invalidErrorType = 'InvalidProviderAPIKey';
 
+async function* createEmptyAsyncGenerator<T>(): AsyncGenerator<T> {
+  yield* [] as unknown as T[];
+}
+
 // Mock the console.error to avoid polluting test output
 vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -21,7 +25,7 @@ beforeEach(() => {
   instance = new LobeGoogleAI({ apiKey: 'test' });
 
   // Use vi.spyOn to mock the chat.completions.create method
-  const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+  const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
   vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
 });
 
@@ -440,16 +444,16 @@ describe('LobeGoogleAI', () => {
         const enhancedStream = instance['createEnhancedStream'](mockStream, abortController.signal);
 
         const reader = enhancedStream.getReader();
-        const chunks: any[] = [];
+        let chunks: any[] = [];
 
         // Read first value then cancel to trigger error chunk
-        chunks.push((await reader.read()).value);
+        chunks = chunks.concat((await reader.read()).value);
         abortController.abort();
 
         // Read all remaining chunks
         let result;
         while (!(result = await reader.read()).done) {
-          chunks.push(result.value);
+          chunks = chunks.concat(result.value);
         }
 
         // Batch-assert the entire chunks array
@@ -467,9 +471,7 @@ describe('LobeGoogleAI', () => {
       });
 
       it('should handle stream cancellation without data', async () => {
-        const mockStream = (async function* () {
-          // Empty stream
-        })();
+        const mockStream = createEmptyAsyncGenerator<{ text: string }>();
 
         const abortController = new AbortController();
         const enhancedStream = instance['createEnhancedStream'](mockStream, abortController.signal);
@@ -494,13 +496,13 @@ describe('LobeGoogleAI', () => {
         const enhancedStream = instance['createEnhancedStream'](mockStream, abortController.signal);
 
         const reader = enhancedStream.getReader();
-        const chunks: any[] = [];
+        let chunks: any[] = [];
 
         // Read first value then collect remaining chunks (error included)
-        chunks.push((await reader.read()).value);
+        chunks = chunks.concat((await reader.read()).value);
         let result;
         while (!(result = await reader.read()).done) {
-          chunks.push(result.value);
+          chunks = chunks.concat(result.value);
         }
 
         // Assert both data and error chunk together
@@ -519,6 +521,7 @@ describe('LobeGoogleAI', () => {
 
       it('should handle AbortError without data', async () => {
         const mockStream = (async function* () {
+          yield* [] as any;
           throw new Error('aborted');
         })();
 
@@ -526,17 +529,15 @@ describe('LobeGoogleAI', () => {
         const enhancedStream = instance['createEnhancedStream'](mockStream, abortController.signal);
 
         const reader = enhancedStream.getReader();
-        const chunks: any[] = [];
 
         // Read error chunk
         const chunk1 = await reader.read();
-        chunks.push(chunk1.value);
 
         // Stream should be closed
         const chunk2 = await reader.read();
         expect(chunk2.done).toBe(true);
 
-        expect(chunks[0][LOBE_ERROR_KEY]).toEqual({
+        expect(chunk1.value[LOBE_ERROR_KEY]).toEqual({
           body: {
             message: 'aborted',
             name: 'AbortError',
@@ -559,13 +560,13 @@ describe('LobeGoogleAI', () => {
         const enhancedStream = instance['createEnhancedStream'](mockStream, abortController.signal);
 
         const reader = enhancedStream.getReader();
-        const chunks: any[] = [];
+        let chunks: any[] = [];
 
         // Read first value then collect remaining chunks (parsing error)
-        chunks.push((await reader.read()).value);
+        chunks = chunks.concat((await reader.read()).value);
         let result;
         while (!(result = await reader.read()).done) {
-          chunks.push(result.value);
+          chunks = chunks.concat(result.value);
         }
 
         expect(chunks).toEqual([
@@ -586,7 +587,7 @@ describe('LobeGoogleAI', () => {
 
 describe('thinkingConfig includeThoughts logic', () => {
   it('should enable thinking when thinkingBudget is set', async () => {
-    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
     vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
 
     await instance.chat({
@@ -602,7 +603,7 @@ describe('thinkingConfig includeThoughts logic', () => {
   });
 
   it('should enable thinking when thinkingLevel is set', async () => {
-    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
     vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
 
     await instance.chat({
@@ -618,7 +619,7 @@ describe('thinkingConfig includeThoughts logic', () => {
   });
 
   it('should let API decide thinking for gemini-3-pro-image models without explicit params', async () => {
-    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
     vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
 
     await instance.chat({
@@ -633,8 +634,23 @@ describe('thinkingConfig includeThoughts logic', () => {
     expect(config.thinkingConfig?.includeThoughts).toBeUndefined();
   });
 
+  it('should omit thinkingConfig when all fields are undefined', async () => {
+    const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
+    vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
+
+    await instance.chat({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'gemini-3.1-pro-preview',
+      temperature: 0,
+    });
+
+    const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
+    const config = callArgs[0].config;
+    expect(config.thinkingConfig).toBeUndefined();
+  });
+
   it('should enable thinking for thinking-enabled models', async () => {
-    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
     vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
 
     await instance.chat({
@@ -649,7 +665,7 @@ describe('thinkingConfig includeThoughts logic', () => {
   });
 
   it('should disable thinking when resolvedThinkingBudget is 0', async () => {
-    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
     vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
 
     await instance.chat({
@@ -780,9 +796,7 @@ describe('buildGoogleToolsWithSearch', () => {
       temperature: 0,
       enabledSearch: true,
       urlContext: true,
-      tools: [
-        { type: 'function', function: { name: 'test_tool', description: 'A test tool' } },
-      ],
+      tools: [{ type: 'function', function: { name: 'test_tool', description: 'A test tool' } }],
     });
 
     const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
@@ -835,9 +849,7 @@ describe('buildGoogleToolsWithSearch', () => {
       temperature: 0,
       enabledSearch: true,
       urlContext: true,
-      tools: [
-        { type: 'function', function: { name: 'test_tool', description: 'A test tool' } },
-      ],
+      tools: [{ type: 'function', function: { name: 'test_tool', description: 'A test tool' } }],
     });
 
     const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -1,10 +1,10 @@
-import {
-  type GenerateContentConfig,
-  type HttpOptions,
-  type ThinkingConfig,
-  type Tool as GoogleFunctionCallTool,
-} from '@google/genai';
 import { GoogleGenAI } from '@google/genai';
+import type {
+  GenerateContentConfig,
+  HttpOptions,
+  ThinkingConfig,
+  Tool as GoogleFunctionCallTool,
+} from '@google/genai';
 import debug from 'debug';
 
 import { type LobeRuntimeAI } from '../../core/BaseAI';
@@ -53,6 +53,19 @@ const isGemini3OrAbove = (model?: string): boolean => {
   const match = /gemini-(\d+)/.exec(model);
   if (!match) return false;
   return Number.parseInt(match[1], 10) >= 3;
+};
+
+const normalizeThinkingConfig = (config?: ThinkingConfig): ThinkingConfig | undefined => {
+  if (!config) return undefined;
+
+  const { includeThoughts, thinkingBudget, thinkingLevel } = config;
+
+  // Avoid sending `thinkingConfig: {}` (all fields undefined) which can lead upstream
+  // to treat thinking as disabled and produce no thought parts.
+  if (includeThoughts === undefined && thinkingBudget === undefined && thinkingLevel === undefined)
+    return undefined;
+
+  return config;
 };
 
 const modelsDisableInstuction = new Set([
@@ -215,7 +228,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
         thinkingConfig:
           modelsDisableInstuction.has(model) || model.toLowerCase().includes('learnlm')
             ? undefined
-            : thinkingConfig,
+            : normalizeThinkingConfig(thinkingConfig),
         tools: this.buildGoogleToolsWithSearch(payload.tools, payload),
         topP: payload.top_p,
       };

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel2Slider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel2Slider.tsx
@@ -7,7 +7,8 @@ type ThinkingLevel2 = (typeof THINKING_LEVELS_2)[number];
 export type ThinkingLevel2SliderProps = CreatedLevelSliderProps<ThinkingLevel2>;
 
 const ThinkingLevel2Slider = createLevelSliderComponent<ThinkingLevel2>({
-  configKey: 'thinkingLevel',
+  configKey: 'thinkingLevel2',
+  fallbackKey: 'thinkingLevel',
   defaultValue: 'high',
   levels: THINKING_LEVELS_2,
   style: { minWidth: 110 },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel3Slider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel3Slider.tsx
@@ -7,7 +7,8 @@ type ThinkingLevel3 = (typeof THINKING_LEVELS_3)[number];
 export type ThinkingLevel3SliderProps = CreatedLevelSliderProps<ThinkingLevel3>;
 
 const ThinkingLevel3Slider = createLevelSliderComponent<ThinkingLevel3>({
-  configKey: 'thinkingLevel',
+  configKey: 'thinkingLevel3',
+  fallbackKey: 'thinkingLevel',
   defaultValue: 'high',
   levels: THINKING_LEVELS_3,
   style: { minWidth: 160 },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel4Slider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel4Slider.tsx
@@ -7,8 +7,9 @@ type ThinkingLevel4 = (typeof THINKING_LEVELS_4)[number];
 export type ThinkingLevel4SliderProps = CreatedLevelSliderProps<ThinkingLevel4>;
 
 const ThinkingLevel4Slider = createLevelSliderComponent<ThinkingLevel4>({
-  configKey: 'thinkingLevel',
-  defaultValue: 'minimal',
+  configKey: 'thinkingLevel4',
+  fallbackKey: 'thinkingLevel',
+  defaultValue: 'high',
   levels: THINKING_LEVELS_4,
   style: { minWidth: 110 },
 });

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel5Slider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel5Slider.tsx
@@ -7,7 +7,8 @@ type ThinkingLevel5 = (typeof THINKING_LEVELS_5)[number];
 export type ThinkingLevel5SliderProps = CreatedLevelSliderProps<ThinkingLevel5>;
 
 const ThinkingLevel5Slider = createLevelSliderComponent<ThinkingLevel5>({
-  configKey: 'thinkingLevel',
+  configKey: 'thinkingLevel5',
+  fallbackKey: 'thinkingLevel',
   defaultValue: 'minimal',
   levels: THINKING_LEVELS_5,
   style: { minWidth: 200 },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/createLevelSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/createLevelSlider.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { type LobeAgentChatConfig } from '@lobechat/types';
-import { type SliderSingleProps } from 'antd/es/slider';
-import { type CSSProperties } from 'react';
+import type { LobeAgentChatConfig } from '@lobechat/types';
+import type { SliderSingleProps } from 'antd/es/slider';
+import type { CSSProperties } from 'react';
 import { memo } from 'react';
 
 import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
@@ -21,6 +21,11 @@ export interface LevelSliderConfig<T extends string> {
    * Default value when no value is provided
    */
   defaultValue: T;
+  /**
+   * Optional legacy key to read from when configKey is not set.
+   * Keeps UI consistent when older configs stored values under a previous key.
+   */
+  fallbackKey?: keyof LobeAgentChatConfig;
   /**
    * Ordered array of level values (left to right on slider)
    */
@@ -47,7 +52,7 @@ export interface CreatedLevelSliderProps<T extends string> {
  * (reading/writing to agent store).
  */
 export function createLevelSliderComponent<T extends string>(config: LevelSliderConfig<T>) {
-  const { levels, configKey, defaultValue, marks, style } = config;
+  const { levels, configKey, fallbackKey, defaultValue, marks, style } = config;
 
   // Inner pure UI component - no store hooks, safe for preview
   const LevelSliderInner = memo<{
@@ -71,13 +76,24 @@ export function createLevelSliderComponent<T extends string>(config: LevelSlider
     const { updateAgentChatConfig } = useUpdateAgentConfig();
     const agentConfig = useAgentStore((s) => chatConfigByIdSelectors.getChatConfigById(agentId)(s));
 
-    const storeValue = (agentConfig[configKey] as T) || dv;
+    const resolveValue = (): T => {
+      const rawValue = agentConfig[configKey];
+      if (typeof rawValue === 'string' && levels.includes(rawValue as T)) return rawValue as T;
+
+      if (fallbackKey) {
+        const rawFallback = agentConfig[fallbackKey];
+        if (typeof rawFallback === 'string' && levels.includes(rawFallback as T))
+          return rawFallback as T;
+      }
+
+      return dv;
+    };
 
     const handleChange = (newValue: T) => {
       updateAgentChatConfig({ [configKey]: newValue });
     };
 
-    return <LevelSliderInner defaultValue={dv} value={storeValue} onChange={handleChange} />;
+    return <LevelSliderInner defaultValue={dv} value={resolveValue()} onChange={handleChange} />;
   });
 
   // Main exported component - chooses between controlled and store mode

--- a/src/services/chat/mecha/modelParamsResolver.test.ts
+++ b/src/services/chat/mecha/modelParamsResolver.test.ts
@@ -515,10 +515,22 @@ describe('resolveModelExtendParams', () => {
         expect(result.thinkingLevel).toBeUndefined();
       });
 
-      it('should not read from thinkingLevel config key', () => {
+      it('should fallback to thinkingLevel config key (backward compatibility)', () => {
         const result = resolveModelExtendParams({
           chatConfig: {
             thinkingLevel: 'high',
+          } as any,
+          model: 'gemini-3-pro-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBe('high');
+      });
+
+      it('should ignore thinkingLevel fallback when out of range', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: {
+            thinkingLevel: 'medium',
           } as any,
           model: 'gemini-3-pro-preview',
           provider: 'google',
@@ -560,7 +572,7 @@ describe('resolveModelExtendParams', () => {
         expect(result.thinkingLevel).toBeUndefined();
       });
 
-      it('should not read from thinkingLevel config key', () => {
+      it('should fallback to thinkingLevel config key (backward compatibility)', () => {
         const result = resolveModelExtendParams({
           chatConfig: {
             thinkingLevel: 'high',
@@ -569,7 +581,50 @@ describe('resolveModelExtendParams', () => {
           provider: 'google',
         });
 
-        expect(result.thinkingLevel).toBeUndefined();
+        expect(result.thinkingLevel).toBe('high');
+      });
+    });
+
+    describe('thinkingLevel variant priority', () => {
+      it('should prefer variant key over thinkingLevel when both are supported and configured', () => {
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'isModelHasExtendParams').mockReturnValue(
+          () => true,
+        );
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParams').mockReturnValue(() => [
+          'thinkingLevel',
+          'thinkingLevel3',
+        ]);
+
+        const result = resolveModelExtendParams({
+          chatConfig: {
+            thinkingLevel: 'high',
+            thinkingLevel3: 'medium',
+          } as any,
+          model: 'gemini-3.1-pro-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBe('medium');
+      });
+
+      it('should select another variant key when the higher-priority variant is not configured', () => {
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'isModelHasExtendParams').mockReturnValue(
+          () => true,
+        );
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParams').mockReturnValue(() => [
+          'thinkingLevel2',
+          'thinkingLevel3',
+        ]);
+
+        const result = resolveModelExtendParams({
+          chatConfig: {
+            thinkingLevel2: 'low',
+          } as any,
+          model: 'gemini-3-pro-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBe('low');
       });
     });
   });

--- a/src/services/chat/mecha/modelParamsResolver.ts
+++ b/src/services/chat/mecha/modelParamsResolver.ts
@@ -1,4 +1,6 @@
-import { type LobeAgentChatConfig } from '@lobechat/types';
+import type { LobeAgentChatConfig } from '@lobechat/types';
+import type { ExtendParamsType } from 'model-bank';
+import { ModelProvider } from 'model-bank';
 
 import { aiModelSelectors, getAiInfraStoreState } from '@/store/aiInfra';
 
@@ -168,24 +170,67 @@ export const resolveModelExtendParams = (ctx: ModelParamsContext): ModelExtendPa
     extendParams.thinkingBudget = chatConfig.thinkingBudget;
   }
 
-  if (modelExtendParams.includes('thinkingLevel') && chatConfig.thinkingLevel) {
-    extendParams.thinkingLevel = chatConfig.thinkingLevel;
+  const thinkingLevelVariants: readonly {
+    allowedLevels: readonly string[];
+    configKey: keyof LobeAgentChatConfig;
+    extendParam: ExtendParamsType;
+  }[] = [
+    {
+      allowedLevels: ['minimal', 'low', 'medium', 'high'],
+      configKey: 'thinkingLevel5',
+      extendParam: 'thinkingLevel5',
+    },
+    {
+      allowedLevels: ['minimal', 'high'],
+      configKey: 'thinkingLevel4',
+      extendParam: 'thinkingLevel4',
+    },
+    {
+      allowedLevels: ['low', 'medium', 'high'],
+      configKey: 'thinkingLevel3',
+      extendParam: 'thinkingLevel3',
+    },
+    { allowedLevels: ['low', 'high'], configKey: 'thinkingLevel2', extendParam: 'thinkingLevel2' },
+  ];
+
+  const resolveThinkingLevelFromVariant = (
+    variantKey: keyof LobeAgentChatConfig,
+    allowedLevels: readonly string[],
+  ) => {
+    const value = chatConfig[variantKey];
+    if (typeof value === 'string' && allowedLevels.includes(value)) return value;
+    return undefined;
+  };
+
+  // Prefer explicit variant keys when present and configured.
+  for (const { configKey, extendParam, allowedLevels } of thinkingLevelVariants) {
+    if (!modelExtendParams.includes(extendParam)) continue;
+    const resolved = resolveThinkingLevelFromVariant(configKey, allowedLevels);
+    if (resolved) {
+      extendParams.thinkingLevel = resolved;
+      break;
+    }
   }
 
-  if (modelExtendParams.includes('thinkingLevel2') && chatConfig.thinkingLevel2) {
-    extendParams.thinkingLevel = chatConfig.thinkingLevel2;
+  // Next, use base thinkingLevel when supported.
+  if (!extendParams.thinkingLevel) {
+    const baseValue = chatConfig.thinkingLevel;
+    if (modelExtendParams.includes('thinkingLevel') && typeof baseValue === 'string') {
+      extendParams.thinkingLevel = baseValue;
+    }
   }
 
-  if (modelExtendParams.includes('thinkingLevel3') && chatConfig.thinkingLevel3) {
-    extendParams.thinkingLevel = chatConfig.thinkingLevel3;
-  }
-
-  if (modelExtendParams.includes('thinkingLevel4') && chatConfig.thinkingLevel4) {
-    extendParams.thinkingLevel = chatConfig.thinkingLevel4;
-  }
-
-  if (modelExtendParams.includes('thinkingLevel5') && chatConfig.thinkingLevel5) {
-    extendParams.thinkingLevel = chatConfig.thinkingLevel5;
+  // Finally, backward-compatible fallback: previous UI versions wrote to `thinkingLevel`
+  // even when the model expected `thinkingLevel2/3/4/5`.
+  if (!extendParams.thinkingLevel) {
+    const baseValue = chatConfig.thinkingLevel;
+    for (const { extendParam, allowedLevels } of thinkingLevelVariants) {
+      if (!modelExtendParams.includes(extendParam)) continue;
+      if (typeof baseValue === 'string' && allowedLevels.includes(baseValue)) {
+        extendParams.thinkingLevel = baseValue;
+        break;
+      }
+    }
   }
 
   // URL context

--- a/src/store/agent/slices/agent/action.ts
+++ b/src/store/agent/slices/agent/action.ts
@@ -2,28 +2,142 @@ import { isChatGroupSessionId } from '@lobechat/types';
 import { getSingletonAnalyticsOptional } from '@lobehub/analytics';
 import isEqual from 'fast-deep-equal';
 import { produce } from 'immer';
-import { type SWRResponse } from 'swr';
-import { type PartialDeep } from 'type-fest';
+import type { SWRResponse } from 'swr';
+import type { PartialDeep } from 'type-fest';
 
 import { MESSAGE_CANCEL_FLAT } from '@/const/message';
 import { mutate, useClientDataSWR } from '@/libs/swr';
-import { type CreateAgentParams, type CreateAgentResult } from '@/services/agent';
+import type { CreateAgentParams, CreateAgentResult } from '@/services/agent';
 import { agentService } from '@/services/agent';
-import { type StoreSetter } from '@/store/types';
+import type { StoreSetter } from '@/store/types';
 import { getUserStoreState } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
-import {
-  type LobeAgentChatConfig,
-  type LobeAgentConfig,
-  type RuntimeEnvConfig,
-} from '@/types/agent';
-import { type MetaData } from '@/types/meta';
+import type { LobeAgentChatConfig, LobeAgentConfig, RuntimeEnvConfig } from '@/types/agent';
+import type { MetaData } from '@/types/meta';
 import { merge } from '@/utils/merge';
 
-import { type AgentStore } from '../../store';
-import { type AgentSliceState, type LoadingState, type SaveStatus } from './initialState';
+import type { AgentStore } from '../../store';
+import type { AgentSliceState, LoadingState, SaveStatus } from './initialState';
 
 const FETCH_AGENT_CONFIG_KEY = 'FETCH_AGENT_CONFIG';
+
+type ThinkingLevelVariantKey =
+  | 'thinkingLevel2'
+  | 'thinkingLevel3'
+  | 'thinkingLevel4'
+  | 'thinkingLevel5';
+
+const THINKING_LEVEL_VARIANT_LEVELS = {
+  thinkingLevel2: ['low', 'high'],
+  thinkingLevel3: ['low', 'medium', 'high'],
+  thinkingLevel4: ['minimal', 'high'],
+  thinkingLevel5: ['minimal', 'low', 'medium', 'high'],
+} as const satisfies Record<ThinkingLevelVariantKey, readonly string[]>;
+
+const THINKING_LEVEL_VARIANTS = [
+  'thinkingLevel5',
+  'thinkingLevel4',
+  'thinkingLevel3',
+  'thinkingLevel2',
+] as const satisfies readonly ThinkingLevelVariantKey[];
+
+const normalizeModelId = (id: string) => id.trim().toLowerCase();
+
+interface ExtendParamsLookup {
+  byId: Map<string, string[]>;
+  byProviderAndId: Map<string, string[]>;
+}
+
+let extendParamsLookupPromise: Promise<ExtendParamsLookup> | undefined;
+
+const getModelExtendParams = (model: unknown): string[] | undefined => {
+  const extendParams = (model as { settings?: { extendParams?: unknown } })?.settings?.extendParams;
+  if (!Array.isArray(extendParams) || extendParams.length === 0) return undefined;
+
+  const stringParams = extendParams.filter((item): item is string => typeof item === 'string');
+  if (stringParams.length === 0) return undefined;
+
+  return stringParams;
+};
+
+const getExtendParamsLookup = async (): Promise<ExtendParamsLookup> => {
+  if (!extendParamsLookupPromise) {
+    extendParamsLookupPromise = import('model-bank').then(({ LOBE_DEFAULT_MODEL_LIST }) => {
+      const byId = new Map<string, string[]>();
+      const byProviderAndId = new Map<string, string[]>();
+
+      for (const model of LOBE_DEFAULT_MODEL_LIST) {
+        const extendParams = getModelExtendParams(model);
+        if (!extendParams) continue;
+
+        const normalizedId = normalizeModelId(model.id);
+        const normalizedIdDash = normalizedId.replaceAll('.', '-');
+
+        byId.set(normalizedId, extendParams);
+        byId.set(normalizedIdDash, extendParams);
+
+        byProviderAndId.set(`${model.providerId}:${normalizedId}`, extendParams);
+        byProviderAndId.set(`${model.providerId}:${normalizedIdDash}`, extendParams);
+      }
+
+      return { byId, byProviderAndId };
+    });
+  }
+
+  return extendParamsLookupPromise;
+};
+
+const stripProviderPrefix = (id: string) => {
+  if (!id.includes('/')) return id;
+  return id.split('/').at(-1) || id;
+};
+
+const buildModelCandidates = (model: string) => {
+  const candidates = new Set<string>();
+
+  const addCandidate = (value?: string) => {
+    if (!value) return;
+    const normalized = normalizeModelId(value);
+    if (!normalized) return;
+
+    candidates.add(normalized);
+    candidates.add(normalized.replaceAll('.', '-'));
+  };
+
+  addCandidate(model);
+  addCandidate(stripProviderPrefix(model));
+
+  return [...candidates];
+};
+
+const resolveModelExtendParams = async (
+  model: string,
+  provider?: string,
+): Promise<string[] | undefined> => {
+  const lookup = await getExtendParamsLookup();
+  const candidates = buildModelCandidates(model);
+
+  if (provider) {
+    for (const candidate of candidates) {
+      const extendParams = lookup.byProviderAndId.get(`${provider}:${candidate}`);
+      if (extendParams) return extendParams;
+    }
+  }
+
+  for (const candidate of candidates) {
+    const extendParams = lookup.byId.get(candidate);
+    if (extendParams) return extendParams;
+  }
+
+  return undefined;
+};
+
+const pickThinkingLevelVariantKey = (
+  extendParams?: string[],
+): ThinkingLevelVariantKey | undefined =>
+  THINKING_LEVEL_VARIANTS.find((key) => !!extendParams?.includes(key));
+
+const legacyThinkingLevelMigrationInFlight = new Set<string>();
 
 /**
  * Agent Slice Actions
@@ -247,9 +361,96 @@ export class AgentSliceActionImpl {
           this.#get().internal_dispatchAgentMap(agentId, data);
 
           this.#set({ activeAgentId: data.id }, false, 'fetchAgentConfig');
+
+          // Migrate legacy Gemini thinking level config for upgraded agents:
+          // older configs stored only `thinkingLevel`, while newer models use thinkingLevel2/3/4/5.
+          const chatConfig = data.chatConfig || {};
+          const modelId = normalizeModelId(stripProviderPrefix(data.model));
+          const hasVariantKey = THINKING_LEVEL_VARIANTS.some(
+            (key) => typeof (chatConfig as any)[key] === 'string',
+          );
+
+          if (
+            data.provider === 'google' &&
+            modelId.includes('gemini-3') &&
+            typeof chatConfig.thinkingLevel === 'string' &&
+            !hasVariantKey
+          ) {
+            void this.#get().internal_migrateLegacyThinkingLevel(agentId, data);
+          }
         },
       },
     );
+  };
+
+  internal_migrateLegacyThinkingLevel = async (
+    agentId: string,
+    config: LobeAgentConfig,
+  ): Promise<void> => {
+    if (legacyThinkingLevelMigrationInFlight.has(agentId)) return;
+    legacyThinkingLevelMigrationInFlight.add(agentId);
+
+    try {
+      if (config.provider !== 'google') return;
+
+      const modelId = normalizeModelId(stripProviderPrefix(config.model));
+      if (!modelId.includes('gemini-3')) return;
+
+      const fetchedChatConfig = config.chatConfig || {};
+      const fetchedLegacyThinkingLevel = fetchedChatConfig.thinkingLevel;
+      if (!fetchedLegacyThinkingLevel || typeof fetchedLegacyThinkingLevel !== 'string') return;
+
+      // If the fetched config already has a new variant key, skip.
+      if (
+        THINKING_LEVEL_VARIANTS.some((key) => typeof (fetchedChatConfig as any)[key] === 'string')
+      ) {
+        return;
+      }
+
+      // If the store already has a new variant key (e.g. user edited quickly), skip without importing model-bank.
+      const currentBeforeLookup = this.#get().agentMap?.[agentId] as
+        | PartialDeep<LobeAgentConfig>
+        | undefined;
+      const currentBeforeLookupChatConfig = (currentBeforeLookup?.chatConfig ||
+        {}) as LobeAgentChatConfig;
+      if (
+        THINKING_LEVEL_VARIANTS.some(
+          (key) => typeof (currentBeforeLookupChatConfig as any)[key] === 'string',
+        )
+      ) {
+        return;
+      }
+
+      const extendParams = await resolveModelExtendParams(config.model, config.provider);
+      const variantKey = pickThinkingLevelVariantKey(extendParams);
+      if (!variantKey) return;
+
+      // Re-check the latest store state to avoid overwriting user edits during the async lookup.
+      const currentAgent = this.#get().agentMap?.[agentId] as
+        | PartialDeep<LobeAgentConfig>
+        | undefined;
+      if (!currentAgent) return;
+      if (currentAgent.model !== config.model || currentAgent.provider !== config.provider) return;
+
+      const currentChatConfig = (currentAgent.chatConfig || {}) as LobeAgentChatConfig;
+      if (typeof (currentChatConfig as any)[variantKey] === 'string') return;
+
+      const legacyThinkingLevel =
+        typeof currentChatConfig.thinkingLevel === 'string'
+          ? currentChatConfig.thinkingLevel
+          : fetchedLegacyThinkingLevel;
+
+      const allowedLevels = THINKING_LEVEL_VARIANT_LEVELS[variantKey];
+      if (!allowedLevels.includes(legacyThinkingLevel as never)) return;
+
+      await this.#get().optimisticUpdateAgentConfig(agentId, {
+        chatConfig: {
+          [variantKey]: legacyThinkingLevel,
+        },
+      });
+    } finally {
+      legacyThinkingLevelMigrationInFlight.delete(agentId);
+    }
   };
 
   internal_dispatchAgentMap = (id: string, config: PartialDeep<LobeAgentConfig>): void => {


### PR DESCRIPTION
#### 💻 Change Type

  - [ ] ✨ feat
  - [x] 🐛 fix
  - [ ] ♻️ refactor
  - [ ] 💄 style
  - [ ] 👷 build
  - [ ] ⚡️ perf
  - [ ] ✅ test
  - [ ] 📝 docs
  - [ ] 🔨 chore

  #### 🔗 Related Issue

  fixes #12959

  #### 🔀 Description of Change

  本 PR 修复 Gemini 3.x 思考参数在 UI/Resolver/Runtime/Store 链路上的不一致与兼容问题，避免请求携带空的 thinkingConfig: {}，并确保 UI 展示值与实际下发值一致。

  - **Google runtime：省略空 thinkingConfig**
      - packages/model-runtime/src/providers/google/index.ts
          - 新增 normalizeThinkingConfig：当 includeThoughts / thinkingBudget / thinkingLevel 全部为 undefined 时返回 undefined，避免发送 thinkingConfig: {}。
      - packages/model-runtime/src/providers/google/index.test.ts
          - 增加回归测试：gemini-3.1-pro-preview 未显式设置 thinking 参数时，断言最终请求 config.thinkingConfig === undefined。
  - **UI：slider 写入正确 key + 读取 legacy fallback**
      - src/features/ModelSwitchPanel/components/ControlsForm/createLevelSlider.tsx
          - createLevelSliderComponent 支持 fallbackKey：当 configKey 未设置时，从 legacy key 读取并校验范围，避免 UI 显示与实际下发不一致。
      - src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel2Slider.tsx
      - src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel3Slider.tsx
      - src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel4Slider.tsx
      - src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel5Slider.tsx
          - 分别改为写入 thinkingLevel2/3/4/5，并设置 fallbackKey: 'thinkingLevel' 兼容旧配置。
  - **Resolver：variant 优先级 + legacy 回退（范围校验）**
      - src/services/chat/mecha/modelParamsResolver.ts
          - 当模型声明多个 thinkingLevel* 时，优先采用显式配置的 thinkingLevel2/3/4/5；否则才使用 thinkingLevel；最后才对 variant 做 legacy fallback（并按每个 variant 的允许值范围过滤）。
      - src/services/chat/mecha/modelParamsResolver.test.ts
          - 增加/更新测试：覆盖 legacy fallback、越界忽略、以及多 key 声明时的 variant 优先级。
  - **Store：fetch 触发 legacy 迁移（竞态保护 + 性能）**
      - src/store/agent/slices/agent/action.ts
          - useFetchAgentConfig 成功后仅对 google + gemini-3* 且存在 legacy thinkingLevel、且 thinkingLevel2/3/4/5 均为空的配置触发迁移。
          - internal_migrateLegacyThinkingLevel 写回前二次检查最新 store 状态，避免覆盖用户并发编辑；并对 model-bank extendParams 查询做缓存，减少重复扫描/导入开销。
  - **Defaults：补齐确定性默认值**
      - packages/const/src/settings/agent.ts
          - 显式设置 thinkingLevel、thinkingLevel2/3/4、thinkingLevel5 默认值，减少行为依赖 legacy fallback 的不确定性。

  #### 🧪 How to Test

  - [x] Tested locally
  - [x] Added/updated tests
  - [ ] No tests needed

  本地测试命令（按包/文件定向执行）：

  - bunx vitest run --silent='passed-only' 'src/services/chat/mecha/modelParamsResolver.test.ts'
  - bunx vitest run --silent='passed-only' 'src/store/agent/slices/agent/action.test.ts'
  - cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/providers/google/index.test.ts'

  手动场景建议：

  1. 创建/打开旧 agent（仅 thinkingLevel 有值），切换到支持 thinkingLevel2/3/4/5 的 Gemini 3.x 模型：
      - UI slider 应显示 legacy 对应值（而非默认值）
      - 发送请求应下发正确的 thinkingLevel（variant 或 fallback 结果一致）
  2. Gemini 3.1 模型不设置任何 thinking 参数时：
      - 请求中不应包含 thinkingConfig: {}

  #### 📸 Screenshots / Videos
<img width="1221" height="1076" alt="image" src="https://github.com/user-attachments/assets/39a1c0b8-b834-44eb-b47a-99b9429c1da2" />


  #### 📝 Additional Information

  - 兼容性：保留对 legacy thinkingLevel 的读取回退，并提供 fetch 后迁移回填，避免升级后的 UI/运行时不一致。
  - 风险控制：迁移写回增加竞态保护，避免覆盖用户并发编辑。
  - 性能：model-bank extendParams lookup 增加缓存，避免每次 fetch 扫描列表。