### PR TITLE
🐛 fix(chat-input): preserve fullscreen editor state and send behavior

### DIFF
--- a/src/features/ChatInput/Desktop/index.tsx
+++ b/src/features/ChatInput/Desktop/index.tsx
@@ -4,11 +4,13 @@ import { type ChatInputProps } from '@lobehub/editor/react';
 import { ChatInput, ChatInputActionBar } from '@lobehub/editor/react';
 import { Center, Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles, cx } from 'antd-style';
-import { type ReactNode } from 'react';
+import { type ReactNode, use } from 'react';
 import { memo, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 
 import { useChatInputStore } from '@/features/ChatInput/store';
+import { LayoutContainerContext } from '@/routes/(main)/_layout/DesktopLayoutContainer/LayoutContainerContext';
 import { useChatStore } from '@/store/chat';
 import { chatSelectors } from '@/store/chat/selectors';
 import { fileChatSelectors, useFileStore } from '@/store/file';
@@ -23,7 +25,7 @@ import SendArea from '../SendArea';
 import TypoBar from '../TypoBar';
 import ContextContainer from './ContextContainer';
 
-const styles = createStaticStyles(({ css }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   container: css`
     .show-on-hover {
       opacity: 0;
@@ -46,6 +48,8 @@ const styles = createStaticStyles(({ css }) => ({
     width: 100%;
     height: 100%;
     margin-block-start: 0;
+
+    background: ${cssVar.colorBgContainer};
   `,
   inputFullscreen: css`
     border: none;
@@ -77,6 +81,7 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
     sendAreaPrefix,
   }) => {
     const { t } = useTranslation('chat');
+    const layoutContainerRef = use(LayoutContainerContext);
     const [chatInputHeight, updateSystemStatus] = useGlobalStore((s) => [
       systemStatusSelectors.chatInputHeight(s),
       s.updateSystemStatus,
@@ -93,15 +98,18 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
 
     const chatKey = useChatStore(chatSelectors.currentChatKey);
 
+    const setExpand = useChatInputStore((s) => s.setExpand);
+
     useEffect(() => {
       if (editor) editor.focus();
-    }, [chatKey, editor]);
+      setExpand(false);
+    }, [chatKey, editor, setExpand]);
 
     const shouldShowContextContainer =
       leftActions.flat().includes('fileUpload') || hasContextSelections || hasFiles;
     const contextContainerNode = shouldShowContextContainer && <ContextContainer />;
 
-    return (
+    const content = (
       <Flexbox
         className={cx(styles.container, expand && styles.fullscreen)}
         gap={8}
@@ -164,6 +172,11 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
         )}
       </Flexbox>
     );
+
+    if (expand && layoutContainerRef.current)
+      return createPortal(content, layoutContainerRef.current);
+
+    return content;
   },
 );
 

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -198,7 +198,6 @@ const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
       }}
       onCompositionEnd={({ event }) => compositionProps.onCompositionEnd(event)}
       onCompositionStart={({ event }) => compositionProps.onCompositionStart(event)}
-      onInit={(editor) => storeApi.setState({ editor })}
       onBlur={() => {
         disableScope(HotkeyEnum.AddUserMessage);
       }}
@@ -220,11 +219,28 @@ const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
       onFocus={() => {
         enableScope(HotkeyEnum.AddUserMessage);
       }}
+      onInit={(editor) => {
+        const saved = storeApi.getState()._savedEditorState;
+        storeApi.setState({ _savedEditorState: undefined, editor });
+        if (saved) {
+          requestAnimationFrame(() => {
+            editor.setDocument('json', saved);
+          });
+        }
+      }}
       onPressEnter={({ event: e }) => {
         if (e.shiftKey || isComposingRef.current) return;
         // when user like alt + enter to add ai message
         if (e.altKey && hotkey === combineKeys([KeyEnum.Alt, KeyEnum.Enter])) return true;
         const commandKey = isCommandPressed(e);
+        // In fullscreen mode, Enter inserts newline; only Cmd/Ctrl+Enter sends
+        if (expand) {
+          if (commandKey) {
+            send();
+            return true;
+          }
+          return;
+        }
         // when user like cmd + enter to send message
         if (useCmdEnterToSend) {
           if (commandKey) {

--- a/src/features/ChatInput/store/action.ts
+++ b/src/features/ChatInput/store/action.ts
@@ -59,7 +59,9 @@ export const store: CreateStore = (publicState) => (set, get) => ({
   },
 
   setExpand: (expand) => {
-    set({ expand });
+    const editor = get().editor;
+    const _savedEditorState = editor?.getDocument('json') as Record<string, any> | undefined;
+    set({ _savedEditorState, expand });
   },
 
   setJSONState: (content) => {

--- a/src/features/ChatInput/store/action.ts
+++ b/src/features/ChatInput/store/action.ts
@@ -41,6 +41,9 @@ export const store: CreateStore = (publicState) => (set, get) => ({
       getEditorData: get().getJSONState,
       getMarkdownContent: get().getMarkdownContent,
     });
+    if (get().expand) {
+      set({ _savedEditorState: undefined, expand: false });
+    }
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         editor.focus();

--- a/src/features/ChatInput/store/initialState.ts
+++ b/src/features/ChatInput/store/initialState.ts
@@ -47,6 +47,7 @@ export interface PublicState {
 }
 
 export interface State extends PublicState {
+  _savedEditorState?: Record<string, any>;
   editor?: IEditor;
   isContentEmpty: boolean;
   markdownContent: string;

--- a/src/routes/(main)/_layout/DesktopLayoutContainer.tsx
+++ b/src/routes/(main)/_layout/DesktopLayoutContainer.tsx
@@ -1,7 +1,7 @@
 import { Flexbox } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { type FC, type PropsWithChildren } from 'react';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 
 import { isDesktop } from '@/const/version';
 import { useIsDark } from '@/hooks/useIsDark';
@@ -9,9 +9,11 @@ import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { getDarwinMajorVersion, isMacOSWithLargeWindowBorders } from '@/utils/platform';
 
+import { LayoutContainerContext } from './DesktopLayoutContainer/LayoutContainerContext';
 import { styles } from './DesktopLayoutContainer/style';
 
 const DesktopLayoutContainer: FC<PropsWithChildren> = ({ children }) => {
+  const innerContainerRef = useRef<HTMLDivElement>(null);
   const isDarkMode = useIsDark();
   const [expand] = useGlobalStore((s) => [systemStatusSelectors.showLeftPanel(s)]);
 
@@ -49,10 +51,11 @@ const DesktopLayoutContainer: FC<PropsWithChildren> = ({ children }) => {
       <Flexbox
         className={styles.innerContainer}
         height={'100%'}
+        ref={innerContainerRef}
         style={innerCssVariables}
         width={'100%'}
       >
-        {children}
+        <LayoutContainerContext value={innerContainerRef}>{children}</LayoutContainerContext>
       </Flexbox>
     </Flexbox>
   );

--- a/src/routes/(main)/_layout/DesktopLayoutContainer/LayoutContainerContext.ts
+++ b/src/routes/(main)/_layout/DesktopLayoutContainer/LayoutContainerContext.ts
@@ -1,0 +1,5 @@
+import { createContext, type RefObject } from 'react';
+
+export const LayoutContainerContext = createContext<RefObject<HTMLDivElement | null>>({
+  current: null,
+});


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-6603

#### 🔀 Description of Change

- Preserve and restore editor JSON content when toggling chat input fullscreen mode.
- Render fullscreen chat input through the desktop layout container portal to keep layout behavior consistent.
- Adjust fullscreen keyboard behavior so `Enter` inserts a newline and `Cmd/Ctrl+Enter` sends.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

- This change is scoped to desktop chat input behavior only.

Made with [Cursor](https://cursor.com)