### PR TITLE
🔨 chore: add agent avatar data to brief list API

### DIFF
--- a/packages/database/src/models/__tests__/agent.getAvatars.test.ts
+++ b/packages/database/src/models/__tests__/agent.getAvatars.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getTestDB } from '../../core/getTestDB';
+import { agents, users } from '../../schemas';
+import type { LobeChatDatabase } from '../../type';
+import { AgentModel } from '../agent';
+
+const serverDB: LobeChatDatabase = await getTestDB();
+
+const userId = 'avatar-test-user-id';
+const userId2 = 'avatar-test-user-id-2';
+
+beforeEach(async () => {
+  await serverDB.delete(users);
+  await serverDB.insert(users).values([{ id: userId }, { id: userId2 }]);
+});
+
+afterEach(async () => {
+  await serverDB.delete(users);
+});
+
+describe('AgentModel.getAgentAvatarsByIds', () => {
+  it('should return empty array for empty input', async () => {
+    const model = new AgentModel(serverDB, userId);
+    const result = await model.getAgentAvatarsByIds([]);
+    expect(result).toEqual([]);
+  });
+
+  it('should return agent avatar info by IDs', async () => {
+    await serverDB.insert(agents).values([
+      {
+        avatar: '🤖',
+        backgroundColor: '#ff0000',
+        id: 'agent-av-1',
+        slug: 'agent-av-1',
+        title: 'Agent One',
+        userId,
+      },
+      {
+        avatar: '🧠',
+        backgroundColor: '#00ff00',
+        id: 'agent-av-2',
+        slug: 'agent-av-2',
+        title: 'Agent Two',
+        userId,
+      },
+    ]);
+
+    const model = new AgentModel(serverDB, userId);
+    const result = await model.getAgentAvatarsByIds(['agent-av-1', 'agent-av-2']);
+
+    expect(result).toHaveLength(2);
+    const agent1 = result.find((a) => a.id === 'agent-av-1');
+    expect(agent1).toEqual({
+      avatar: '🤖',
+      backgroundColor: '#ff0000',
+      id: 'agent-av-1',
+      title: 'Agent One',
+    });
+  });
+
+  it('should only return agents owned by the current user', async () => {
+    await serverDB.insert(agents).values([
+      { avatar: '🤖', id: 'agent-mine', slug: 'agent-mine', title: 'Mine', userId },
+      { avatar: '👻', id: 'agent-other', slug: 'agent-other', title: 'Other', userId: userId2 },
+    ]);
+
+    const model = new AgentModel(serverDB, userId);
+    const result = await model.getAgentAvatarsByIds(['agent-mine', 'agent-other']);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('agent-mine');
+  });
+
+  it('should return only selected fields', async () => {
+    await serverDB.insert(agents).values({
+      avatar: '🤖',
+      backgroundColor: '#000',
+      description: 'Should not be returned',
+      id: 'agent-fields',
+      slug: 'agent-fields',
+      title: 'Test Agent',
+      userId,
+    });
+
+    const model = new AgentModel(serverDB, userId);
+    const result = await model.getAgentAvatarsByIds(['agent-fields']);
+
+    expect(result).toHaveLength(1);
+    expect(Object.keys(result[0]).sort()).toEqual(['avatar', 'backgroundColor', 'id', 'title']);
+  });
+});

