### PR TITLE
docs: clarify WeChat channel availability

### DIFF
--- a/docs/usage/channels/overview.mdx
+++ b/docs/usage/channels/overview.mdx
@@ -25,6 +25,10 @@ tags:
 
 Channels allow you to connect your LobeHub agents to external messaging platforms. Once connected, users can interact with your AI assistant directly in the chat apps they already use — no need to visit LobeHub.
 
+> [!NOTE]
+>
+> WeChat currently requires an active subscription. If you are using the community edition without a subscription, the WeChat channel option may not appear in the Channels settings yet.
+
 ## Supported Platforms
 
 | Platform                                   | Description                                                     |
@@ -33,7 +37,7 @@ Channels allow you to connect your LobeHub agents to external messaging platform
 | [Slack](/docs/usage/channels/slack)        | Connect to Slack for channel and direct message conversations   |
 | [Telegram](/docs/usage/channels/telegram)  | Connect to Telegram for private and group conversations         |
 | [QQ](/docs/usage/channels/qq)              | Connect to QQ for group chats and direct messages               |
-| [WeChat (微信)](/docs/usage/channels/wechat) | Connect to WeChat via iLink Bot for private and group chats     |
+| [WeChat (微信)](/docs/usage/channels/wechat) | Connect to WeChat via iLink Bot for private and group chats (requires an active subscription) |
 | [Feishu (飞书)](/docs/usage/channels/feishu) | Connect to Feishu for team collaboration (Chinese version)      |
 | [Lark](/docs/usage/channels/lark)          | Connect to Lark for team collaboration (international version)  |
 
@@ -57,6 +61,8 @@ Each channel integration works by linking a bot account on the target platform t
    - [WeChat (微信)](/docs/usage/channels/wechat)
    - [Feishu (飞书)](/docs/usage/channels/feishu)
    - [Lark](/docs/usage/channels/lark)
+
+If you do not see **WeChat** in the channel list, check that your account has an active subscription first.
 
 ## Feature Support
 

--- a/docs/usage/channels/overview.zh-CN.mdx
+++ b/docs/usage/channels/overview.zh-CN.mdx
@@ -24,6 +24,10 @@ tags:
 
 渠道功能允许您将 LobeHub 代理连接到外部消息平台。一旦连接，用户可以直接在他们已经使用的聊天应用中与您的 AI 助手互动，无需访问 LobeHub。
 
+> [!NOTE]
+>
+> 微信渠道目前需要有效订阅。如果您使用的是没有订阅的社区版，**渠道**设置中可能暂时不会显示微信选项。
+
 ## 支持的平台
 
 | 平台                                        | 描述                         |
@@ -32,7 +36,7 @@ tags:
 | [Slack](/docs/usage/channels/slack)       | 连接到 Slack，用于频道和私信对话        |
 | [Telegram](/docs/usage/channels/telegram) | 连接到 Telegram，用于私人和群组对话     |
 | [QQ](/docs/usage/channels/qq)             | 连接到 QQ，用于群聊和私信             |
-| [微信](/docs/usage/channels/wechat)         | 通过 iLink Bot 连接到微信，用于私聊和群聊 |
+| [微信](/docs/usage/channels/wechat)         | 通过 iLink Bot 连接到微信，用于私聊和群聊（需要有效订阅） |
 | [飞书](/docs/usage/channels/feishu)         | 连接到飞书，用于团队协作（中国版）          |
 | [Lark](/docs/usage/channels/lark)         | 连接到 Lark，用于团队协作（国际版）       |
 
@@ -56,6 +60,8 @@ tags:
    - [微信](/docs/usage/channels/wechat)
    - [飞书](/docs/usage/channels/feishu)
    - [Lark](/docs/usage/channels/lark)
+
+如果您在渠道列表中看不到 **微信**，请先确认当前账户是否拥有有效订阅。
 
 ## 功能支持
 


### PR DESCRIPTION
## Summary
- clarify in the channels overview that WeChat currently requires an active subscription
- note that community edition users may not see the WeChat option in channel settings yet
- keep the English and Chinese overview pages aligned

## Testing
- `git diff --check`

Related to #13461.
