### PR TITLE
🐛 fix(task): include config in getTaskDetail response

### DIFF
--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -77,6 +77,7 @@ export interface TaskDetailData {
   activities?: TaskDetailActivity[];
   agentId?: string | null;
   checkpoint?: CheckpointConfig;
+  config?: Record<string, unknown>;
   createdAt?: string;
   dependencies?: Array<{ dependsOn: string; type: string }>;
   description?: string | null;

--- a/src/server/services/task/index.ts
+++ b/src/server/services/task/index.ts
@@ -125,6 +125,7 @@ export class TaskService {
     return {
       agentId: task.assigneeAgentId,
       checkpoint: this.taskModel.getCheckpointConfig(task),
+      config: task.config ? (task.config as Record<string, unknown>) : undefined,
       createdAt: task.createdAt ? new Date(task.createdAt).toISOString() : undefined,
       dependencies: dependencies.map((d) => {
         const info = depIdToInfo.get(d.dependsOnId);


### PR DESCRIPTION
## Summary

`getTaskDetail` was extracting `checkpoint` and `review` from the task's `config` JSONB column, but not returning the `config` object itself. This meant model/provider overrides written via `task.updateConfig` (#13502) could never be read back by the frontend.

Adds `config` to the detail response so `TaskDetailData.config.model` / `TaskDetailData.config.provider` selectors work end-to-end.

## Changes

- `src/server/services/task/index.ts`: Add `config` field to `getTaskDetail` return value

## Test plan

- [x] Write model override via `task.updateConfig` → call `task.detail` → verify `config.model` and `config.provider` are present in response

cc @arvinxx

🤖 Generated with [Claude Code](https://claude.com/claude-code)