--- a/packages/database/src/models/__tests__/task.getTreeAgentIds.test.ts
+++ b/packages/database/src/models/__tests__/task.getTreeAgentIds.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getTestDB } from '../../core/getTestDB';
+import { agents, users } from '../../schemas';
+import type { LobeChatDatabase } from '../../type';
+import { TaskModel } from '../task';
+
+const serverDB: LobeChatDatabase = await getTestDB();
+
+const userId = 'tree-agent-test-user-id';
+const userId2 = 'tree-agent-test-user-id-2';
+
+const createAgent = async (id: string, uid = userId) => {
+  await serverDB.insert(agents).values({ id, slug: id, userId: uid }).onConflictDoNothing();
+  return id;
+};
+
+beforeEach(async () => {
+  await serverDB.delete(users);
+  await serverDB.insert(users).values([{ id: userId }, { id: userId2 }]);
+});
+
+afterEach(async () => {
+  await serverDB.delete(users);
+});
+
+describe('TaskModel.getTreeAgentIdsForTaskIds', () => {
+  it('should return empty object for empty input', async () => {
+    const model = new TaskModel(serverDB, userId);
+    const result = await model.getTreeAgentIdsForTaskIds([]);
+    expect(result).toEqual({});
+  });
+
+  it('should return empty object when task has no agents', async () => {
+    const model = new TaskModel(serverDB, userId);
+    const task = await model.create({ instruction: 'No agents task' });
+
+    const result = await model.getTreeAgentIdsForTaskIds([task.id]);
+    expect(result).toEqual({});
+  });
+
+  it('should collect assignee agent from a single task', async () => {
+    const agentId = await createAgent('agent-assignee-1');
+    const model = new TaskModel(serverDB, userId);
+    const task = await model.create({
+      assigneeAgentId: agentId,
+      instruction: 'Single task',
+    });
+
+    const result = await model.getTreeAgentIdsForTaskIds([task.id]);
+    expect(result[task.id]).toEqual([agentId]);
+  });
+
+  it('should collect creator agent from a single task', async () => {
+    const agentId = await createAgent('agent-creator-1');
+    const model = new TaskModel(serverDB, userId);
+    const task = await model.create({
+      createdByAgentId: agentId,
+      instruction: 'Created by agent',
+    });
+
+    const result = await model.getTreeAgentIdsForTaskIds([task.id]);
+    expect(result[task.id]).toEqual([agentId]);
+  });
+
+  it('should collect both assignee and creator agents', async () => {
+    const assigneeId = await createAgent('agent-both-assignee');
+    const creatorId = await createAgent('agent-both-creator');
+    const model = new TaskModel(serverDB, userId);
+    const task = await model.create({
+      assigneeAgentId: assigneeId,
+      createdByAgentId: creatorId,
+      instruction: 'Both agents',
+    });
+
+    const result = await model.getTreeAgentIdsForTaskIds([task.id]);
+    expect(result[task.id]).toHaveLength(2);
+    expect(result[task.id]).toContain(assigneeId);
+    expect(result[task.id]).toContain(creatorId);
+  });
+
+  it('should collect agents from full task tree (child input → root → all descendants)', async () => {
+    const agentA = await createAgent('agent-tree-a');
+    const agentB = await createAgent('agent-tree-b');
+    const agentC = await createAgent('agent-tree-c');
+    const model = new TaskModel(serverDB, userId);
+
+    const root = await model.create({
+      assigneeAgentId: agentA,
+      instruction: 'Root',
+    });
+    const child = await model.create({
+      assigneeAgentId: agentB,
+      instruction: 'Child',
+      parentTaskId: root.id,
+    });
+    await model.create({
+      assigneeAgentId: agentC,
+      instruction: 'Grandchild',
+      parentTaskId: child.id,
+    });
+
+    // Query from child — should walk UP to root, then DOWN to get all agents
+    const result = await model.getTreeAgentIdsForTaskIds([child.id]);
+    expect(result[child.id]).toHaveLength(3);
+    expect(result[child.id]).toContain(agentA);
+    expect(result[child.id]).toContain(agentB);
+    expect(result[child.id]).toContain(agentC);
+  });
+
+  it('should deduplicate agents across tree', async () => {
+    const agentId = await createAgent('agent-dedup');
+    const model = new TaskModel(serverDB, userId);
+
+    const root = await model.create({
+      assigneeAgentId: agentId,
+      instruction: 'Root',
+    });
+    await model.create({
+      assigneeAgentId: agentId,
+      instruction: 'Child with same agent',
+      parentTaskId: root.id,
+    });
+
+    const result = await model.getTreeAgentIdsForTaskIds([root.id]);
+    expect(result[root.id]).toEqual([agentId]);
+  });
+
+  it('should handle multiple task IDs from different trees', async () => {
+    const agentA = await createAgent('agent-multi-a');
+    const agentB = await createAgent('agent-multi-b');
+    const model = new TaskModel(serverDB, userId);
+
+    const tree1Root = await model.create({
+      assigneeAgentId: agentA,
+      instruction: 'Tree 1',
+    });
+    const tree2Root = await model.create({
+      assigneeAgentId: agentB,
+      instruction: 'Tree 2',
+    });
+
+    const result = await model.getTreeAgentIdsForTaskIds([tree1Root.id, tree2Root.id]);
+    expect(result[tree1Root.id]).toEqual([agentA]);
+    expect(result[tree2Root.id]).toEqual([agentB]);
+  });
+
+  it('should not return agents from tasks owned by another user', async () => {
+    const agentId = await createAgent('agent-isolation', userId2);
+    const model1 = new TaskModel(serverDB, userId);
+    const model2 = new TaskModel(serverDB, userId2);
+
+    const task = await model2.create({
+      assigneeAgentId: agentId,
+      instruction: 'User 2 task',
+    });
+
+    // User 1 should not see user 2's task tree agents
+    const result = await model1.getTreeAgentIdsForTaskIds([task.id]);
+    expect(result).toEqual({});
+  });
+});

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -74,6 +74,23 @@ export class AgentModel {
   };
 
   /**
+   * Get minimal agent info (avatar, title, backgroundColor) by IDs.
+   */
+  getAgentAvatarsByIds = async (ids: string[]) => {
+    if (ids.length === 0) return [];
+
+    return this.db
+      .select({
+        avatar: agents.avatar,
+        backgroundColor: agents.backgroundColor,
+        id: agents.id,
+        title: agents.title,
+      })
+      .from(agents)
+      .where(and(eq(agents.userId, this.userId), inArray(agents.id, ids)));
+  };
+
+  /**
    * Get agent config by ID or slug (single query with OR condition)
    */
   getAgentConfig = async (idOrSlug: string) => {

--- a/packages/database/src/models/task.ts
+++ b/packages/database/src/models/task.ts
@@ -212,6 +212,59 @@ export class TaskModel {
     return result.rows as TaskItem[];
   }
 
+  /**
+   * For a list of task IDs, find all agent IDs (assignee + creator) across their full task trees.
+   * Walks UP to find root, then DOWN to collect all agents.
+   * Returns { [inputTaskId]: agentId[] }
+   */
+  async getTreeAgentIdsForTaskIds(taskIds: string[]): Promise<Record<string, string[]>> {
+    if (taskIds.length === 0) return {};
+
+    const taskIdParams = taskIds.map((id) => sql`${id}`);
+    const taskIdList = sql.join(taskIdParams, sql`, `);
+
+    const result = await this.db.execute(sql`
+      WITH RECURSIVE
+      ancestors AS (
+        SELECT id AS origin_id, id, parent_task_id
+        FROM tasks
+        WHERE id IN (${taskIdList})
+          AND created_by_user_id = ${this.userId}
+        UNION ALL
+        SELECT a.origin_id, t.id, t.parent_task_id
+        FROM tasks t
+        JOIN ancestors a ON t.id = a.parent_task_id
+      ),
+      roots AS (
+        SELECT DISTINCT ON (origin_id) origin_id, id AS root_id
+        FROM ancestors
+        WHERE parent_task_id IS NULL
+      ),
+      descendants AS (
+        SELECT r.origin_id, t.id, t.assignee_agent_id, t.created_by_agent_id
+        FROM tasks t
+        JOIN roots r ON t.id = r.root_id
+        UNION ALL
+        SELECT d.origin_id, t.id, t.assignee_agent_id, t.created_by_agent_id
+        FROM tasks t
+        JOIN descendants d ON t.parent_task_id = d.id
+      )
+      SELECT origin_id, assignee_agent_id, created_by_agent_id
+      FROM descendants
+      WHERE assignee_agent_id IS NOT NULL OR created_by_agent_id IS NOT NULL
+    `);
+
+    const map: Record<string, Set<string>> = {};
+    for (const row of result.rows as any[]) {
+      const originId = row.origin_id as string;
+      if (!map[originId]) map[originId] = new Set();
+      if (row.assignee_agent_id) map[originId].add(row.assignee_agent_id as string);
+      if (row.created_by_agent_id) map[originId].add(row.created_by_agent_id as string);
+    }
+
+    return Object.fromEntries(Object.entries(map).map(([k, v]) => [k, Array.from(v)]));
+  }
+
   // ========== Status ==========
 
   async updateStatus(

--- a/packages/database/src/models/task.ts
+++ b/packages/database/src/models/task.ts
@@ -234,6 +234,7 @@ export class TaskModel {
         SELECT a.origin_id, t.id, t.parent_task_id
         FROM tasks t
         JOIN ancestors a ON t.id = a.parent_task_id
+        WHERE t.created_by_user_id = ${this.userId}
       ),
       roots AS (
         SELECT DISTINCT ON (origin_id) origin_id, id AS root_id
@@ -244,10 +245,12 @@ export class TaskModel {
         SELECT r.origin_id, t.id, t.assignee_agent_id, t.created_by_agent_id
         FROM tasks t
         JOIN roots r ON t.id = r.root_id
+        WHERE t.created_by_user_id = ${this.userId}
         UNION ALL
         SELECT d.origin_id, t.id, t.assignee_agent_id, t.created_by_agent_id
         FROM tasks t
         JOIN descendants d ON t.parent_task_id = d.id
+        WHERE t.created_by_user_id = ${this.userId}
       )
       SELECT origin_id, assignee_agent_id, created_by_agent_id
       FROM descendants

--- a/src/server/routers/lambda/brief.ts
+++ b/src/server/routers/lambda/brief.ts
@@ -1,51 +1,11 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
-import { AgentModel } from '@/database/models/agent';
 import { BriefModel } from '@/database/models/brief';
 import { TaskModel } from '@/database/models/task';
-import type { BriefItem } from '@/database/schemas';
-import type { LobeChatDatabase } from '@/database/type';
 import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
-
-type AgentAvatarInfo = {
-  avatar: string | null;
-  backgroundColor: string | null;
-  id: string;
-  title: string | null;
-};
-
-const enrichBriefsWithAgents = async (
-  briefs: BriefItem[],
-  db: LobeChatDatabase,
-  userId: string,
-) => {
-  const taskIds = briefs.map((b) => b.taskId).filter((id): id is string => id !== null);
-
-  if (taskIds.length === 0) {
-    return briefs.map((brief) => ({ ...brief, agents: [] as AgentAvatarInfo[] }));
-  }
-
-  const taskModel = new TaskModel(db, userId);
-  const taskAgentIdsMap = await taskModel.getTreeAgentIdsForTaskIds(taskIds);
-
-  const allAgentIds = [...new Set(Object.values(taskAgentIdsMap).flat())];
-  let agentMap: Record<string, AgentAvatarInfo> = {};
-
-  if (allAgentIds.length > 0) {
-    const agentModel = new AgentModel(db, userId);
-    const agentList = await agentModel.getAgentAvatarsByIds(allAgentIds);
-    agentMap = Object.fromEntries(agentList.map((a) => [a.id, a]));
-  }
-
-  return briefs.map((brief) => ({
-    ...brief,
-    agents: (brief.taskId ? taskAgentIdsMap[brief.taskId] || [] : [])
-      .map((id) => agentMap[id])
-      .filter(Boolean),
-  }));
-};
+import { BriefService } from '@/server/services/brief';
 
 const briefProcedure = authedProcedure.use(serverDatabase);
 
@@ -148,11 +108,10 @@ export const briefRouter = router({
 
   list: briefProcedure.input(listSchema).query(async ({ input, ctx }) => {
     try {
-      const model = new BriefModel(ctx.serverDB, ctx.userId);
-      const result = await model.list(input);
-      const data = await enrichBriefsWithAgents(result.briefs, ctx.serverDB, ctx.userId);
+      const service = new BriefService(ctx.serverDB, ctx.userId);
+      const result = await service.list(input);
 
-      return { data, success: true, total: result.total };
+      return { data: result.briefs, success: true, total: result.total };
     } catch (error) {
       console.error('[brief:list]', error);
       throw new TRPCError({
@@ -165,9 +124,8 @@ export const briefRouter = router({
 
   listUnresolved: briefProcedure.query(async ({ ctx }) => {
     try {
-      const model = new BriefModel(ctx.serverDB, ctx.userId);
-      const items = await model.listUnresolved();
-      const data = await enrichBriefsWithAgents(items, ctx.serverDB, ctx.userId);
+      const service = new BriefService(ctx.serverDB, ctx.userId);
+      const data = await service.listUnresolved();
 
       return { data, success: true };
     } catch (error) {

--- a/src/server/routers/lambda/brief.ts
+++ b/src/server/routers/lambda/brief.ts
@@ -1,10 +1,51 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
+import { AgentModel } from '@/database/models/agent';
 import { BriefModel } from '@/database/models/brief';
 import { TaskModel } from '@/database/models/task';
+import type { BriefItem } from '@/database/schemas';
+import type { LobeChatDatabase } from '@/database/type';
 import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
+
+type AgentAvatarInfo = {
+  avatar: string | null;
+  backgroundColor: string | null;
+  id: string;
+  title: string | null;
+};
+
+const enrichBriefsWithAgents = async (
+  briefs: BriefItem[],
+  db: LobeChatDatabase,
+  userId: string,
+) => {
+  const taskIds = briefs.map((b) => b.taskId).filter((id): id is string => id !== null);
+
+  if (taskIds.length === 0) {
+    return briefs.map((brief) => ({ ...brief, agents: [] as AgentAvatarInfo[] }));
+  }
+
+  const taskModel = new TaskModel(db, userId);
+  const taskAgentIdsMap = await taskModel.getTreeAgentIdsForTaskIds(taskIds);
+
+  const allAgentIds = [...new Set(Object.values(taskAgentIdsMap).flat())];
+  let agentMap: Record<string, AgentAvatarInfo> = {};
+
+  if (allAgentIds.length > 0) {
+    const agentModel = new AgentModel(db, userId);
+    const agentList = await agentModel.getAgentAvatarsByIds(allAgentIds);
+    agentMap = Object.fromEntries(agentList.map((a) => [a.id, a]));
+  }
+
+  return briefs.map((brief) => ({
+    ...brief,
+    agents: (brief.taskId ? taskAgentIdsMap[brief.taskId] || [] : [])
+      .map((id) => agentMap[id])
+      .filter(Boolean),
+  }));
+};
 
 const briefProcedure = authedProcedure.use(serverDatabase);
 
@@ -109,7 +150,9 @@ export const briefRouter = router({
     try {
       const model = new BriefModel(ctx.serverDB, ctx.userId);
       const result = await model.list(input);
-      return { data: result.briefs, success: true, total: result.total };
+      const data = await enrichBriefsWithAgents(result.briefs, ctx.serverDB, ctx.userId);
+
+      return { data, success: true, total: result.total };
     } catch (error) {
       console.error('[brief:list]', error);
       throw new TRPCError({
@@ -124,7 +167,9 @@ export const briefRouter = router({
     try {
       const model = new BriefModel(ctx.serverDB, ctx.userId);
       const items = await model.listUnresolved();
-      return { data: items, success: true };
+      const data = await enrichBriefsWithAgents(items, ctx.serverDB, ctx.userId);
+
+      return { data, success: true };
     } catch (error) {
       console.error('[brief:listUnresolved]', error);
       throw new TRPCError({

--- a/src/server/services/brief/index.test.ts
+++ b/src/server/services/brief/index.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentModel } from '@/database/models/agent';
+import { BriefModel } from '@/database/models/brief';
+import { TaskModel } from '@/database/models/task';
+import type { LobeChatDatabase } from '@/database/type';
+
+import { BriefService } from './index';
+
+vi.mock('@/database/models/agent', () => ({
+  AgentModel: vi.fn(),
+}));
+
+vi.mock('@/database/models/brief', () => ({
+  BriefModel: vi.fn(),
+}));
+
+vi.mock('@/database/models/task', () => ({
+  TaskModel: vi.fn(),
+}));
+
+describe('BriefService', () => {
+  const db = {} as LobeChatDatabase;
+  const userId = 'user-1';
+
+  const mockAgentModel = {
+    getAgentAvatarsByIds: vi.fn(),
+  };
+
+  const mockBriefModel = {
+    list: vi.fn(),
+    listUnresolved: vi.fn(),
+  };
+
+  const mockTaskModel = {
+    getTreeAgentIdsForTaskIds: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (AgentModel as any).mockImplementation(() => mockAgentModel);
+    (BriefModel as any).mockImplementation(() => mockBriefModel);
+    (TaskModel as any).mockImplementation(() => mockTaskModel);
+  });
+
+  describe('enrichBriefsWithAgents', () => {
+    it('should return briefs with empty agents when no taskIds', async () => {
+      const service = new BriefService(db, userId);
+
+      const briefs = [
+        { id: 'b1', taskId: null, title: 'Brief 1' },
+        { id: 'b2', taskId: null, title: 'Brief 2' },
+      ] as any[];
+
+      const result = await service.enrichBriefsWithAgents(briefs);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].agents).toEqual([]);
+      expect(result[1].agents).toEqual([]);
+      expect(mockTaskModel.getTreeAgentIdsForTaskIds).not.toHaveBeenCalled();
+    });
+
+    it('should enrich briefs with agent data from task trees', async () => {
+      const service = new BriefService(db, userId);
+
+      const briefs = [
+        { id: 'b1', taskId: 'task-1', title: 'Brief 1' },
+        { id: 'b2', taskId: 'task-2', title: 'Brief 2' },
+      ] as any[];
+
+      mockTaskModel.getTreeAgentIdsForTaskIds.mockResolvedValue({
+        'task-1': ['agent-a', 'agent-b'],
+        'task-2': ['agent-b', 'agent-c'],
+      });
+
+      mockAgentModel.getAgentAvatarsByIds.mockResolvedValue([
+        { avatar: '🤖', backgroundColor: null, id: 'agent-a', title: 'Agent A' },
+        { avatar: '🧠', backgroundColor: '#fff', id: 'agent-b', title: 'Agent B' },
+        { avatar: '🔧', backgroundColor: null, id: 'agent-c', title: 'Agent C' },
+      ]);
+
+      const result = await service.enrichBriefsWithAgents(briefs);
+
+      expect(result[0].agents).toHaveLength(2);
+      expect(result[0].agents[0].id).toBe('agent-a');
+      expect(result[0].agents[1].id).toBe('agent-b');
+
+      expect(result[1].agents).toHaveLength(2);
+      expect(result[1].agents[0].id).toBe('agent-b');
+      expect(result[1].agents[1].id).toBe('agent-c');
+
+      expect(mockTaskModel.getTreeAgentIdsForTaskIds).toHaveBeenCalledWith(['task-1', 'task-2']);
+      expect(mockAgentModel.getAgentAvatarsByIds).toHaveBeenCalledWith(
+        expect.arrayContaining(['agent-a', 'agent-b', 'agent-c']),
+      );
+    });
+
+    it('should handle briefs with mixed null and non-null taskIds', async () => {
+      const service = new BriefService(db, userId);
+
+      const briefs = [
+        { id: 'b1', taskId: 'task-1', title: 'With task' },
+        { id: 'b2', taskId: null, title: 'No task' },
+      ] as any[];
+
+      mockTaskModel.getTreeAgentIdsForTaskIds.mockResolvedValue({
+        'task-1': ['agent-a'],
+      });
+
+      mockAgentModel.getAgentAvatarsByIds.mockResolvedValue([
+        { avatar: '🤖', backgroundColor: null, id: 'agent-a', title: 'Agent A' },
+      ]);
+
+      const result = await service.enrichBriefsWithAgents(briefs);
+
+      expect(result[0].agents).toHaveLength(1);
+      expect(result[1].agents).toEqual([]);
+    });
+
+    it('should handle task with no agents in tree', async () => {
+      const service = new BriefService(db, userId);
+
+      const briefs = [{ id: 'b1', taskId: 'task-1', title: 'Brief' }] as any[];
+
+      mockTaskModel.getTreeAgentIdsForTaskIds.mockResolvedValue({});
+
+      const result = await service.enrichBriefsWithAgents(briefs);
+
+      expect(result[0].agents).toEqual([]);
+      expect(mockAgentModel.getAgentAvatarsByIds).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('list', () => {
+    it('should return enriched briefs with total', async () => {
+      const service = new BriefService(db, userId);
+
+      mockBriefModel.list.mockResolvedValue({
+        briefs: [{ id: 'b1', taskId: null, title: 'Brief' }],
+        total: 1,
+      });
+
+      const result = await service.list({ limit: 10, offset: 0 });
+
+      expect(result.total).toBe(1);
+      expect(result.briefs).toHaveLength(1);
+      expect(result.briefs[0].agents).toEqual([]);
+      expect(mockBriefModel.list).toHaveBeenCalledWith({ limit: 10, offset: 0 });
+    });
+  });
+
+  describe('listUnresolved', () => {
+    it('should return enriched unresolved briefs', async () => {
+      const service = new BriefService(db, userId);
+
+      mockBriefModel.listUnresolved.mockResolvedValue([
+        { id: 'b1', taskId: null, title: 'Unresolved' },
+      ]);
+
+      const result = await service.listUnresolved();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].agents).toEqual([]);
+      expect(mockBriefModel.listUnresolved).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/services/brief/index.ts
+++ b/src/server/services/brief/index.ts
@@ -1,0 +1,62 @@
+import { AgentModel } from '@/database/models/agent';
+import { BriefModel } from '@/database/models/brief';
+import { TaskModel } from '@/database/models/task';
+import type { BriefItem } from '@/database/schemas';
+import type { LobeChatDatabase } from '@/database/type';
+
+export interface AgentAvatarInfo {
+  avatar: string | null;
+  backgroundColor: string | null;
+  id: string;
+  title: string | null;
+}
+
+export type BriefWithAgents = BriefItem & { agents: AgentAvatarInfo[] };
+
+export class BriefService {
+  private agentModel: AgentModel;
+  private briefModel: BriefModel;
+  private taskModel: TaskModel;
+
+  constructor(db: LobeChatDatabase, userId: string) {
+    this.agentModel = new AgentModel(db, userId);
+    this.briefModel = new BriefModel(db, userId);
+    this.taskModel = new TaskModel(db, userId);
+  }
+
+  async enrichBriefsWithAgents(briefs: BriefItem[]): Promise<BriefWithAgents[]> {
+    const taskIds = briefs.map((b) => b.taskId).filter((id): id is string => id !== null);
+
+    if (taskIds.length === 0) {
+      return briefs.map((brief) => ({ ...brief, agents: [] }));
+    }
+
+    const taskAgentIdsMap = await this.taskModel.getTreeAgentIdsForTaskIds(taskIds);
+
+    const allAgentIds = [...new Set(Object.values(taskAgentIdsMap).flat())];
+    let agentMap: Record<string, AgentAvatarInfo> = {};
+
+    if (allAgentIds.length > 0) {
+      const agentList = await this.agentModel.getAgentAvatarsByIds(allAgentIds);
+      agentMap = Object.fromEntries(agentList.map((a) => [a.id, a]));
+    }
+
+    return briefs.map((brief) => ({
+      ...brief,
+      agents: (brief.taskId ? taskAgentIdsMap[brief.taskId] || [] : [])
+        .map((id) => agentMap[id])
+        .filter(Boolean),
+    }));
+  }
+
+  async list(options?: { limit?: number; offset?: number; type?: string }) {
+    const result = await this.briefModel.list(options);
+    const data = await this.enrichBriefsWithAgents(result.briefs);
+    return { briefs: data, total: result.total };
+  }
+
+  async listUnresolved() {
+    const items = await this.briefModel.listUnresolved();
+    return this.enrichBriefsWithAgents(items);
+  }
+}


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Fixes LOBE-6577

#### 🔀 Description of Change

Enrich brief `list` and `listUnresolved` endpoints with agent avatar data from the task tree.

- **`TaskModel.getTreeAgentIdsForTaskIds`**: New method using recursive CTE to walk UP from each brief's taskId to find roots, then DOWN to collect all agent IDs (assignee + creator) across full task trees
- **`AgentModel.getAgentAvatarsByIds`**: New batch method to fetch minimal agent info (id, avatar, title, backgroundColor)
- **`briefRouter.list` / `listUnresolved`**: Enriched via shared `enrichBriefsWithAgents` helper — each brief now includes an `agents` array

Response shape change:
```typescript
// Each brief in data[] now includes:
agents: Array<{ id: string; avatar: string | null; title: string | null; backgroundColor: string | null }>
```

#### 🧪 How to Test

- [x] No tests needed

#### 📝 Additional Information

Non-breaking change — `agents` is an additive field on existing brief items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)