### PR TITLE
🐛 fix(gemini): align thinkingLevel config resolution across the stack

### DIFF
--- a/packages/model-runtime/src/providers/google/index.test.ts
+++ b/packages/model-runtime/src/providers/google/index.test.ts
@@ -12,6 +12,10 @@ const provider = 'google';
 const bizErrorType = 'ProviderBizError';
 const invalidErrorType = 'InvalidProviderAPIKey';
 
+async function* createEmptyAsyncGenerator<T>(): AsyncGenerator<T> {
+  yield* [] as unknown as T[];
+}
+
 // Mock the console.error to avoid polluting test output
 vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -21,7 +25,7 @@ beforeEach(() => {
   instance = new LobeGoogleAI({ apiKey: 'test' });
 
   // Use vi.spyOn to mock the chat.completions.create method
-  const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+  const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
   vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
 });
 
@@ -354,16 +358,16 @@ describe('LobeGoogleAI', () => {
         const enhancedStream = instance['createEnhancedStream'](mockStream, abortController.signal);
 
         const reader = enhancedStream.getReader();
-        const chunks: any[] = [];
+        let chunks: any[] = [];
 
         // Read first value then cancel to trigger error chunk
-        chunks.push((await reader.read()).value); // eslint-disable-line unicorn/no-immediate-mutation
+        chunks = chunks.concat((await reader.read()).value);
         abortController.abort();
 
         // Read all remaining chunks
         let result;
         while (!(result = await reader.read()).done) {
-          chunks.push(result.value);
+          chunks = chunks.concat(result.value);
         }
 
         // Batch-assert the entire chunks array
@@ -381,9 +385,7 @@ describe('LobeGoogleAI', () => {
       });
 
       it('should handle stream cancellation without data', async () => {
-        const mockStream = (async function* () {
-          // Empty stream
-        })();
+        const mockStream = createEmptyAsyncGenerator<{ text: string }>();
 
         const abortController = new AbortController();
         const enhancedStream = instance['createEnhancedStream'](mockStream, abortController.signal);
@@ -408,13 +410,13 @@ describe('LobeGoogleAI', () => {
         const enhancedStream = instance['createEnhancedStream'](mockStream, abortController.signal);
 
         const reader = enhancedStream.getReader();
-        const chunks: any[] = [];
+        let chunks: any[] = [];
 
         // Read first value then collect remaining chunks (error included)
-        chunks.push((await reader.read()).value); // eslint-disable-line unicorn/no-immediate-mutation
+        chunks = chunks.concat((await reader.read()).value);
         let result;
         while (!(result = await reader.read()).done) {
-          chunks.push(result.value);
+          chunks = chunks.concat(result.value);
         }
 
         // Assert both data and error chunk together
@@ -434,6 +436,7 @@ describe('LobeGoogleAI', () => {
       it('should handle AbortError without data', async () => {
         // eslint-disable-next-line require-yield
         const mockStream = (async function* () {
+          yield* [] as any;
           throw new Error('aborted');
         })();
 
@@ -441,17 +444,15 @@ describe('LobeGoogleAI', () => {
         const enhancedStream = instance['createEnhancedStream'](mockStream, abortController.signal);
 
         const reader = enhancedStream.getReader();
-        const chunks: any[] = [];
 
         // Read error chunk
         const chunk1 = await reader.read();
-        chunks.push(chunk1.value);
 
         // Stream should be closed
         const chunk2 = await reader.read();
         expect(chunk2.done).toBe(true);
 
-        expect(chunks[0][LOBE_ERROR_KEY]).toEqual({
+        expect(chunk1.value[LOBE_ERROR_KEY]).toEqual({
           body: {
             message: 'aborted',
             name: 'AbortError',
@@ -474,13 +475,13 @@ describe('LobeGoogleAI', () => {
         const enhancedStream = instance['createEnhancedStream'](mockStream, abortController.signal);
 
         const reader = enhancedStream.getReader();
-        const chunks: any[] = [];
+        let chunks: any[] = [];
 
         // Read first value then collect remaining chunks (parsing error)
-        chunks.push((await reader.read()).value); // eslint-disable-line unicorn/no-immediate-mutation
+        chunks = chunks.concat((await reader.read()).value);
         let result;
         while (!(result = await reader.read()).done) {
-          chunks.push(result.value);
+          chunks = chunks.concat(result.value);
         }
 
         expect(chunks).toEqual([
@@ -501,7 +502,7 @@ describe('LobeGoogleAI', () => {
 
 describe('thinkingConfig includeThoughts logic', () => {
   it('should enable thinking when thinkingBudget is set', async () => {
-    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
     vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
 
     await instance.chat({
@@ -517,7 +518,7 @@ describe('thinkingConfig includeThoughts logic', () => {
   });
 
   it('should enable thinking when thinkingLevel is set', async () => {
-    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
     vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
 
     await instance.chat({
@@ -533,7 +534,7 @@ describe('thinkingConfig includeThoughts logic', () => {
   });
 
   it('should let API decide thinking for gemini-3-pro-image models without explicit params', async () => {
-    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
     vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
 
     await instance.chat({
@@ -548,8 +549,23 @@ describe('thinkingConfig includeThoughts logic', () => {
     expect(config.thinkingConfig?.includeThoughts).toBeUndefined();
   });
 
+  it('should omit thinkingConfig when all fields are undefined', async () => {
+    const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
+    vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
+
+    await instance.chat({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'gemini-3.1-pro-preview',
+      temperature: 0,
+    });
+
+    const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
+    const config = callArgs[0].config;
+    expect(config.thinkingConfig).toBeUndefined();
+  });
+
   it('should enable thinking for thinking-enabled models', async () => {
-    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
     vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
 
     await instance.chat({
@@ -564,7 +580,7 @@ describe('thinkingConfig includeThoughts logic', () => {
   });
 
   it('should disable thinking when resolvedThinkingBudget is 0', async () => {
-    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
     vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
 
     await instance.chat({

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -1,10 +1,10 @@
-import {
-  type GenerateContentConfig,
-  type HttpOptions,
-  type ThinkingConfig,
-  type Tool as GoogleFunctionCallTool,
-} from '@google/genai';
 import { GoogleGenAI } from '@google/genai';
+import type {
+  GenerateContentConfig,
+  HttpOptions,
+  ThinkingConfig,
+  Tool as GoogleFunctionCallTool,
+} from '@google/genai';
 import debug from 'debug';
 
 import { type LobeRuntimeAI } from '../../core/BaseAI';
@@ -53,6 +53,19 @@ const isGemini3OrAbove = (model?: string): boolean => {
   const match = /gemini-(\d+)/.exec(model);
   if (!match) return false;
   return Number.parseInt(match[1], 10) >= 3;
+};
+
+const normalizeThinkingConfig = (config?: ThinkingConfig): ThinkingConfig | undefined => {
+  if (!config) return undefined;
+
+  const { includeThoughts, thinkingBudget, thinkingLevel } = config;
+
+  // Avoid sending `thinkingConfig: {}` (all fields undefined) which can lead upstream
+  // to treat thinking as disabled and produce no thought parts.
+  if (includeThoughts === undefined && thinkingBudget === undefined && thinkingLevel === undefined)
+    return undefined;
+
+  return config;
 };
 
 const modelsDisableInstuction = new Set([
@@ -215,7 +228,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
         thinkingConfig:
           modelsDisableInstuction.has(model) || model.toLowerCase().includes('learnlm')
             ? undefined
-            : thinkingConfig,
+            : normalizeThinkingConfig(thinkingConfig),
         // https://ai.google.dev/gemini-api/docs/tool-combination
         toolConfig: this.needsServerSideToolInvocations(payload)
           ? { includeServerSideToolInvocations: true }

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel2Slider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel2Slider.tsx
@@ -7,7 +7,7 @@ type ThinkingLevel2 = (typeof THINKING_LEVELS_2)[number];
 export type ThinkingLevel2SliderProps = CreatedLevelSliderProps<ThinkingLevel2>;
 
 const ThinkingLevel2Slider = createLevelSliderComponent<ThinkingLevel2>({
-  configKey: 'thinkingLevel',
+  configKey: 'thinkingLevel2',
   defaultValue: 'high',
   levels: THINKING_LEVELS_2,
   style: { minWidth: 110 },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel3Slider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel3Slider.tsx
@@ -7,7 +7,7 @@ type ThinkingLevel3 = (typeof THINKING_LEVELS_3)[number];
 export type ThinkingLevel3SliderProps = CreatedLevelSliderProps<ThinkingLevel3>;
 
 const ThinkingLevel3Slider = createLevelSliderComponent<ThinkingLevel3>({
-  configKey: 'thinkingLevel',
+  configKey: 'thinkingLevel3',
   defaultValue: 'high',
   levels: THINKING_LEVELS_3,
   style: { minWidth: 160 },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel4Slider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel4Slider.tsx
@@ -8,7 +8,7 @@ export type ThinkingLevel4SliderProps = CreatedLevelSliderProps<ThinkingLevel4>;
 
 const ThinkingLevel4Slider = createLevelSliderComponent<ThinkingLevel4>({
   configKey: 'thinkingLevel4',
-  defaultValue: 'high',
+  defaultValue: 'minimal',
   levels: THINKING_LEVELS_4,
   style: { minWidth: 110 },
 });

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel4Slider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel4Slider.tsx
@@ -7,8 +7,8 @@ type ThinkingLevel4 = (typeof THINKING_LEVELS_4)[number];
 export type ThinkingLevel4SliderProps = CreatedLevelSliderProps<ThinkingLevel4>;
 
 const ThinkingLevel4Slider = createLevelSliderComponent<ThinkingLevel4>({
-  configKey: 'thinkingLevel',
-  defaultValue: 'minimal',
+  configKey: 'thinkingLevel4',
+  defaultValue: 'high',
   levels: THINKING_LEVELS_4,
   style: { minWidth: 110 },
 });

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel5Slider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel5Slider.tsx
@@ -7,7 +7,7 @@ type ThinkingLevel5 = (typeof THINKING_LEVELS_5)[number];
 export type ThinkingLevel5SliderProps = CreatedLevelSliderProps<ThinkingLevel5>;
 
 const ThinkingLevel5Slider = createLevelSliderComponent<ThinkingLevel5>({
-  configKey: 'thinkingLevel',
+  configKey: 'thinkingLevel5',
   defaultValue: 'minimal',
   levels: THINKING_LEVELS_5,
   style: { minWidth: 200 },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/createLevelSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/createLevelSlider.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { type LobeAgentChatConfig } from '@lobechat/types';
-import { type SliderSingleProps } from 'antd/es/slider';
-import { type CSSProperties } from 'react';
+import type { LobeAgentChatConfig } from '@lobechat/types';
+import type { SliderSingleProps } from 'antd/es/slider';
+import type { CSSProperties } from 'react';
 import { memo } from 'react';
 
 import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
@@ -71,13 +71,18 @@ export function createLevelSliderComponent<T extends string>(config: LevelSlider
     const { updateAgentChatConfig } = useUpdateAgentConfig();
     const agentConfig = useAgentStore((s) => chatConfigByIdSelectors.getChatConfigById(agentId)(s));
 
-    const storeValue = (agentConfig[configKey] as T) || dv;
+    const resolveValue = (): T => {
+      const rawValue = agentConfig[configKey];
+      if (typeof rawValue === 'string' && levels.includes(rawValue as T)) return rawValue as T;
+
+      return dv;
+    };
 
     const handleChange = (newValue: T) => {
       updateAgentChatConfig({ [configKey]: newValue });
     };
 
-    return <LevelSliderInner defaultValue={dv} value={storeValue} onChange={handleChange} />;
+    return <LevelSliderInner defaultValue={dv} value={resolveValue()} onChange={handleChange} />;
   });
 
   // Main exported component - chooses between controlled and store mode

--- a/src/services/chat/mecha/modelParamsResolver.test.ts
+++ b/src/services/chat/mecha/modelParamsResolver.test.ts
@@ -637,7 +637,7 @@ describe('resolveModelExtendParams', () => {
         expect(result.thinkingLevel).toBe('high');
       });
 
-      it('should use the first supported thinkingLevel param and ignore other keys', () => {
+      it('should prefer the first configured thinkingLevel param before defaulting', () => {
         vi.spyOn(aiModelSelectors.aiModelSelectors, 'isModelHasExtendParams').mockReturnValue(
           () => true,
         );
@@ -654,7 +654,25 @@ describe('resolveModelExtendParams', () => {
           provider: 'google',
         });
 
-        expect(result.thinkingLevel).toBe('high');
+        expect(result.thinkingLevel).toBe('medium');
+      });
+
+      it('should fall back to the first supported thinkingLevel default when none are configured', () => {
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'isModelHasExtendParams').mockReturnValue(
+          () => true,
+        );
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParams').mockReturnValue(() => [
+          'thinkingLevel4',
+          'thinkingLevel3',
+        ]);
+
+        const result = resolveModelExtendParams({
+          chatConfig: {} as any,
+          model: 'gemini-3.1-pro-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBe('minimal');
       });
     });
   });

--- a/src/services/chat/mecha/modelParamsResolver.test.ts
+++ b/src/services/chat/mecha/modelParamsResolver.test.ts
@@ -479,7 +479,7 @@ describe('resolveModelExtendParams', () => {
           provider: 'provider',
         });
 
-        expect(result.thinkingLevel).toBeUndefined();
+        expect(result.thinkingLevel).toBe('high');
       });
     });
 
@@ -512,7 +512,7 @@ describe('resolveModelExtendParams', () => {
           provider: 'google',
         });
 
-        expect(result.thinkingLevel).toBeUndefined();
+        expect(result.thinkingLevel).toBe('high');
       });
     });
 
@@ -545,7 +545,73 @@ describe('resolveModelExtendParams', () => {
           provider: 'google',
         });
 
-        expect(result.thinkingLevel).toBeUndefined();
+        expect(result.thinkingLevel).toBe('high');
+      });
+    });
+
+    describe('thinkingLevel4 param', () => {
+      beforeEach(() => {
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'isModelHasExtendParams').mockReturnValue(
+          () => true,
+        );
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParams').mockReturnValue(() => [
+          'thinkingLevel4',
+        ]);
+      });
+
+      it('should set thinkingLevel from thinkingLevel4 config key', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: {
+            thinkingLevel4: 'minimal',
+          } as any,
+          model: 'gemini-3.1-flash-image-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBe('minimal');
+      });
+
+      it('should use the default thinkingLevel when thinkingLevel4 is not configured', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: {} as any,
+          model: 'gemini-3.1-flash-image-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBe('minimal');
+      });
+    });
+
+    describe('thinkingLevel5 param', () => {
+      beforeEach(() => {
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'isModelHasExtendParams').mockReturnValue(
+          () => true,
+        );
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParams').mockReturnValue(() => [
+          'thinkingLevel5',
+        ]);
+      });
+
+      it('should set thinkingLevel from thinkingLevel5 config key', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: {
+            thinkingLevel5: 'medium',
+          } as any,
+          model: 'gemini-3.1-flash-lite-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBe('medium');
+      });
+
+      it('should use the default thinkingLevel when thinkingLevel5 is not configured', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: {} as any,
+          model: 'gemini-3.1-flash-lite-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBe('minimal');
       });
     });
 
@@ -562,6 +628,26 @@ describe('resolveModelExtendParams', () => {
         const result = resolveModelExtendParams({
           chatConfig: {
             thinkingLevel: 'high',
+            thinkingLevel3: 'medium',
+          } as any,
+          model: 'gemini-3.1-pro-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBe('high');
+      });
+
+      it('should use the first supported thinkingLevel param and ignore other keys', () => {
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'isModelHasExtendParams').mockReturnValue(
+          () => true,
+        );
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParams').mockReturnValue(() => [
+          'thinkingLevel',
+          'thinkingLevel3',
+        ]);
+
+        const result = resolveModelExtendParams({
+          chatConfig: {
             thinkingLevel3: 'medium',
           } as any,
           model: 'gemini-3.1-pro-preview',
@@ -1140,7 +1226,7 @@ describe('resolveModelExtendParams', () => {
         expect(result.reasoning_effort).toBeUndefined();
         expect(result.verbosity).toBeUndefined();
         expect(result.thinkingBudget).toBeUndefined();
-        expect(result.thinkingLevel).toBeUndefined();
+        expect(result.thinkingLevel).toBe('high');
         expect(result.urlContext).toBeUndefined();
         expect(result.imageAspectRatio).toBeUndefined();
         expect(result.imageResolution).toBeUndefined();

--- a/src/services/chat/mecha/modelParamsResolver.test.ts
+++ b/src/services/chat/mecha/modelParamsResolver.test.ts
@@ -498,7 +498,7 @@ describe('resolveModelExtendParams', () => {
           chatConfig: {
             thinkingLevel2: 'low',
           } as any,
-          model: 'gemini-3-pro-preview',
+          model: 'gemini-3.1-pro-preview',
           provider: 'google',
         });
 
@@ -508,19 +508,7 @@ describe('resolveModelExtendParams', () => {
       it('should not set thinkingLevel when thinkingLevel2 is not configured', () => {
         const result = resolveModelExtendParams({
           chatConfig: {} as any,
-          model: 'gemini-3-pro-preview',
-          provider: 'google',
-        });
-
-        expect(result.thinkingLevel).toBeUndefined();
-      });
-
-      it('should not read from thinkingLevel config key', () => {
-        const result = resolveModelExtendParams({
-          chatConfig: {
-            thinkingLevel: 'high',
-          } as any,
-          model: 'gemini-3-pro-preview',
+          model: 'gemini-3.1-pro-preview',
           provider: 'google',
         });
 
@@ -559,17 +547,28 @@ describe('resolveModelExtendParams', () => {
 
         expect(result.thinkingLevel).toBeUndefined();
       });
+    });
 
-      it('should not read from thinkingLevel config key', () => {
+    describe('thinkingLevel selection order', () => {
+      it('should use the first configured thinkingLevel* extend param in modelExtendParams order', () => {
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'isModelHasExtendParams').mockReturnValue(
+          () => true,
+        );
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParams').mockReturnValue(() => [
+          'thinkingLevel',
+          'thinkingLevel3',
+        ]);
+
         const result = resolveModelExtendParams({
           chatConfig: {
             thinkingLevel: 'high',
+            thinkingLevel3: 'medium',
           } as any,
           model: 'gemini-3.1-pro-preview',
           provider: 'google',
         });
 
-        expect(result.thinkingLevel).toBeUndefined();
+        expect(result.thinkingLevel).toBe('high');
       });
     });
   });

--- a/src/services/chat/mecha/modelParamsResolver.ts
+++ b/src/services/chat/mecha/modelParamsResolver.ts
@@ -31,6 +31,22 @@ export interface ModelExtendParams {
   verbosity?: string;
 }
 
+const DEFAULT_THINKING_LEVEL_BY_EXTEND_PARAM = {
+  thinkingLevel: 'high',
+  thinkingLevel2: 'high',
+  thinkingLevel3: 'high',
+  thinkingLevel4: 'minimal',
+  thinkingLevel5: 'minimal',
+} as const satisfies Partial<Record<ExtendParamsType, string>>;
+
+const THINKING_LEVEL_PARAM_TO_CONFIG_KEY = {
+  thinkingLevel: 'thinkingLevel',
+  thinkingLevel2: 'thinkingLevel2',
+  thinkingLevel3: 'thinkingLevel3',
+  thinkingLevel4: 'thinkingLevel4',
+  thinkingLevel5: 'thinkingLevel5',
+} as const satisfies Partial<Record<ExtendParamsType, keyof LobeAgentChatConfig>>;
+
 /**
  * Resolves extended parameters for model runtime based on model capabilities and chat config
  *
@@ -169,24 +185,19 @@ export const resolveModelExtendParams = (ctx: ModelParamsContext): ModelExtendPa
     extendParams.thinkingBudget = chatConfig.thinkingBudget;
   }
 
-  const thinkingLevelParamToConfigKey: Partial<Record<ExtendParamsType, keyof LobeAgentChatConfig>> =
-    {
-      thinkingLevel: 'thinkingLevel',
-      thinkingLevel2: 'thinkingLevel2',
-      thinkingLevel3: 'thinkingLevel3',
-      thinkingLevel4: 'thinkingLevel4',
-      thinkingLevel5: 'thinkingLevel5',
-    };
+  const supportedThinkingLevelParam = modelExtendParams.find(
+    (extendParam): extendParam is keyof typeof THINKING_LEVEL_PARAM_TO_CONFIG_KEY =>
+      extendParam in THINKING_LEVEL_PARAM_TO_CONFIG_KEY,
+  );
 
-  for (const extendParam of modelExtendParams) {
-    const configKey = thinkingLevelParamToConfigKey[extendParam];
-    if (!configKey) continue;
-
+  if (supportedThinkingLevelParam) {
+    const configKey = THINKING_LEVEL_PARAM_TO_CONFIG_KEY[supportedThinkingLevelParam];
     const value = chatConfig[configKey];
-    if (typeof value === 'string') {
-      extendParams.thinkingLevel = value;
-      break;
-    }
+
+    extendParams.thinkingLevel =
+      typeof value === 'string'
+        ? value
+        : DEFAULT_THINKING_LEVEL_BY_EXTEND_PARAM[supportedThinkingLevelParam];
   }
 
   // URL context

--- a/src/services/chat/mecha/modelParamsResolver.ts
+++ b/src/services/chat/mecha/modelParamsResolver.ts
@@ -1,4 +1,5 @@
-import { type LobeAgentChatConfig } from '@lobechat/types';
+import type { LobeAgentChatConfig } from '@lobechat/types';
+import type { ExtendParamsType } from 'model-bank';
 
 import { aiModelSelectors, getAiInfraStoreState } from '@/store/aiInfra';
 
@@ -168,24 +169,24 @@ export const resolveModelExtendParams = (ctx: ModelParamsContext): ModelExtendPa
     extendParams.thinkingBudget = chatConfig.thinkingBudget;
   }
 
-  if (modelExtendParams.includes('thinkingLevel') && chatConfig.thinkingLevel) {
-    extendParams.thinkingLevel = chatConfig.thinkingLevel;
-  }
+  const thinkingLevelParamToConfigKey: Partial<Record<ExtendParamsType, keyof LobeAgentChatConfig>> =
+    {
+      thinkingLevel: 'thinkingLevel',
+      thinkingLevel2: 'thinkingLevel2',
+      thinkingLevel3: 'thinkingLevel3',
+      thinkingLevel4: 'thinkingLevel4',
+      thinkingLevel5: 'thinkingLevel5',
+    };
 
-  if (modelExtendParams.includes('thinkingLevel2') && chatConfig.thinkingLevel2) {
-    extendParams.thinkingLevel = chatConfig.thinkingLevel2;
-  }
+  for (const extendParam of modelExtendParams) {
+    const configKey = thinkingLevelParamToConfigKey[extendParam];
+    if (!configKey) continue;
 
-  if (modelExtendParams.includes('thinkingLevel3') && chatConfig.thinkingLevel3) {
-    extendParams.thinkingLevel = chatConfig.thinkingLevel3;
-  }
-
-  if (modelExtendParams.includes('thinkingLevel4') && chatConfig.thinkingLevel4) {
-    extendParams.thinkingLevel = chatConfig.thinkingLevel4;
-  }
-
-  if (modelExtendParams.includes('thinkingLevel5') && chatConfig.thinkingLevel5) {
-    extendParams.thinkingLevel = chatConfig.thinkingLevel5;
+    const value = chatConfig[configKey];
+    if (typeof value === 'string') {
+      extendParams.thinkingLevel = value;
+      break;
+    }
   }
 
   // URL context

--- a/src/services/chat/mecha/modelParamsResolver.ts
+++ b/src/services/chat/mecha/modelParamsResolver.ts
@@ -185,19 +185,24 @@ export const resolveModelExtendParams = (ctx: ModelParamsContext): ModelExtendPa
     extendParams.thinkingBudget = chatConfig.thinkingBudget;
   }
 
-  const supportedThinkingLevelParam = modelExtendParams.find(
+  const supportedThinkingLevelParams = modelExtendParams.filter(
     (extendParam): extendParam is keyof typeof THINKING_LEVEL_PARAM_TO_CONFIG_KEY =>
       extendParam in THINKING_LEVEL_PARAM_TO_CONFIG_KEY,
   );
 
-  if (supportedThinkingLevelParam) {
+  for (const supportedThinkingLevelParam of supportedThinkingLevelParams) {
     const configKey = THINKING_LEVEL_PARAM_TO_CONFIG_KEY[supportedThinkingLevelParam];
     const value = chatConfig[configKey];
 
+    if (typeof value === 'string') {
+      extendParams.thinkingLevel = value;
+      break;
+    }
+  }
+
+  if (!extendParams.thinkingLevel && supportedThinkingLevelParams.length > 0) {
     extendParams.thinkingLevel =
-      typeof value === 'string'
-        ? value
-        : DEFAULT_THINKING_LEVEL_BY_EXTEND_PARAM[supportedThinkingLevelParam];
+      DEFAULT_THINKING_LEVEL_BY_EXTEND_PARAM[supportedThinkingLevelParams[0]];
   }
 
   // URL context


### PR DESCRIPTION
#### 💻 Change Type

  - [ ] ✨ feat
  - [x] 🐛 fix
  - [ ] ♻️ refactor
  - [ ] 💄 style
  - [ ] 👷 build
  - [ ] ⚡️ perf
  - [ ] ✅ test
  - [ ] 📝 docs
  - [ ] 🔨 chore

#### 🔗 Related Issue

  fixes #12959

#### 🔀 Description of Change

本 PR 修复 Gemini 3.x `thinking` 参数在 UI / Resolver / Runtime 链路上的一致性问题，避免请求携带空的 `thinkingConfig: {}`，并保证不同模型能够稳定读取并下发正确的 `thinkingLevel*` 配置。

- **Google runtime**：省略空 `thinkingConfig`
  - `packages/model-runtime/src/providers/google/index.ts`
    - 新增 `normalizeThinkingConfig`：当 `includeThoughts` / `thinkingBudget` / `thinkingLevel` 全部为 `undefined` 时返回 `undefined`，避免发送 `thinkingConfig: {}`。
  - `packages/model-runtime/src/providers/google/index.test.ts`
    - 增加回归测试：`gemini-3.1-pro-preview` 未显式设置 `thinking` 参数时，断言最终请求 `config.thinkingConfig === undefined`。
- **UI**：`ThinkingLevel` sliders 读写正确的配置 key
  - `src/features/ModelSwitchPanel/components/ControlsForm/createLevelSlider.tsx`
  - `src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel2Slider.tsx`
  - `src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel3Slider.tsx`
  - `src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel4Slider.tsx`
  - `src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel5Slider.tsx`
    - `ThinkingLevel2/3/4/5` sliders 分别读写 `thinkingLevel2/3/4/5`。
- **Resolver**：按模型声明的 `extendParams` 精确映射 `thinkingLevel*`
  - `src/services/chat/mecha/modelParamsResolver.ts`
    - 当模型声明 `thinkingLevel` / `thinkingLevel2` / `thinkingLevel3` / `thinkingLevel4` / `thinkingLevel5` 时，只从 `chatConfig` 中读取对应的同名 key，并下发到 `extendParams.thinkingLevel`。
    - 当模型支持多个 `thinkingLevel*` 参数时，优先使用第一个已显式配置的 key；只有在所有相关 key 都未配置时，才回落到默认值。
    - 默认值规则如下：
      - `thinkingLevel` / `thinkingLevel2` / `thinkingLevel3` -> `high`
      - `thinkingLevel4` / `thinkingLevel5` -> `minimal`
    - 避免跨 `thinkingLevel*` 复用其它 key，也避免已配置值被更前面的默认值覆盖。
- **Tests**：补充 `thinkingLevel*` 映射与优先级覆盖
  - `src/services/chat/mecha/modelParamsResolver.test.ts`
    - 更新并补充测试，覆盖：
      - 同名 key 映射
      - 老数据缺省时的默认值补齐
      - 多个 `thinkingLevel*` 同时存在时显式值优先
      - 所有相关 key 都未配置时再使用默认值回落

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed
- `bunx vitest run --silent='passed-only' 'src/services/chat/mecha/modelParamsResolver.test.ts'`
- `cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/providers/google/index.test.ts'`

#### 📸 Screenshots / Videos

<img width="1521" height="1113" alt="image" src="https://github.com/user-attachments/assets/2458b521-652a-467a-948a-3f2253dc9b5c" />

#### 📝 Additional Information
