### PR TITLE
🔨 chore(task): add generic updateTaskConfig for safe config merging

### DIFF
--- a/packages/database/src/models/__tests__/task.test.ts
+++ b/packages/database/src/models/__tests__/task.test.ts
@@ -599,6 +599,95 @@ describe('TaskModel', () => {
     });
   });
 
+  describe('updateTaskConfig', () => {
+    it('should merge partial config into empty config', async () => {
+      const model = new TaskModel(serverDB, userId);
+      const task = await model.create({ instruction: 'Test' });
+
+      const updated = await model.updateTaskConfig(task.id, { model: 'gpt-4', provider: 'openai' });
+      expect(updated).not.toBeNull();
+      expect((updated!.config as Record<string, unknown>).model).toBe('gpt-4');
+      expect((updated!.config as Record<string, unknown>).provider).toBe('openai');
+    });
+
+    it('should deep merge into existing config', async () => {
+      const model = new TaskModel(serverDB, userId);
+      const task = await model.create({ instruction: 'Test' });
+
+      // Set initial config with checkpoint
+      await model.updateTaskConfig(task.id, {
+        checkpoint: { onAgentRequest: true, topic: { after: true } },
+      });
+
+      // Merge review config — checkpoint should be preserved
+      const updated = await model.updateTaskConfig(task.id, {
+        review: { enabled: true },
+      });
+
+      const config = updated!.config as Record<string, any>;
+      expect(config.checkpoint).toEqual({ onAgentRequest: true, topic: { after: true } });
+      expect(config.review).toEqual({ enabled: true });
+    });
+
+    it('should deep merge nested fields within a config key', async () => {
+      const model = new TaskModel(serverDB, userId);
+      const task = await model.create({ instruction: 'Test' });
+
+      // Set initial checkpoint config
+      await model.updateTaskConfig(task.id, {
+        checkpoint: { onAgentRequest: true, topic: { after: true } },
+      });
+
+      // Update checkpoint with additional nested field — deep merge should preserve existing fields
+      const updated = await model.updateTaskConfig(task.id, {
+        checkpoint: { topic: { before: true } },
+      });
+
+      const config = updated!.config as Record<string, any>;
+      expect(config.checkpoint.onAgentRequest).toBe(true);
+      expect(config.checkpoint.topic.after).toBe(true);
+      expect(config.checkpoint.topic.before).toBe(true);
+    });
+
+    it('should return null for non-existent task', async () => {
+      const model = new TaskModel(serverDB, userId);
+      const result = await model.updateTaskConfig('non-existent-id', { model: 'gpt-4' });
+      expect(result).toBeNull();
+    });
+
+    it('should work with updateCheckpointConfig delegating to updateTaskConfig', async () => {
+      const model = new TaskModel(serverDB, userId);
+      const task = await model.create({ instruction: 'Test' });
+
+      // Set some initial non-checkpoint config
+      await model.updateTaskConfig(task.id, { model: 'gpt-4' });
+
+      // Use updateCheckpointConfig — should preserve other config keys
+      await model.updateCheckpointConfig(task.id, { onAgentRequest: true });
+
+      const updated = (await model.findById(task.id))!;
+      const config = updated.config as Record<string, any>;
+      expect(config.model).toBe('gpt-4');
+      expect(config.checkpoint).toEqual({ onAgentRequest: true });
+    });
+
+    it('should work with updateReviewConfig delegating to updateTaskConfig', async () => {
+      const model = new TaskModel(serverDB, userId);
+      const task = await model.create({ instruction: 'Test' });
+
+      // Set some initial non-review config
+      await model.updateTaskConfig(task.id, { provider: 'anthropic' });
+
+      // Use updateReviewConfig — should preserve other config keys
+      await model.updateReviewConfig(task.id, { enabled: true, maxIterations: 3 });
+
+      const updated = (await model.findById(task.id))!;
+      const config = updated.config as Record<string, any>;
+      expect(config.provider).toBe('anthropic');
+      expect(config.review).toEqual({ enabled: true, maxIterations: 3 });
+    });
+  });
+
   describe('topic management', () => {
     it('should increment topic count', async () => {
       const model = new TaskModel(serverDB, userId);

--- a/packages/database/src/models/task.ts
+++ b/packages/database/src/models/task.ts
@@ -288,6 +288,21 @@ export class TaskModel {
     return result.length;
   }
 
+  // ========== Config ==========
+
+  /**
+   * Safely merge-update the task's config object.
+   * Reads the current config, shallow-merges the incoming partial, and writes back.
+   */
+  async updateTaskConfig(id: string, partial: Record<string, unknown>): Promise<TaskItem | null> {
+    const task = await this.findById(id);
+    if (!task) return null;
+
+    const current = (task.config as Record<string, unknown>) || {};
+    const config = { ...current, ...partial };
+    return this.update(id, { config });
+  }
+
   // ========== Checkpoint ==========
 
   getCheckpointConfig(task: TaskItem): CheckpointConfig {
@@ -295,11 +310,7 @@ export class TaskModel {
   }
 
   async updateCheckpointConfig(id: string, checkpoint: CheckpointConfig): Promise<TaskItem | null> {
-    const task = await this.findById(id);
-    if (!task) return null;
-
-    const config = { ...(task.config as Record<string, any>), checkpoint };
-    return this.update(id, { config });
+    return this.updateTaskConfig(id, { checkpoint });
   }
 
   // ========== Review Config ==========
@@ -309,11 +320,7 @@ export class TaskModel {
   }
 
   async updateReviewConfig(id: string, review: Record<string, any>): Promise<TaskItem | null> {
-    const task = await this.findById(id);
-    if (!task) return null;
-
-    const config = { ...(task.config as Record<string, any>), review };
-    return this.update(id, { config });
+    return this.updateTaskConfig(id, { review });
   }
 
   // Check if a task should pause after a topic completes

--- a/packages/database/src/models/task.ts
+++ b/packages/database/src/models/task.ts
@@ -6,6 +6,8 @@ import type {
 } from '@lobechat/types';
 import { and, desc, eq, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm';
 
+import { merge } from '@/utils/merge';
+
 import type { NewTask, NewTaskComment, TaskCommentItem, TaskItem } from '../schemas/task';
 import { taskComments, taskDependencies, taskDocuments, tasks } from '../schemas/task';
 import type { LobeChatDatabase } from '../type';
@@ -299,7 +301,7 @@ export class TaskModel {
     if (!task) return null;
 
     const current = (task.config as Record<string, unknown>) || {};
-    const config = { ...current, ...partial };
+    const config = merge(current, partial);
     return this.update(id, { config });
   }
 

--- a/src/server/routers/lambda/task.ts
+++ b/src/server/routers/lambda/task.ts
@@ -1167,6 +1167,27 @@ export const taskRouter = router({
     }
   }),
 
+  updateConfig: taskProcedure
+    .input(idInput.merge(z.object({ config: z.record(z.unknown()) })))
+    .mutation(async ({ input, ctx }) => {
+      const { id, config } = input;
+      try {
+        const model = ctx.taskModel;
+        const resolved = await resolveOrThrow(model, id);
+        const task = await model.updateTaskConfig(resolved.id, config);
+        if (!task) throw new TRPCError({ code: 'NOT_FOUND', message: 'Task not found' });
+        return { data: task, message: 'Config updated', success: true };
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        console.error('[task:updateConfig]', error);
+        throw new TRPCError({
+          cause: error,
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to update task config',
+        });
+      }
+    }),
+
   updateStatus: taskProcedure
     .input(
       z.object({

--- a/src/server/services/toolExecution/serverRuntimes/task.ts
+++ b/src/server/services/toolExecution/serverRuntimes/task.ts
@@ -129,8 +129,7 @@ const createTaskRuntime = ({
       changes.push(`priority → ${priorityLabel(args.priority)}`);
     }
     if (args.review) {
-      const currentConfig = (task.config as Record<string, any>) || {};
-      updateData.config = { ...currentConfig, review: { enabled: true, ...args.review } };
+      await taskModel.updateTaskConfig(task.id, { review: { enabled: true, ...args.review } });
       changes.push('review config updated');
     }
 


### PR DESCRIPTION
## Summary

- Add `updateTaskConfig` method to `TaskModel` for safely merge-updating the task config JSON (read → shallow merge → write)
- Add `task.updateConfig` TRPC procedure exposing the new generic method
- Refactor `updateCheckpointConfig` / `updateReviewConfig` to delegate to `updateTaskConfig`, eliminating duplicated merge logic
- Update tool execution runtime to use `updateTaskConfig` instead of manual config merging

Fixes LOBE-6634

## Test plan

- [x] All 54 existing task model tests pass
- [x] Type check passes
- [ ] Verify `updateConfig` TRPC endpoint works via client

🤖 Generated with [Claude Code](https://claude.com/claude-code)