### PR TITLE
👷 build(model-bank): align pnpm setup with packageManager

### DIFF
--- a/.github/workflows/release-model-bank.yml
+++ b/.github/workflows/release-model-bank.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.20.0
 
       - name: Install dependencies
         run: pnpm install
@@ -61,8 +59,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.20.0
 
       - name: Install dependencies
         run: pnpm install
@@ -86,8 +82,8 @@ jobs:
         env:
           MODEL_BANK_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "lobehubbot"
+          git config user.email "i@lobehub.com"
           git add packages/model-bank/package.json
           git commit -m "🔖 chore(model-bank): release v${MODEL_BANK_VERSION}"
           git push


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 👷 build
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None

#### 🔀 Description of Change

- Remove hardcoded pnpm version (`10.20.0`) from the ModelBank release workflow so CI uses the repository `packageManager` version (`pnpm@10.33.0+sha...`) and avoids `ERR_PNPM_BAD_PM_VERSION`.
- Align the release commit identity in this workflow to `lobehubbot / i@lobehub.com` for consistency with other release workflows.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Verification:
- Re-run `Release ModelBank` workflow and confirm `pnpm/action-setup` no longer fails with multiple version configuration.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

This change only affects CI workflow configuration and does not impact runtime behavior.

Made with [Cursor](https://cursor.com)