### PR TITLE
📝 docs: sync contributing guide branding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Lobe Chat - Contributing Guide 🌟
+# LobeHub - Contributing Guide 🌟
 
-We're thrilled that you want to contribute to Lobe Chat, the future of communication! 😄
+We're thrilled that you want to contribute to LobeHub, the future of communication! 😄
 
-Lobe Chat is an open-source project, and we welcome your collaboration. Before you jump in, let's make sure you're all set to contribute effectively and have loads of fun along the way!
+LobeHub is an open-source project, and we welcome your collaboration. Before you jump in, let's make sure you're all set to contribute effectively and have loads of fun along the way!
 
 ## Table of Contents
 
@@ -69,11 +69,11 @@ git fetch upstream
 git merge upstream/main
 ```
 
-This ensures you're working on the most current version of Lobe Chat. Stay fresh! 💨
+This ensures you're working on the most current version of LobeHub. Stay fresh! 💨
 
 ## Open a Pull Request
 
-🚀 Time to share your contribution! Head over to the original Lobe Chat repository and open a Pull Request (PR). Our maintainers will review your work.
+🚀 Time to share your contribution! Head over to the original LobeHub repository and open a Pull Request (PR). Our maintainers will review your work.
 
 ## Review and Collaboration
 
@@ -81,8 +81,8 @@ This ensures you're working on the most current version of Lobe Chat. Stay fresh
 
 ## Celebrate 🎉
 
-🎈 Congratulations! Your contribution is now part of Lobe Chat. 🥳
+🎈 Congratulations! Your contribution is now part of LobeHub. 🥳
 
-Thank you for making Lobe Chat even more magical. We can't wait to see what you create! 🌠
+Thank you for making LobeHub even more magical. We can't wait to see what you create! 🌠
 
 Happy Coding! 🚀🦄

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lobehub/lobehub",
-  "version": "2.1.46",
+  "version": "2.1.47",
   "description": "LobeHub - an open-source,comprehensive AI Agent framework that supports speech synthesis, multimodal, and extensible Function Call plugin system. Supports one-click free deployment of your private ChatGPT/LLM web application.",
   "keywords": [
     "framework",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lobehub/lobehub",
-  "version": "2.1.47",
+  "version": "2.1.46",
   "description": "LobeHub - an open-source,comprehensive AI Agent framework that supports speech synthesis, multimodal, and extensible Function Call plugin system. Supports one-click free deployment of your private ChatGPT/LLM web application.",
   "keywords": [
     "framework",


### PR DESCRIPTION
## Summary
- replace stale `Lobe Chat` branding in `CONTRIBUTING.md` with the current `LobeHub` project name
- keep the existing contribution flow intact while aligning the guide with the repository branding used in `README.md` and the repo name

## Why
The repository and README now consistently use `LobeHub`, but the contribution guide still refers to the project as `Lobe Chat` in multiple places. This makes the contributor entrypoint look stale even though the repo branding has already moved on.

## Validation
- compared `CONTRIBUTING.md` with `README.md` and the current repository name
- verified that this change only updates the stale project name references