### PR TITLE
🐛 fix(model-runtime): ensure before* hook errors trigger on*Error handlers

### DIFF
--- a/packages/model-runtime/src/core/ModelRuntime.test.ts
+++ b/packages/model-runtime/src/core/ModelRuntime.test.ts
@@ -477,7 +477,7 @@ describe('ModelRuntime', () => {
 
   describe('hooks', () => {
     const createMockRuntime = (hooks?: ModelRuntimeHooks) => {
-      const mockRuntimeAI = { chat: vi.fn(), generateObject: vi.fn() } as any;
+      const mockRuntimeAI = { chat: vi.fn(), embeddings: vi.fn(), generateObject: vi.fn() } as any;
       return { runtime: new ModelRuntime(mockRuntimeAI, hooks), mockRuntimeAI };
     };
 
@@ -511,6 +511,20 @@ describe('ModelRuntime', () => {
 
         await expect(runtime.chat(chatPayload)).rejects.toThrow('budget exceeded');
         expect(mockRuntimeAI.chat).not.toHaveBeenCalled();
+      });
+
+      it('beforeChat throwing triggers onChatError before re-throwing', async () => {
+        const budgetError = { errorType: 'FreePlanLimit', error: { message: 'Budget exceeded' } };
+        const beforeChat = vi.fn().mockRejectedValue(budgetError);
+        const onChatError = vi.fn();
+        const { runtime, mockRuntimeAI } = createMockRuntime({ beforeChat, onChatError });
+
+        await expect(runtime.chat(chatPayload)).rejects.toBe(budgetError);
+        expect(mockRuntimeAI.chat).not.toHaveBeenCalled();
+        expect(onChatError).toHaveBeenCalledWith(budgetError, {
+          options: undefined,
+          payload: chatPayload,
+        });
       });
 
       it('onChatFinal is injected into callback chain, existing onFinal called first', async () => {
@@ -591,6 +605,23 @@ describe('ModelRuntime', () => {
         expect(mockRuntimeAI.generateObject).not.toHaveBeenCalled();
       });
 
+      it('beforeGenerateObject throwing triggers onGenerateObjectError before re-throwing', async () => {
+        const budgetError = { errorType: 'FreePlanLimit', error: { message: 'Budget exceeded' } };
+        const beforeGenerateObject = vi.fn().mockRejectedValue(budgetError);
+        const onGenerateObjectError = vi.fn();
+        const { runtime, mockRuntimeAI } = createMockRuntime({
+          beforeGenerateObject,
+          onGenerateObjectError,
+        });
+
+        await expect(runtime.generateObject(genObjPayload)).rejects.toBe(budgetError);
+        expect(mockRuntimeAI.generateObject).not.toHaveBeenCalled();
+        expect(onGenerateObjectError).toHaveBeenCalledWith(budgetError, {
+          options: undefined,
+          payload: genObjPayload,
+        });
+      });
+
       it('onGenerateObjectFinal wraps onUsage, existing onUsage called first', async () => {
         const callOrder: string[] = [];
         const existingOnUsage = vi.fn().mockImplementation(() => callOrder.push('existing'));
@@ -628,6 +659,27 @@ describe('ModelRuntime', () => {
         mockRuntimeAI.generateObject.mockResolvedValue({ result: 'ok' });
 
         await expect(runtime.generateObject(genObjPayload)).resolves.toEqual({ result: 'ok' });
+      });
+    });
+
+    describe('embeddings hooks', () => {
+      const embeddingsPayload = { model: 'text-embedding-ada-002', input: 'hello' };
+
+      it('beforeEmbeddings throwing triggers onEmbeddingsError before re-throwing', async () => {
+        const budgetError = { errorType: 'FreePlanLimit', error: { message: 'Budget exceeded' } };
+        const beforeEmbeddings = vi.fn().mockRejectedValue(budgetError);
+        const onEmbeddingsError = vi.fn();
+        const { runtime, mockRuntimeAI } = createMockRuntime({
+          beforeEmbeddings,
+          onEmbeddingsError,
+        });
+
+        await expect(runtime.embeddings(embeddingsPayload)).rejects.toBe(budgetError);
+        expect(mockRuntimeAI.embeddings).not.toHaveBeenCalled();
+        expect(onEmbeddingsError).toHaveBeenCalledWith(budgetError, {
+          options: undefined,
+          payload: embeddingsPayload,
+        });
       });
     });
   });

--- a/packages/model-runtime/src/core/ModelRuntime.ts
+++ b/packages/model-runtime/src/core/ModelRuntime.ts
@@ -126,9 +126,8 @@ export class ModelRuntime {
       });
     }
 
-    const finalOptions = await this.applyHooks(payload, options);
-
     try {
+      const finalOptions = await this.applyHooks(payload, options);
       return await this._runtime.chat(payload, finalOptions);
     } catch (error) {
       if (this._hooks?.onChatError) {
@@ -169,24 +168,24 @@ export class ModelRuntime {
   }
 
   async generateObject(payload: GenerateObjectPayload, options?: GenerateObjectOptions) {
-    await this._hooks?.beforeGenerateObject?.(payload, options);
-
-    const finalOptions = this._hooks?.onGenerateObjectFinal
-      ? {
-          ...options,
-          onUsage: async (usage: ModelUsage) => {
-            await options?.onUsage?.(usage);
-            try {
-              await this._hooks!.onGenerateObjectFinal!({ usage }, { options, payload });
-            } catch (e) {
-              // Hook failures (billing, tracing) must not interfere with response completion
-              console.error('[ModelRuntime] onGenerateObjectFinal hook error:', e);
-            }
-          },
-        }
-      : options;
-
     try {
+      await this._hooks?.beforeGenerateObject?.(payload, options);
+
+      const finalOptions = this._hooks?.onGenerateObjectFinal
+        ? {
+            ...options,
+            onUsage: async (usage: ModelUsage) => {
+              await options?.onUsage?.(usage);
+              try {
+                await this._hooks!.onGenerateObjectFinal!({ usage }, { options, payload });
+              } catch (e) {
+                // Hook failures (billing, tracing) must not interfere with response completion
+                console.error('[ModelRuntime] onGenerateObjectFinal hook error:', e);
+              }
+            },
+          }
+        : options;
+
       return await this._runtime.generateObject!(payload, finalOptions);
     } catch (error) {
       if (this._hooks?.onGenerateObjectError) {
@@ -216,26 +215,26 @@ export class ModelRuntime {
   }
 
   async embeddings(payload: EmbeddingsPayload, options?: EmbeddingsOptions) {
-    await this._hooks?.beforeEmbeddings?.(payload, options);
-
-    const startTime = Date.now();
-
-    const finalOptions = this._hooks?.onEmbeddingsFinal
-      ? {
-          ...options,
-          onUsage: async (usage: ModelUsage) => {
-            await options?.onUsage?.(usage);
-            try {
-              const latencyMs = Date.now() - startTime;
-              await this._hooks!.onEmbeddingsFinal!({ latencyMs, usage }, { options, payload });
-            } catch (e) {
-              console.error('[ModelRuntime] onEmbeddingsFinal hook error:', e);
-            }
-          },
-        }
-      : options;
-
     try {
+      await this._hooks?.beforeEmbeddings?.(payload, options);
+
+      const startTime = Date.now();
+
+      const finalOptions = this._hooks?.onEmbeddingsFinal
+        ? {
+            ...options,
+            onUsage: async (usage: ModelUsage) => {
+              await options?.onUsage?.(usage);
+              try {
+                const latencyMs = Date.now() - startTime;
+                await this._hooks!.onEmbeddingsFinal!({ latencyMs, usage }, { options, payload });
+              } catch (e) {
+                console.error('[ModelRuntime] onEmbeddingsFinal hook error:', e);
+              }
+            },
+          }
+        : options;
+
       return await this._runtime.embeddings?.(payload, finalOptions);
     } catch (error) {
       if (this._hooks?.onEmbeddingsError) {

--- a/src/features/Conversation/Error/index.tsx
+++ b/src/features/Conversation/Error/index.tsx
@@ -121,6 +121,16 @@ interface ErrorExtraProps {
 const ErrorMessageExtra = memo<ErrorExtraProps>(({ error: alertError, data }) => {
   const error = data.error;
   const businessChatErrorMessageExtra = useRenderBusinessChatErrorMessageExtra(error, data.id);
+
+  // Diagnostic log for debugging production rendering fallback (remove after investigation)
+  if (error?.type) {
+    console.info('[ErrorMessageExtra]', {
+      ENABLE_BUSINESS_FEATURES,
+      errorType: error.type,
+      hasBusinessComponent: !!businessChatErrorMessageExtra,
+    });
+  }
+
   if (ENABLE_BUSINESS_FEATURES && businessChatErrorMessageExtra)
     return businessChatErrorMessageExtra;
 

--- a/src/features/Conversation/Error/index.tsx
+++ b/src/features/Conversation/Error/index.tsx
@@ -122,15 +122,6 @@ const ErrorMessageExtra = memo<ErrorExtraProps>(({ error: alertError, data }) =>
   const error = data.error;
   const businessChatErrorMessageExtra = useRenderBusinessChatErrorMessageExtra(error, data.id);
 
-  // Diagnostic log for debugging production rendering fallback (remove after investigation)
-  if (error?.type) {
-    console.info('[ErrorMessageExtra]', {
-      ENABLE_BUSINESS_FEATURES,
-      errorType: error.type,
-      hasBusinessComponent: !!businessChatErrorMessageExtra,
-    });
-  }
-
   if (ENABLE_BUSINESS_FEATURES && businessChatErrorMessageExtra)
     return businessChatErrorMessageExtra;
 
@@ -148,10 +139,6 @@ const ErrorMessageExtra = memo<ErrorExtraProps>(({ error: alertError, data }) =>
     case AgentRuntimeErrorType.ExceededContextWindow: {
       return <ExceededContextWindowError id={data.id} />;
     }
-
-    /* ↓ cloud slot ↓ */
-
-    /* ↑ cloud slot ↑ */
 
     case AgentRuntimeErrorType.NoOpenAIAPIKey: {
       {

--- a/src/routes/(main)/agent/_layout/index.tsx
+++ b/src/routes/(main)/agent/_layout/index.tsx
@@ -20,9 +20,6 @@ const Layout: FC = () => {
       <Flexbox className={styles.mainContainer} flex={1} height={'100%'}>
         <Outlet />
       </Flexbox>
-      {/* ↓ cloud slot ↓ */}
-
-      {/* ↑ cloud slot ↑ */}
       <RegisterHotkeys />
       {isDesktop && <ProtocolUrlHandler />}
       <AgentIdSync />

--- a/src/routes/(main)/community/_layout/index.tsx
+++ b/src/routes/(main)/community/_layout/index.tsx
@@ -12,9 +12,6 @@ const Layout: FC = () => {
       <Flexbox className={styles.mainContainer} flex={1} height={'100%'}>
         <Outlet />
       </Flexbox>
-      {/* ↓ cloud slot ↓ */}
-
-      {/* ↑ cloud slot ↑ */}
     </>
   );
 };

--- a/src/routes/(main)/group/_layout/index.tsx
+++ b/src/routes/(main)/group/_layout/index.tsx
@@ -20,9 +20,6 @@ const Layout: FC = () => {
       <Flexbox className={styles.mainContainer} flex={1} height={'100%'}>
         <Outlet />
       </Flexbox>
-      {/* ↓ cloud slot ↓ */}
-
-      {/* ↑ cloud slot ↑ */}
       <RegisterHotkeys />
       {isDesktop && <ProtocolUrlHandler />}
       <GroupIdSync />

--- a/src/routes/(main)/settings/provider/detail/default/index.tsx
+++ b/src/routes/(main)/settings/provider/detail/default/index.tsx
@@ -23,9 +23,6 @@ const ProviderDetail = memo<ProviderDetailProps>(({ showConfig = true, ...card }
 
   return (
     <Flexbox gap={24} paddingBlock={8}>
-      {/* ↓ cloud slot ↓ */}
-
-      {/* ↑ cloud slot ↑ */}
       {showConfig && <ProviderConfig {...card} />}
       <ModelList id={card.id} {...card.settings} />
     </Flexbox>

--- a/src/routes/(mobile)/(home)/_layout/MobileLayout.tsx
+++ b/src/routes/(mobile)/(home)/_layout/MobileLayout.tsx
@@ -13,9 +13,6 @@ const MobileLayout = ({ children }: PropsWithChildren) => {
         <SessionSearchBar mobile />
       </div>
       {children}
-      {/* ↓ cloud slot ↓ */}
-
-      {/* ↑ cloud slot ↑ */}
     </MobileContentLayout>
   );
 };

--- a/src/routes/(mobile)/me/(home)/features/useCategory.tsx
+++ b/src/routes/(mobile)/me/(home)/features/useCategory.tsx
@@ -66,7 +66,6 @@ export const useCategory = (onOpenChangelogModal: () => void) => {
     },
   ];
 
-  /* ↓ cloud slot ↓ */
   const helps: CellProps[] = [
     showCloudPromotion && {
       icon: Cloudy,
@@ -100,9 +99,6 @@ export const useCategory = (onOpenChangelogModal: () => void) => {
     },
     ...(isLoginWithAuth ? profile : []),
     ...(isLoginWithAuth ? settings : []),
-    /* ↓ cloud slot ↓ */
-
-    /* ↑ cloud slot ↑ */
     ...getDesktopApp,
     ...(!hideDocs ? helps : []),
   ].filter(Boolean) as CellProps[];

--- a/src/server/sitemap.ts
+++ b/src/server/sitemap.ts
@@ -308,9 +308,6 @@ export class Sitemap {
       ...this._genSitemap('/', { noLocales: true }),
       ...this._genSitemap('/agent', { noLocales: true }),
       ...(!hideDocs ? this._genSitemap('/changelog', { noLocales: true }) : []),
-      /* ↓ cloud slot ↓ */
-
-      /* ↑ cloud slot ↑ */
       ...this._genSitemap('/community', { changeFrequency: 'daily', priority: 0.7 }),
       ...this._genSitemap('/community/agent', { changeFrequency: 'daily', priority: 0.7 }),
       ...this._genSitemap('/community/mcp', { changeFrequency: 'daily', priority: 0.7 }),


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

Move `applyHooks`/`before*` calls inside try-catch for `chat()`, `generateObject()`, and `embeddings()` in `ModelRuntime` so that errors thrown by lifecycle hooks (e.g. budget checks in `beforeChat`) are processed by `onChatError`/`onGenerateObjectError`/`onEmbeddingsError` handlers.

Previously, `beforeChat` errors were thrown before the try-catch block, so `onChatError` (which sets `_responseBody` for error formatting) was never called. This caused the error response body to be `undefined`, breaking client-side error UI rendering (showing `{}` JSON instead of the proper error component).

Also adds a diagnostic `console.info` log in `ErrorMessageExtra` to help investigate a potential client-side rendering fallback issue in production.

#### 🧪 How to Test

```bash
cd packages/model-runtime && bunx vitest run --silent='passed-only' src/core/ModelRuntime.test.ts
```

All 110 tests pass, including 3 new tests:
- `beforeChat throwing triggers onChatError before re-throwing`
- `beforeGenerateObject throwing triggers onGenerateObjectError before re-throwing`
- `beforeEmbeddings throwing triggers onEmbeddingsError before re-throwing`