### PR TITLE
🔨 chore(i18n): remove unused suspectedReason locale key

### DIFF
--- a/locales/ar/subscription.json
+++ b/locales/ar/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "مكافأتي",
   "referral.table.columns.rewardedAt": "وقت المكافأة",
   "referral.table.columns.status": "الحالة",
-  "referral.table.columns.suspectedReason": "سبب الشك",
   "referral.table.status.pending_reward": "المكافأة المعلقة",
   "referral.table.status.registered": "مسجل",
   "referral.table.status.revoked": "تم الإلغاء",

--- a/locales/bg-BG/subscription.json
+++ b/locales/bg-BG/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "Моята награда",
   "referral.table.columns.rewardedAt": "Време на награждаване",
   "referral.table.columns.status": "Статус",
-  "referral.table.columns.suspectedReason": "Причина за аномалия",
   "referral.table.status.pending_reward": "Очаквана награда",
   "referral.table.status.registered": "Регистриран",
   "referral.table.status.revoked": "Отменен",

--- a/locales/de-DE/subscription.json
+++ b/locales/de-DE/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "Meine Belohnung",
   "referral.table.columns.rewardedAt": "Belohnungszeitpunkt",
   "referral.table.columns.status": "Status",
-  "referral.table.columns.suspectedReason": "Grund für Anomalie",
   "referral.table.status.pending_reward": "Ausstehende Belohnung",
   "referral.table.status.registered": "Registriert",
   "referral.table.status.revoked": "Widerrufen",

--- a/locales/en-US/subscription.json
+++ b/locales/en-US/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "My Reward",
   "referral.table.columns.rewardedAt": "Reward Time",
   "referral.table.columns.status": "Status",
-  "referral.table.columns.suspectedReason": "Anomaly Reason",
   "referral.table.status.pending_reward": "Under Review",
   "referral.table.status.registered": "Registered",
   "referral.table.status.revoked": "Revoked",

--- a/locales/es-ES/subscription.json
+++ b/locales/es-ES/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "Mi Recompensa",
   "referral.table.columns.rewardedAt": "Fecha de Recompensa",
   "referral.table.columns.status": "Estado",
-  "referral.table.columns.suspectedReason": "Motivo de Anomalía",
   "referral.table.status.pending_reward": "Recompensa Pendiente",
   "referral.table.status.registered": "Registrado",
   "referral.table.status.revoked": "Revocado",

--- a/locales/fa-IR/subscription.json
+++ b/locales/fa-IR/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "پاداش من",
   "referral.table.columns.rewardedAt": "زمان دریافت پاداش",
   "referral.table.columns.status": "وضعیت",
-  "referral.table.columns.suspectedReason": "دلیل مشکوک بودن",
   "referral.table.status.pending_reward": "پاداش در انتظار",
   "referral.table.status.registered": "ثبت‌نام شده",
   "referral.table.status.revoked": "لغو شده",

--- a/locales/fr-FR/subscription.json
+++ b/locales/fr-FR/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "Ma récompense",
   "referral.table.columns.rewardedAt": "Date de récompense",
   "referral.table.columns.status": "Statut",
-  "referral.table.columns.suspectedReason": "Raison de l’anomalie",
   "referral.table.status.pending_reward": "Récompense en attente",
   "referral.table.status.registered": "Inscrit",
   "referral.table.status.revoked": "Révoqué",

--- a/locales/it-IT/subscription.json
+++ b/locales/it-IT/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "Mia Ricompensa",
   "referral.table.columns.rewardedAt": "Data Ricompensa",
   "referral.table.columns.status": "Stato",
-  "referral.table.columns.suspectedReason": "Motivo Anomalia",
   "referral.table.status.pending_reward": "Ricompensa in sospeso",
   "referral.table.status.registered": "Registrato",
   "referral.table.status.revoked": "Revocato",

--- a/locales/ja-JP/subscription.json
+++ b/locales/ja-JP/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "自分の報酬",
   "referral.table.columns.rewardedAt": "報酬付与日時",
   "referral.table.columns.status": "ステータス",
-  "referral.table.columns.suspectedReason": "異常理由",
   "referral.table.status.pending_reward": "保留中の報酬",
   "referral.table.status.registered": "登録済み",
   "referral.table.status.revoked": "取り消し",

--- a/locales/ko-KR/subscription.json
+++ b/locales/ko-KR/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "내 보상",
   "referral.table.columns.rewardedAt": "보상 시간",
   "referral.table.columns.status": "상태",
-  "referral.table.columns.suspectedReason": "이상 사유",
   "referral.table.status.pending_reward": "보상 대기 중",
   "referral.table.status.registered": "가입 완료",
   "referral.table.status.revoked": "취소됨",

