### PR TITLE
🔒 fix: sanitize HTML artifact content and sandbox iframe to prevent XSS-to-RCE

### DIFF
--- a/packages/utils/src/client/sanitize.ts
+++ b/packages/utils/src/client/sanitize.ts
@@ -1,5 +1,38 @@
 import DOMPurify from 'dompurify';
 
+const FORBID_EVENT_HANDLERS = [
+  'onblur',
+  'onchange',
+  'onclick',
+  'onerror',
+  'onfocus',
+  'onkeydown',
+  'onkeypress',
+  'onkeyup',
+  'onload',
+  'onmousedown',
+  'onmouseout',
+  'onmouseover',
+  'onmouseup',
+  'onreset',
+  'onselect',
+  'onsubmit',
+  'onunload',
+];
+
+/**
+ * Sanitizes HTML content to prevent XSS attacks while preserving safe HTML elements
+ * @param content - The HTML content to sanitize
+ * @returns Sanitized HTML content safe for rendering
+ */
+export const sanitizeHTMLContent = (content: string): string => {
+  return DOMPurify.sanitize(content, {
+    FORBID_ATTR: FORBID_EVENT_HANDLERS,
+    FORBID_TAGS: ['embed', 'link', 'meta', 'object', 'script'],
+    KEEP_CONTENT: true,
+  });
+};
+
 /**
  * Sanitizes SVG content to prevent XSS attacks while preserving safe SVG elements and attributes
  * @param content - The SVG content to sanitize
@@ -7,25 +40,7 @@ import DOMPurify from 'dompurify';
  */
 export const sanitizeSVGContent = (content: string): string => {
   return DOMPurify.sanitize(content, {
-    FORBID_ATTR: [
-      'onblur',
-      'onchange',
-      'onclick',
-      'onerror',
-      'onfocus',
-      'onkeydown',
-      'onkeypress',
-      'onkeyup',
-      'onload',
-      'onmousedown',
-      'onmouseout',
-      'onmouseover',
-      'onmouseup',
-      'onreset',
-      'onselect',
-      'onsubmit',
-      'onunload',
-    ],
+    FORBID_ATTR: FORBID_EVENT_HANDLERS,
     FORBID_TAGS: ['embed', 'link', 'object', 'script', 'style'],
     KEEP_CONTENT: false,
     USE_PROFILES: { svg: true, svgFilters: true },

--- a/src/features/Portal/Artifacts/Body/Renderer/HTML.tsx
+++ b/src/features/Portal/Artifacts/Body/Renderer/HTML.tsx
@@ -1,4 +1,5 @@
-import { memo, useEffect, useRef } from 'react';
+import { sanitizeHTMLContent } from '@lobehub/utils/client';
+import { memo, useMemo } from 'react';
 
 interface HTMLRendererProps {
   height?: string;
@@ -6,20 +7,16 @@ interface HTMLRendererProps {
   width?: string;
 }
 const HTMLRenderer = memo<HTMLRendererProps>(({ htmlContent, width = '100%', height = '100%' }) => {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const sanitizedContent = useMemo(() => sanitizeHTMLContent(htmlContent), [htmlContent]);
 
-  useEffect(() => {
-    if (!iframeRef.current) return;
-
-    const doc = iframeRef.current.contentDocument;
-    if (!doc) return;
-
-    doc.open();
-    doc.write(htmlContent);
-    doc.close();
-  }, [htmlContent]);
-
-  return <iframe ref={iframeRef} style={{ border: 'none', height, width }} title="html-renderer" />;
+  return (
+    <iframe
+      sandbox=""
+      srcDoc={sanitizedContent}
+      style={{ border: 'none', height, width }}
+      title="html-renderer"
+    />
+  );
 });
 
 export default HTMLRenderer;

--- a/src/features/Portal/Artifacts/Body/Renderer/HTML.tsx
+++ b/src/features/Portal/Artifacts/Body/Renderer/HTML.tsx
@@ -1,4 +1,4 @@
-import { sanitizeHTMLContent } from '@lobehub/utils/client';
+import { sanitizeHTMLContent } from '@lobechat/utils/client';
 import { memo, useMemo } from 'react';
 
 interface HTMLRendererProps {


### PR DESCRIPTION
## Summary
- Add `sanitizeHTMLContent()` using DOMPurify to strip dangerous tags (`script`, `embed`, `object`, `link`, `meta`) and all `on*` event handler attributes from HTML artifact content
- Add `sandbox=""` attribute to the HTML artifact iframe, blocking all script execution and `window.parent` access
- Replace `doc.write()` with `srcDoc` for cleaner, safer rendering
- Extract shared `FORBID_EVENT_HANDLERS` list to DRY up SVG and HTML sanitization

## Security
Fixes [GHSA-xq4x-622m-q8fq](https://github.com/lobehub/lobehub/security/advisories/GHSA-xq4x-622m-q8fq) — a critical XSS-to-RCE vulnerability where a malicious LLM provider can inject `<img src=x onerror='...'>` inside `<lobeArtifact>` tags, executing arbitrary commands via Electron's `shellCommand` API.

**Defense-in-depth approach:**
1. **DOMPurify sanitization** — strips dangerous tags and event handler attributes before rendering
2. **Iframe sandbox** — even if sanitization is bypassed, `sandbox=""` prevents all script execution and parent frame access

## Test plan
- [x] Existing `sanitize.test.ts` tests pass (6/6)
- [ ] Verify `<lobeArtifact type="text/html">` still renders safe HTML correctly
- [ ] Verify `<img src=x onerror='alert(1)'>` inside artifact is stripped and does not execute
- [ ] Verify SVG artifacts still render correctly (shared `FORBID_EVENT_HANDLERS` refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)