### PR TITLE
🐛 fix(fetch-sse): stop injecting contextBody into structured provider errors

### DIFF
--- a/packages/fetch-sse/src/__tests__/fetchSSE.test.ts
+++ b/packages/fetch-sse/src/__tests__/fetchSSE.test.ts
@@ -598,6 +598,42 @@ describe('fetchSSE', () => {
       expect(mockOnErrorHandle).toHaveBeenCalledWith(mockError);
     });
 
+    it('should NOT inject contextBody into structured provider errors (regression)', async () => {
+      const mockOnErrorHandle = vi.fn();
+      const mockError: ChatMessageError = {
+        body: {
+          error: {
+            type: 'invalid_request_error',
+            message: 'Invalid signature in thinking block',
+          },
+          provider: 'lobehub',
+          errorType: 'ProviderBizError',
+        },
+        message: 'ProviderBizError',
+        type: 'ProviderBizError',
+      };
+
+      (fetchEventSource as any).mockImplementationOnce(
+        (url: string, options: FetchEventSourceInit) => {
+          options.onerror!(mockError);
+        },
+      );
+
+      try {
+        await fetchSSE('/', {
+          onErrorHandle: mockOnErrorHandle,
+          requestContext: { provider: 'openai', model: 'gpt-4o' },
+        });
+      } catch (e) {}
+
+      expect(mockOnErrorHandle).toHaveBeenCalledWith(mockError);
+      const receivedError = mockOnErrorHandle.mock.calls[0][0];
+      expect(receivedError.body).not.toHaveProperty('elapsedMs');
+      expect(receivedError.body).not.toHaveProperty('networkStatus');
+      expect(receivedError.body).not.toHaveProperty('model');
+      expect(receivedError.body.provider).toBe('lobehub');
+    });
+
     it('should call onErrorHandle when Unknown error is thrown', async () => {
       const mockOnErrorHandle = vi.fn();
       const mockError = new Error('Unknown error');
@@ -609,7 +645,10 @@ describe('fetchSSE', () => {
       );
 
       try {
-        await fetchSSE('/', { onErrorHandle: mockOnErrorHandle });
+        await fetchSSE('/', {
+          onErrorHandle: mockOnErrorHandle,
+          requestContext: { provider: 'openai', model: 'gpt-4o' },
+        });
       } catch (e) {}
 
       expect(mockOnErrorHandle).toHaveBeenCalledWith({
@@ -618,7 +657,10 @@ describe('fetchSSE', () => {
         body: {
           message: 'Unknown error',
           name: 'Error',
-          stack: expect.any(String),
+          provider: 'openai',
+          model: 'gpt-4o',
+          elapsedMs: expect.any(Number),
+          networkStatus: expect.any(Boolean),
         },
       });
     });

--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -323,7 +323,7 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
 
         options.onErrorHandle?.(
           error.type
-            ? { ...error, body: { ...error.body, ...contextBody } }
+            ? error
             : {
                 body: {
                   message: error.message,


### PR DESCRIPTION
## Summary

- Stop spreading `contextBody` into structured provider errors (e.g. `ProviderBizError`) that already have their own complete `body`
- Only apply context enrichment (provider, model, elapsedMs, networkStatus) to unknown/unstructured errors

Fixes #13476

## Root Cause

PR #13468 added `{ ...error, body: { ...error.body, ...contextBody } }` for **all** errors with `error.type`. This overwrites existing fields like `provider` and pollutes the error structure that downstream error renderers depend on.

## Test plan

- [ ] Trigger a structured provider error (e.g. invalid thinking block signature) → error body should be unchanged
- [ ] Trigger a network-level fetch error (e.g. disconnect) → error body should still include contextBody fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)