### PR TITLE
🐛 fix(conversation): hide loading placeholder when AI generation is stopped

### DIFF
--- a/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
@@ -78,6 +78,7 @@ const MessageContent = memo<UIChatMessage>(
         {showReasoning && <Reasoning {...props.reasoning} id={id} />}
         <DisplayContent
           content={content}
+          generating={generating}
           hasImages={showImageItems}
           id={id}
           isMultimodal={metadata?.isMultimodal}

--- a/src/features/Conversation/Messages/components/DisplayContent.tsx
+++ b/src/features/Conversation/Messages/components/DisplayContent.tsx
@@ -12,6 +12,7 @@ import { RichContentRenderer } from './RichContentRenderer';
 const DisplayContent = memo<{
   addIdOnDOM?: boolean;
   content: string;
+  generating?: boolean;
   hasImages?: boolean;
   id: string;
   isMultimodal?: boolean;
@@ -22,6 +23,7 @@ const DisplayContent = memo<{
   ({
     markdownProps,
     content,
+    generating,
     isToolCallGenerating,
     hasImages,
     isMultimodal,
@@ -31,7 +33,8 @@ const DisplayContent = memo<{
     const message = normalizeThinkTags(processWithArtifact(content));
     if (isToolCallGenerating) return;
 
-    if ((!content && !hasImages) || content === LOADING_FLAT) return <ContentLoading id={id} />;
+    if (content === LOADING_FLAT) return generating ? <ContentLoading id={id} /> : null;
+    if (!content && !hasImages) return <ContentLoading id={id} />;
 
     const contentParts = isMultimodal ? deserializeParts(tempDisplayContent || content) : null;
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

When sending a message, a temporary assistant message with content `...` (LOADING_FLAT) is inserted optimistically. If the user immediately stops the AI generation before any content is streamed, the `...` message remains in the store and `DisplayContent` unconditionally renders `<ContentLoading>` (animated loading dots) for it — even though nothing is being generated.

**Fix:** Pass the `generating` state to `DisplayContent` and only render `<ContentLoading>` when `content === LOADING_FLAT` AND the message is actively generating. When generation is stopped, the placeholder renders nothing.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Send a message in a conversation
2. Immediately click the stop button before any AI content streams back
3. **Before fix:** The `...` loading animation persists indefinitely
4. **After fix:** No loading animation is shown when generation is stopped