### PR TITLE
Fix GNOME Shell D-Bus freeze on Linux desktop notifications

### DIFF
--- a/apps/desktop/src/main/controllers/NotificationCtr.ts
+++ b/apps/desktop/src/main/controllers/NotificationCtr.ts
@@ -3,7 +3,7 @@ import type {
   ShowDesktopNotificationParams,
 } from '@lobechat/electron-client-ipc';
 import { app, Notification } from 'electron';
-import { macOS, windows } from 'electron-is';
+import { linux, macOS, windows } from 'electron-is';
 
 import { getIpcContext } from '@/utils/ipc';
 import { createLogger } from '@/utils/logger';
@@ -14,6 +14,14 @@ const logger = createLogger('controllers:NotificationCtr');
 
 export default class NotificationCtr extends ControllerModule {
   static override readonly groupName = 'notification';
+
+  /**
+   * Track active notifications so we can clean up properly.
+   * On Linux/GNOME, lingering Notification objects can cause the rendering
+   * thread to block when the user dismisses them, so we proactively close
+   * the previous notification before creating a new one.
+   */
+  private activeNotification: Electron.Notification | null = null;
 
   @IpcMethod()
   async getNotificationPermissionStatus(): Promise<string> {
@@ -93,11 +101,35 @@ export default class NotificationCtr extends ControllerModule {
         logger.debug('Set Windows App User Model ID for notifications');
       }
 
+      if (linux()) {
+        logger.debug(
+          'Linux detected – notifications will use low urgency and non-blocking dispatch ' +
+            'to work around GNOME Shell D-Bus freeze issues',
+        );
+      }
+
       logger.info('Desktop notifications setup completed');
     } catch (error) {
       logger.error('Failed to setup desktop notifications:', error);
     }
   }
+  /**
+   * Close and dereference the active notification to prevent resource leaks.
+   * On Linux/GNOME this is critical: lingering Notification handles can cause
+   * the rendering thread to block when the desktop environment tries to
+   * dismiss them.
+   */
+  private cleanupActiveNotification() {
+    if (this.activeNotification) {
+      try {
+        this.activeNotification.close();
+      } catch {
+        // Notification may already be closed / GC'd – safe to ignore.
+      }
+      this.activeNotification = null;
+    }
+  }
+
   /**
    * Show system desktop notification (only when window is hidden)
    */
@@ -122,19 +154,29 @@ export default class NotificationCtr extends ControllerModule {
         return { reason: 'Window is visible', skipped: true, success: true };
       }
 
+      // Close previous notification before creating a new one to avoid
+      // resource accumulation (especially important on Linux/GNOME).
+      this.cleanupActiveNotification();
+
       logger.info('Window is hidden, showing desktop notification:', params.title);
+
+      const isLinux = linux();
 
       const notification = new Notification({
         body: params.body,
-        // Add more configuration to ensure notifications display properly
         hasReply: false,
         silent: params.silent || false,
-        timeoutType: 'default',
         title: params.title,
-        urgency: 'normal',
+        // On Linux/GNOME, use 'never' so Electron does not keep an internal
+        // timer that races with the desktop-environment's own dismiss logic.
+        // This avoids the freeze reported when the two conflict.
+        timeoutType: isLinux ? 'never' : 'default',
+        // Low urgency on Linux tells the notification daemon it is safe to
+        // expire/collapse the bubble quickly, reducing the chance of D-Bus
+        // round-trip blocking the main process.
+        urgency: isLinux ? 'low' : 'normal',
       });
 
-      // Add more event listeners for debugging
       notification.on('show', () => {
         logger.info('Notification shown');
       });
@@ -144,21 +186,33 @@ export default class NotificationCtr extends ControllerModule {
         const mainWindow = this.app.browserManager.getMainWindow();
         mainWindow.show();
         mainWindow.browserWindow.focus();
+        this.cleanupActiveNotification();
       });
 
       notification.on('close', () => {
         logger.debug('Notification closed');
+        // Dereference immediately so the next notification starts clean.
+        this.activeNotification = null;
       });
 
       notification.on('failed', (error) => {
         logger.error('Notification display failed:', error);
+        this.activeNotification = null;
       });
 