--- a/locales/nl-NL/subscription.json
+++ b/locales/nl-NL/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "Mijn Beloning",
   "referral.table.columns.rewardedAt": "Beloningstijd",
   "referral.table.columns.status": "Status",
-  "referral.table.columns.suspectedReason": "Reden Afwijking",
   "referral.table.status.pending_reward": "In afwachting van beloning",
   "referral.table.status.registered": "Geregistreerd",
   "referral.table.status.revoked": "Ingetrokken",

--- a/locales/pl-PL/subscription.json
+++ b/locales/pl-PL/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "Moja Nagroda",
   "referral.table.columns.rewardedAt": "Czas Przyznania Nagrody",
   "referral.table.columns.status": "Status",
-  "referral.table.columns.suspectedReason": "Powód Nieprawidłowości",
   "referral.table.status.pending_reward": "Oczekująca Nagroda",
   "referral.table.status.registered": "Zarejestrowany",
   "referral.table.status.revoked": "Cofnięty",

--- a/locales/pt-BR/subscription.json
+++ b/locales/pt-BR/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "Minha Recompensa",
   "referral.table.columns.rewardedAt": "Data da Recompensa",
   "referral.table.columns.status": "Status",
-  "referral.table.columns.suspectedReason": "Motivo da Anomalia",
   "referral.table.status.pending_reward": "Recompensa Pendente",
   "referral.table.status.registered": "Registrado",
   "referral.table.status.revoked": "Revogado",

--- a/locales/ru-RU/subscription.json
+++ b/locales/ru-RU/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "Моя награда",
   "referral.table.columns.rewardedAt": "Дата награды",
   "referral.table.columns.status": "Статус",
-  "referral.table.columns.suspectedReason": "Причина подозрения",
   "referral.table.status.pending_reward": "Ожидаемое вознаграждение",
   "referral.table.status.registered": "Зарегистрирован",
   "referral.table.status.revoked": "Отменено",

--- a/locales/tr-TR/subscription.json
+++ b/locales/tr-TR/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "Benim Ödülüm",
   "referral.table.columns.rewardedAt": "Ödül Zamanı",
   "referral.table.columns.status": "Durum",
-  "referral.table.columns.suspectedReason": "Anomali Nedeni",
   "referral.table.status.pending_reward": "Bekleyen Ödül",
   "referral.table.status.registered": "Kayıtlı",
   "referral.table.status.revoked": "İptal Edildi",

--- a/locales/vi-VN/subscription.json
+++ b/locales/vi-VN/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "Phần thưởng của tôi",
   "referral.table.columns.rewardedAt": "Thời gian nhận thưởng",
   "referral.table.columns.status": "Trạng thái",
-  "referral.table.columns.suspectedReason": "Lý do nghi ngờ",
   "referral.table.status.pending_reward": "Phần thưởng đang chờ",
   "referral.table.status.registered": "Đã đăng ký",
   "referral.table.status.revoked": "Đã thu hồi",

--- a/locales/zh-CN/subscription.json
+++ b/locales/zh-CN/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "我的奖励",
   "referral.table.columns.rewardedAt": "奖励时间",
   "referral.table.columns.status": "状态",
-  "referral.table.columns.suspectedReason": "异常原因",
   "referral.table.status.pending_reward": "审核中",
   "referral.table.status.registered": "已注册",
   "referral.table.status.revoked": "已撤销",

--- a/locales/zh-TW/subscription.json
+++ b/locales/zh-TW/subscription.json
@@ -359,7 +359,6 @@
   "referral.table.columns.inviterRewardAmount": "我的獎勵",
   "referral.table.columns.rewardedAt": "獎勵時間",
   "referral.table.columns.status": "狀態",
-  "referral.table.columns.suspectedReason": "異常原因",
   "referral.table.status.pending_reward": "待處理獎勵",
   "referral.table.status.registered": "已註冊",
   "referral.table.status.revoked": "已撤銷",

--- a/src/locales/default/subscription.ts
+++ b/src/locales/default/subscription.ts
@@ -418,7 +418,6 @@ export default {
   'referral.table.columns.inviterRewardAmount': 'My Reward',
   'referral.table.columns.rewardedAt': 'Reward Time',
   'referral.table.columns.status': 'Status',
-  'referral.table.columns.suspectedReason': 'Anomaly Reason',
   'referral.table.status.pending_reward': 'Under Review',
   'referral.table.status.registered': 'Registered',
   'referral.table.status.revoked': 'Revoked',


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Remove unused `referral.table.columns.suspectedReason` i18n key from default locale and all 18 translation files.

#### 🧪 How to Test

- [x] No tests needed