### PR TITLE
refactor: consolidate imports and add electron styling to theme/lang buttons

### DIFF
--- a/src/features/User/UserPanel/LangButton.tsx
+++ b/src/features/User/UserPanel/LangButton.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { localeOptions } from '@/locales/resources';
 import { useGlobalStore } from '@/store/global';
 import { globalGeneralSelectors } from '@/store/global/selectors';
+import { electronStylish } from '@/styles/electron';
 
 const LangButton = memo<{ placement?: DropdownMenuProps['placement']; size?: number }>(
   ({ placement, size }) => {
@@ -101,6 +102,7 @@ const LangButton = memo<{ placement?: DropdownMenuProps['placement']; size?: num
         placement={placement}
         trigger="hover"
         popupProps={{
+          className: electronStylish.nodrag,
           style: {
             maxHeight: 360,
             minWidth: 240,

--- a/src/features/User/UserPanel/ThemeButton.tsx
+++ b/src/features/User/UserPanel/ThemeButton.tsx
@@ -2,9 +2,10 @@ import { type DropdownMenuProps } from '@lobehub/ui';
 import { ActionIcon, DropdownMenu, Icon } from '@lobehub/ui';
 import { Monitor, Moon, Sun } from 'lucide-react';
 import { useTheme as useNextThemesTheme } from 'next-themes';
-import { type FC } from 'react';
-import { useMemo } from 'react';
+import { type FC, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+
+import { electronStylish } from '@/styles/electron';
 
 const themeIcons = {
   dark: Moon,
@@ -45,7 +46,11 @@ const ThemeButton: FC<{ placement?: DropdownMenuProps['placement']; size?: numbe
   );
 
   return (
-    <DropdownMenu items={items} placement={placement}>
+    <DropdownMenu
+      items={items}
+      placement={placement}
+      popupProps={{ className: electronStylish.nodrag }}
+    >
       <ActionIcon
         icon={themeIcons[(theme as 'dark' | 'light' | 'system') || 'system']}
         size={size || { blockSize: 32, size: 16 }}


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

#### 🔀 Description of Change

This PR makes the following improvements to the UserPanel components:

1. **Import consolidation in ThemeButton.tsx**: Combined `FC` and `useMemo` imports from React into a single import statement for cleaner code organization.

2. **Electron styling integration**: Added `electronStylish` import and applied the `nodrag` class to dropdown menu popups in both `ThemeButton` and `LangButton` components via the `popupProps` prop. This ensures proper drag behavior in Electron environments.

The changes maintain existing functionality while improving code organization and adding necessary styling for Electron app compatibility.

#### 🧪 How to Test

- [x] Tested locally
- [x] No tests needed

The changes are straightforward refactoring and styling additions that don't alter component behavior. Existing functionality remains unchanged.

#### 📝 Additional Information

These changes ensure that dropdown menus in the theme and language selection buttons properly respect Electron's drag-to-move behavior by applying the `nodrag` class to prevent unintended window dragging when interacting with the dropdowns.

https://claude.ai/code/session_01K6FLLJ4PMhKWqbRmrGEZkS