### PR TITLE
🐛 fix: stream tool call arguments incrementally in Response API

### DIFF
--- a/packages/openapi/src/services/responses.service.ts
+++ b/packages/openapi/src/services/responses.service.ts
@@ -467,6 +467,12 @@ export class ResponsesService extends BaseService {
       let currentOutputIndex = 0;
       let itemCounter = 0;
       let textMessageStarted = false;
+
+      // Track active (in-progress) tool calls for proper incremental streaming
+      const activeToolCalls = new Map<
+        string,
+        { fcItemId: string; name: string; outputIndex: number; prevArguments: string }
+      >();
       let currentTextItemId = '';
 
       const startTextMessage = function* (seq: { n: number }) {
@@ -532,6 +538,35 @@ export class ResponsesService extends BaseService {
         currentOutputIndex++;
       };
 
+      const finishActiveToolCalls = function* (seq: { n: number }) {
+        for (const [callId, tc] of activeToolCalls) {
+          yield {
+            arguments: tc.prevArguments || '{}',
+            item_id: tc.fcItemId,
+            output_index: tc.outputIndex,
+            sequence_number: seq.n++,
+            type: 'response.function_call_arguments.done' as const,
+          };
+          yield {
+            item: {
+              arguments: tc.prevArguments || '{}',
+              call_id: callId,
+              id: tc.fcItemId,
+              name: tc.name,
+              status: 'completed' as const,
+              type: 'function_call' as const,
+            } as OutputItem,
+            output_index: tc.outputIndex,
+            sequence_number: seq.n++,
+            type: 'response.output_item.done' as const,
+          };
+        }
+        if (activeToolCalls.size > 0) {
+          currentOutputIndex += activeToolCalls.size;
+          activeToolCalls.clear();
+        }
+      };
+
       // Shared mutable sequence counter for generators
       const seq = { n: sequenceNumber };
 
@@ -563,69 +598,77 @@ export class ResponsesService extends BaseService {
               yield* finishTextMessage(seq, accumulatedText);
               accumulatedText = '';
 
-              // Emit function_call output items for each tool call
+              // Stream tool call deltas incrementally within stable output items
               for (const toolCall of chunk.toolsCalling) {
-                const fcItemId = `fc_${responseId}_${itemCounter++}`;
-                // Client function tools use original name; hosted tools use identifier/apiName
-                const isClientTool = toolCall.identifier === 'lobe-client-fn';
-                const toolDisplayName = isClientTool
-                  ? toolCall.apiName
-                  : `${toolCall.identifier}/${toolCall.apiName}`;
-                yield {
-                  item: {
-                    arguments: toolCall.arguments ?? '{}',
-                    call_id: toolCall.id,
-                    id: fcItemId,
-                    name: toolDisplayName,
-                    status: 'in_progress' as const,
-                    type: 'function_call' as const,
-                  } as OutputItem,
-                  output_index: currentOutputIndex,
-                  sequence_number: seq.n++,
-                  type: 'response.output_item.added' as const,
-                };
+                const callId = toolCall.id;
+                const existing = activeToolCalls.get(callId);
 
-                // Emit arguments delta
-                if (toolCall.arguments) {
+                if (!existing) {
+                  // First time seeing this tool call — emit output_item.added
+                  const fcItemId = `fc_${responseId}_${itemCounter++}`;
+                  const isClientTool = toolCall.identifier === 'lobe-client-fn';
+                  const toolDisplayName = isClientTool
+                    ? toolCall.apiName
+                    : `${toolCall.identifier}/${toolCall.apiName}`;
+                  const outputIndex = currentOutputIndex + activeToolCalls.size;
+
+                  activeToolCalls.set(callId, {
+                    fcItemId,
+                    name: toolDisplayName,
+                    outputIndex,
+                    prevArguments: '',
+                  });
+
                   yield {
-                    delta: toolCall.arguments,
-                    item_id: fcItemId,
-                    output_index: currentOutputIndex,
+                    item: {
+                      arguments: '',
+                      call_id: callId,
+                      id: fcItemId,
+                      name: toolDisplayName,
+                      status: 'in_progress' as const,
+                      type: 'function_call' as const,
+                    } as OutputItem,
+                    output_index: outputIndex,
                     sequence_number: seq.n++,
-                    type: 'response.function_call_arguments.delta' as const,
+                    type: 'response.output_item.added' as const,
                   };
+
+                  // Emit initial delta if arguments already present
+                  if (toolCall.arguments) {
+                    activeToolCalls.get(callId)!.prevArguments = toolCall.arguments;
+                    yield {
+                      delta: toolCall.arguments,
+                      item_id: fcItemId,
+                      output_index: outputIndex,
+                      sequence_number: seq.n++,
+                      type: 'response.function_call_arguments.delta' as const,
+                    };
+                  }
+                } else {
+                  // Subsequent chunk — compute incremental delta
+                  const currentArgs = toolCall.arguments ?? '';
+                  const delta = currentArgs.slice(existing.prevArguments.length);
+
+                  if (delta) {
+                    existing.prevArguments = currentArgs;
+                    yield {
+                      delta,
+                      item_id: existing.fcItemId,
+                      output_index: existing.outputIndex,
+                      sequence_number: seq.n++,
+                      type: 'response.function_call_arguments.delta' as const,
+                    };
+                  }
                 }
-
-                // Emit arguments done
-                yield {
-                  arguments: toolCall.arguments ?? '{}',
-                  item_id: fcItemId,
-                  output_index: currentOutputIndex,
-                  sequence_number: seq.n++,
-                  type: 'response.function_call_arguments.done' as const,
-                };
-
-                // Complete the function_call item
-                yield {
-                  item: {
-                    arguments: toolCall.arguments ?? '{}',
-                    call_id: toolCall.id,
-                    id: fcItemId,
-                    name: toolDisplayName,
-                    status: 'completed' as const,
-                    type: 'function_call' as const,
-                  } as OutputItem,
-                  output_index: currentOutputIndex,
-                  sequence_number: seq.n++,
-                  type: 'response.output_item.done' as const,
-                };
-                currentOutputIndex++;
               }
             } else if (chunk.chunkType === 'reasoning' && chunk.reasoning) {
               // Emit reasoning as text delta (within a text message)
               yield* startTextMessage(seq);
             }
           } else if (event.type === 'tool_end') {
+            // Finalize any remaining active tool calls before emitting tool output
+            yield* finishActiveToolCalls(seq);
+
             // Emit function_call_output for completed tool execution
             const toolData = event.data as {
               isSuccess: boolean;
@@ -662,6 +705,9 @@ export class ResponsesService extends BaseService {
           }
         }
       }
+
+      // Finalize any in-progress tool calls
+      yield* finishActiveToolCalls(seq);
 
       // Close any remaining open text message
       yield* finishTextMessage(seq, accumulatedText);

--- a/packages/openapi/src/services/responses.service.ts
+++ b/packages/openapi/src/services/responses.service.ts
@@ -702,6 +702,10 @@ export class ResponsesService extends BaseService {
               type: 'response.output_item.done' as const,
             };
             currentOutputIndex++;
+          } else if (event.type === 'stream_retry') {
+            // LLM retry — discard stale tool call state from the failed attempt
+            // so we don't emit phantom function_calls on final flush
+            activeToolCalls.clear();
           }
         }
       }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- Response API tool call streaming broken -->

