### PR TITLE
🐛 fix: hide copy link button when share visibility is private

### DIFF
--- a/src/features/SharePopover/index.tsx
+++ b/src/features/SharePopover/index.tsx
@@ -227,9 +227,11 @@ const SharePopoverContent = memo<SharePopoverContentProps>(({ onOpenModal }) => 
         >
           {t('shareModal.popover.moreOptions')}
         </Button>
-        <Button icon={LinkIcon} size="small" type="primary" onClick={handleCopyLink}>
-          {t('shareModal.copyLink')}
-        </Button>
+        {currentVisibility !== 'private' && (
+          <Button icon={LinkIcon} size="small" type="primary" onClick={handleCopyLink}>
+            {t('shareModal.copyLink')}
+          </Button>
+        )}
       </Flexbox>
     </Flexbox>
   );


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Hide the "Copy Link" button in the Share Topic popover when the visibility is set to "Private". Copying a private link is meaningless since only the owner can access it, and showing the button may confuse users.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Open a topic and click the share icon
2. When visibility is "Private", the "Copy Link" button should not appear
3. Switch visibility to "Anyone with the link", the "Copy Link" button should appear

#### 📝 Additional Information

N/A