### PR TITLE
🔨 chore(fetch-sse): enrich error context with provider, model, and network diagnostics

### DIFF
--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -93,6 +93,13 @@ interface MessageToolCallsChunk {
   type: 'tool_calls';
 }
 
+export interface FetchSSERequestContext {
+  apiMode?: string;
+  fetchOnClient?: boolean;
+  model?: string;
+  provider?: string;
+}
+
 export interface FetchSSEOptions {
   fetcher?: typeof fetch;
   onAbort?: (text: string) => Promise<void>;
@@ -111,6 +118,7 @@ export interface FetchSSEOptions {
       | MessageSpeedChunk
       | MessageStopChunk,
   ) => void;
+  requestContext?: FetchSSERequestContext;
   responseAnimation?: ResponseAnimation;
 }
 
@@ -235,6 +243,7 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
 
   let finishedType: SSEFinishType = 'done';
   let response!: Response;
+  const fetchStartTime = Date.now();
 
   const { text, speed: smoothingSpeed } = standardizeAnimationStyle(
     options.responseAnimation ?? {},
@@ -303,14 +312,23 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
       } else {
         finishedType = 'error';
 
+        const elapsedMs = Date.now() - fetchStartTime;
+        const networkStatus = typeof navigator !== 'undefined' ? navigator.onLine : undefined;
+
+        const contextBody = {
+          ...options.requestContext,
+          elapsedMs,
+          networkStatus,
+        };
+
         options.onErrorHandle?.(
           error.type
-            ? error
+            ? { ...error, body: { ...error.body, ...contextBody } }
             : {
                 body: {
-                  message: error.message,
-                  name: error.name,
-                  stack: error.stack,
+                  errorMessage: error.message,
+                  errorName: error.name,
+                  ...contextBody,
                 },
                 message: error.message,
                 type: ChatErrorType.UnknownChatFetchError,

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -435,6 +435,12 @@ class ChatService {
       onErrorHandle: options?.onErrorHandle,
       onFinish: options?.onFinish,
       onMessageHandle: options?.onMessageHandle,
+      requestContext: {
+        apiMode,
+        fetchOnClient: enableFetchOnClient,
+        model,
+        provider,
+      },
       responseAnimation: mergedResponseAnimation,
       signal,
     });

--- a/src/store/chat/agents/createAgentExecutors.ts
+++ b/src/store/chat/agents/createAgentExecutors.ts
@@ -476,7 +476,14 @@ export const createAgentExecutors = (context: {
           traceName: TraceNameMap.Conversation,
         },
         onErrorHandle: async (error) => {
-          const localizedError = localizeError(error);
+          const enrichedError = {
+            ...error,
+            body: {
+              ...error.body,
+              traceId,
+            },
+          };
+          const localizedError = localizeError(enrichedError);
 
           await context.get().optimisticUpdateMessageError(assistantMessageId, localizedError, {
             operationId: context.operationId,


### PR DESCRIPTION
## Summary

- Enrich fetch error body with `provider`, `model`, `apiMode`, `fetchOnClient`, `elapsedMs`, `networkStatus`, and `traceId` for better debugging
- Previously, `TypeError: Failed to fetch` errors only showed a useless minified stack trace with no actionable information
- Now errors display enough context to quickly diagnose whether it's a network issue, provider issue, or client-side fetch problem

Fixes LOBE-6594

## Changes

| File | Change |
|------|--------|
| `packages/fetch-sse/src/fetchSSE.ts` | Add `FetchSSERequestContext` interface; record fetch start time; enrich error body with request context, `elapsedMs`, and `networkStatus` |
| `src/services/chat/index.ts` | Pass `requestContext` (provider, model, apiMode, fetchOnClient) to `fetchSSE` |
| `src/store/chat/agents/createAgentExecutors.ts` | Append `traceId` to error body in `onErrorHandle` |

## Error body before vs after

**Before:**
```json
{
  "name": "TypeError",
  "message": "Failed to fetch",
  "stack": "TypeError: Failed to fetch\n at create2 (app://renderer/assets/index-DRIaUz_L.js:599009:33)..."
}
```

**After:**
```json
{
  "provider": "openai",
  "model": "gpt-4o",
  "apiMode": "chatCompletion",
  "fetchOnClient": false,
  "elapsedMs": 45,
  "networkStatus": true,
  "traceId": "xxx-yyy-zzz",
  "errorName": "TypeError",
  "errorMessage": "Failed to fetch"
}
```

## Test plan

- [x] `bun run type-check` — no new type errors in changed files
- [x] Lint and pre-commit hooks pass
- [ ] Verify enriched error body renders correctly in the error UI when a fetch failure occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)