#### 🔀 Description of Change

Fix Response API streaming for tool calls. The internal `tools_calling` stream chunks contain **accumulated** arguments (the full string up to that point), but the Response API was treating each chunk as a complete independent `output_item` — emitting a full lifecycle (`added → delta → done → item.done`) per token delta and incrementing `output_index` from 0 to 90+.

**Before:** Each token delta creates a new output_item:
```
output_index=0: added → delta("") → done → item.done
output_index=1: added → delta('{"des') → done → item.done
output_index=2: added → delta('{"description"') → done → item.done
... up to output_index=93
```

**After:** Single stable output_item with true incremental deltas:
```
output_index=1: added (in_progress)
output_index=1: delta('{"des')
output_index=1: delta('cription"')
output_index=1: delta(': "生成')
... 
output_index=1: arguments.done → item.done (completed)
```

**Implementation:**
- Track active tool calls in a `Map<callId, {fcItemId, outputIndex, prevArguments}>`
- First chunk: emit `output_item.added` + initial delta
- Subsequent chunks: compute incremental delta via `args.slice(prevArgs.length)`
- Finalize with `arguments.done` + `output_item.done` when stream ends or `tool_end` arrives

#### 🧪 How to Test

- [ ] Tested locally
- [ ] No tests needed (no existing test infra for openapi package)

Test with: `POST /api/v1/responses` with a model that returns tool calls (e.g., code sandbox). Verify:
1. `output_index` stays stable per tool call
2. `delta` fields contain only incremental content
3. Only one `output_item.added` / `output_item.done` pair per tool call
4. `response.completed` output matches the streamed tool call

🤖 Generated with [Claude Code](https://claude.com/claude-code)