### PR TITLE
🔒 fix: upgrade nodemailer to v8 to fix SMTP command injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -354,7 +354,7 @@
     "next-themes": "^0.4.6",
     "nextjs-toploader": "^3.9.17",
     "node-machine-id": "^1.1.12",
-    "nodemailer": "^7.0.13",
+    "nodemailer": "^8.0.4",
     "numeral": "^2.0.6",
     "nuqs": "^2.8.6",
     "officeparser": "5.1.1",


### PR DESCRIPTION
## Summary
- Upgrade `nodemailer` from `^7.0.13` to `^8.0.4` to fix SMTP command injection vulnerability via unsanitized `envelope.size` parameter
- Ref: https://github.com/lobehub/lobehub/security/dependabot/20

## Notes
- Only breaking change in v8 is error code `NoAuth` → `ENOAUTH`, which is not used in our codebase
- All used APIs (`createTransport`, `sendMail`, `getTestMessageUrl`, `verify`, `Transporter` type) are fully backward compatible
- `@types/nodemailer` remains unchanged