-      // Use Promise to ensure notification is shown
-      return new Promise((resolve) => {
-        notification.show();
+      this.activeNotification = notification;
+      notification.show();
 
-        // Give the notification some time to display, then check the result
+      // On Linux we return immediately – do NOT block the IPC response on a
+      // setTimeout, because Electron's notification codepath on Linux goes
+      // through D-Bus which can stall under GNOME Shell.
+      if (isLinux) {
+        logger.info('Linux: notification dispatched (non-blocking)');
+        return { success: true };
+      }
+
+      // On other platforms keep the original 100ms grace period.
+      return new Promise((resolve) => {
         setTimeout(() => {
           logger.info('Notification display call completed');
           resolve({ success: true });

--- a/apps/desktop/src/main/controllers/__tests__/NotificationCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/NotificationCtr.test.ts
@@ -5,8 +5,14 @@ import type { App } from '@/core/App';
 
 import NotificationCtr from '../NotificationCtr';
 
-const { ipcMainHandleMock } = vi.hoisted(() => ({
+const { ipcMainHandleMock, mockNotificationInstance, notificationCtorSpy } = vi.hoisted(() => ({
   ipcMainHandleMock: vi.fn(),
+  mockNotificationInstance: {
+    close: vi.fn(),
+    on: vi.fn(),
+    show: vi.fn(),
+  },
+  notificationCtorSpy: vi.fn(),
 }));
 
 // Mock logger
@@ -21,26 +27,30 @@ vi.mock('@/utils/logger', () => ({
 
 // Mock electron
 vi.mock('electron', () => {
-  const mockNotificationInstance = {
-    on: vi.fn(),
-    show: vi.fn(),
-  };
-  const MockNotification = vi.fn(() => mockNotificationInstance) as any;
-  MockNotification.isSupported = vi.fn(() => true);
+  class MockNotification {
+    close = mockNotificationInstance.close;
+    on = mockNotificationInstance.on;
+    show = mockNotificationInstance.show;
+    static isSupported = vi.fn(() => true);
+    constructor(opts?: any) {
+      notificationCtorSpy(opts);
+    }
+  }
 
   return {
-    ipcMain: {
-      handle: ipcMainHandleMock,
-    },
     Notification: MockNotification,
     app: {
       setAppUserModelId: vi.fn(),
+    },
+    ipcMain: {
+      handle: ipcMainHandleMock,
     },
   };
 });
 
 // Mock electron-is
 vi.mock('electron-is', () => ({
+  linux: vi.fn(() => false),
   macOS: vi.fn(() => false),
   windows: vi.fn(() => false),
 }));
@@ -169,7 +179,7 @@ describe('NotificationCtr', () => {
       vi.advanceTimersByTime(100);
       const result = await promise;
 
-      expect(Notification).toHaveBeenCalledWith({
+      expect(notificationCtorSpy).toHaveBeenCalledWith({
         body: 'Test body',
         hasReply: false,
         silent: false,
@@ -191,7 +201,7 @@ describe('NotificationCtr', () => {
       vi.advanceTimersByTime(100);
       const result = await promise;
 
-      expect(Notification).toHaveBeenCalled();
+      expect(notificationCtorSpy).toHaveBeenCalled();
       expect(result).toEqual({ success: true });
     });
 
@@ -206,7 +216,7 @@ describe('NotificationCtr', () => {
       vi.advanceTimersByTime(100);
       const result = await promise;
 
-      expect(Notification).toHaveBeenCalled();
+      expect(notificationCtorSpy).toHaveBeenCalled();
       expect(result).toEqual({ success: true });
     });
 
@@ -224,7 +234,7 @@ describe('NotificationCtr', () => {
       vi.advanceTimersByTime(100);
       await promise;
 
-      expect(Notification).toHaveBeenCalledWith(
+      expect(notificationCtorSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           silent: true,
         }),
@@ -236,16 +246,14 @@ describe('NotificationCtr', () => {
       vi.mocked(Notification.isSupported).mockReturnValue(true);
       mockBrowserWindow.isVisible.mockReturnValue(false);
 
-      // Get the mock instance that will be created
-      const mockInstance = { on: vi.fn(), show: vi.fn() };
-      vi.mocked(Notification).mockReturnValue(mockInstance as any);
-
       const promise = controller.showDesktopNotification(params);
       vi.advanceTimersByTime(100);
       await promise;
 
-      // Find the click handler
-      const clickHandler = mockInstance.on.mock.calls.find((call) => call[0] === 'click')?.[1];
+      // Find the click handler from the shared mock
+      const clickHandler = mockNotificationInstance.on.mock.calls.find(
+        (call) => call[0] === 'click',
+      )?.[1];
 
       expect(clickHandler).toBeDefined();
 
@@ -260,7 +268,7 @@ describe('NotificationCtr', () => {
       const { Notification } = await import('electron');
       vi.mocked(Notification.isSupported).mockReturnValue(true);
       mockBrowserWindow.isVisible.mockReturnValue(false);
-      vi.mocked(Notification).mockImplementationOnce(() => {
+      notificationCtorSpy.mockImplementationOnce(() => {
         throw new Error('Notification error');
       });
 
@@ -272,11 +280,50 @@ describe('NotificationCtr', () => {
       });
     });
 
+    it('should use low urgency and non-blocking dispatch on Linux', async () => {
+      const { Notification } = await import('electron');
+      const electronIs = await import('electron-is');
+      vi.mocked(Notification.isSupported).mockReturnValue(true);
+      vi.mocked(electronIs.linux).mockReturnValue(true);
+      mockBrowserWindow.isVisible.mockReturnValue(false);
+
+      // On Linux the method should resolve immediately without needing timer advancement
+      const result = await controller.showDesktopNotification(params);
+
+      expect(notificationCtorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeoutType: 'never',
+          urgency: 'low',
+        }),
+      );
+      expect(result).toEqual({ success: true });
+
+      vi.mocked(electronIs.linux).mockReturnValue(false);
+    });
+
+    it('should close previous notification before showing a new one', async () => {
+      const { Notification } = await import('electron');
+      vi.mocked(Notification.isSupported).mockReturnValue(true);
+      mockBrowserWindow.isVisible.mockReturnValue(false);
+
+      // Show first notification
+      const p1 = controller.showDesktopNotification(params);
+      vi.advanceTimersByTime(100);
+      await p1;
+
+      // Show second notification – should close the first
+      const p2 = controller.showDesktopNotification(params);
+      vi.advanceTimersByTime(100);
+      await p2;
+
+      expect(mockNotificationInstance.close).toHaveBeenCalled();
+    });
+
     it('should handle unknown error type', async () => {
       const { Notification } = await import('electron');
       vi.mocked(Notification.isSupported).mockReturnValue(true);
       mockBrowserWindow.isVisible.mockReturnValue(false);
-      vi.mocked(Notification).mockImplementationOnce(() => {
+      notificationCtorSpy.mockImplementationOnce(() => {
         throw 'string error';
       });
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] ✅ test

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

#### 🔀 Description of Change

This PR fixes a critical issue where desktop notifications on Linux/GNOME could cause the rendering thread to block due to D-Bus conflicts between Electron's internal notification timeout logic and GNOME Shell's own dismiss logic.

**Key Changes:**

1. **Linux-specific notification configuration**: When running on Linux, notifications now use:
   - `timeoutType: 'never'` to prevent Electron from maintaining an internal timer that races with the desktop environment
   - `urgency: 'low'` to signal the notification daemon it's safe to expire/collapse the bubble quickly

2. **Non-blocking dispatch on Linux**: The IPC response now returns immediately on Linux instead of waiting for a 100ms grace period, preventing the main process from blocking on D-Bus operations.

3. **Active notification tracking and cleanup**: Added `activeNotification` property to track the current notification and a `cleanupActiveNotification()` method that:
   - Closes the previous notification before creating a new one
   - Prevents resource accumulation and lingering handles that could block the rendering thread
   - Safely handles already-closed notifications

4. **Enhanced event handling**: Added proper cleanup in notification event handlers (`click`, `close`, `failed`) to dereference the notification immediately.

5. **Improved test coverage**: 
   - Refactored mocks to use a shared `mockNotificationInstance` for better test isolation
   - Added test for Linux-specific behavior (`timeoutType` and `urgency` settings)
   - Added test for notification cleanup when showing multiple notifications
   - Updated existing tests to use `notificationCtorSpy` for more reliable assertions

#### 🧪 How to Test

- [x] Added/updated tests

The changes include comprehensive unit tests covering:
- Linux-specific notification configuration
- Notification cleanup when showing multiple notifications sequentially
- Existing notification display and event handling scenarios

All tests pass with the new implementation.

#### 📝 Additional Information

This fix addresses a GNOME Shell-specific issue where lingering Notification objects and conflicting timeout logic could cause the rendering thread to freeze when users dismiss notifications. The solution is backward-compatible and only applies special handling on Linux systems.

https://claude.ai/code/session_018r867hmboXbnbVaqdkSQaz