### PR TITLE
🐛 fix(fetch-sse): preserve legacy body.message and body.name keys for compatibility

### DIFF
--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -326,8 +326,8 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
             ? { ...error, body: { ...error.body, ...contextBody } }
             : {
                 body: {
-                  errorMessage: error.message,
-                  errorName: error.name,
+                  message: error.message,
+                  name: error.name,
                   ...contextBody,
                 },
                 message: error.message,


### PR DESCRIPTION
## Summary

- Restores `body.message` and `body.name` fields in the unknown fetch error body that were inadvertently renamed to `body.errorMessage` / `body.errorName` in #13468
- Downstream error handlers and renderers read `body.message` — the rename broke them silently

## Changes

| File | Change |
|------|--------|
| `packages/fetch-sse/src/fetchSSE.ts` | `errorMessage` → `message`, `errorName` → `name` |

## Test plan

- [x] Type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)