### PR TITLE
🐛 fix(chat-input): memoize mentionOption/slashOption to prevent freeze on paste

### DIFF
--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -204,6 +204,51 @@ const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
     [isAutoCompleteEnabled, handleAutoComplete],
   );
 
+  // --- Stable mentionOption & slashOption to prevent infinite re-render on paste ---
+  const mentionMarkdownWriter = useCallback((mention: any) => {
+    if (mention.metadata?.type === 'topic') {
+      return `<refer_topic name="${mention.metadata.topicTitle}" id="${mention.metadata.topicId}" />`;
+    }
+    return `<mention name="${mention.label}" id="${mention.metadata.id}" />`;
+  }, []);
+
+  const mentionOnSelect = useCallback((editor: any, option: any) => {
+    if (option.metadata?.type === 'topic') {
+      editor.dispatchCommand(INSERT_REFER_TOPIC_COMMAND, {
+        topicId: option.metadata.topicId as string,
+        topicTitle: String(option.metadata.topicTitle ?? option.label),
+      });
+    } else if (option.metadata?.type === 'skill' || option.metadata?.type === 'tool') {
+      const payload: InsertActionTagPayload = {
+        category: option.metadata.actionCategory as 'skill' | 'tool',
+        label: String(option.label),
+        type: String(option.metadata.actionType),
+      };
+      editor.dispatchCommand(INSERT_ACTION_TAG_COMMAND, payload);
+    } else {
+      editor.dispatchCommand(INSERT_MENTION_COMMAND, {
+        label: String(option.label),
+        metadata: option.metadata,
+      });
+    }
+  }, []);
+
+  const mentionOption = useMemo(
+    () =>
+      enableMention
+        ? {
+            items: mentionItemsFn,
+            markdownWriter: mentionMarkdownWriter,
+            maxLength: 50,
+            onSelect: mentionOnSelect,
+            renderComp: MentionMenuComp,
+          }
+        : undefined,
+    [enableMention, mentionItemsFn, mentionMarkdownWriter, mentionOnSelect, MentionMenuComp],
+  );
+
+  const slashOption = useMemo(() => ({ items: slashItems }), [slashItems]);
+
   const richRenderProps = useMemo(() => {
     const basePlugins = !enableRichRender
       ? CHAT_INPUT_EMBED_PLUGINS
@@ -233,47 +278,11 @@ const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
       editor={editor}
       {...{ slashPlacement }}
       {...richRenderProps}
+      mentionOption={mentionOption}
       placeholder={<Placeholder />}
+      slashOption={slashOption}
       type={'text'}
       variant={'chat'}
-      mentionOption={
-        enableMention
-          ? {
-              items: mentionItemsFn,
-              markdownWriter: (mention) => {
-                if (mention.metadata?.type === 'topic') {
-                  return `<refer_topic name="${mention.metadata.topicTitle}" id="${mention.metadata.topicId}" />`;
-                }
-                return `<mention name="${mention.label}" id="${mention.metadata.id}" />`;
-              },
-              maxLength: 50,
-              onSelect: (editor, option) => {
-                if (option.metadata?.type === 'topic') {
-                  editor.dispatchCommand(INSERT_REFER_TOPIC_COMMAND, {
-                    topicId: option.metadata.topicId as string,
-                    topicTitle: String(option.metadata.topicTitle ?? option.label),
-                  });
-                } else if (option.metadata?.type === 'skill' || option.metadata?.type === 'tool') {
-                  const payload: InsertActionTagPayload = {
-                    category: option.metadata.actionCategory as 'skill' | 'tool',
-                    label: String(option.label),
-                    type: String(option.metadata.actionType),
-                  };
-                  editor.dispatchCommand(INSERT_ACTION_TAG_COMMAND, payload);
-                } else {
-                  editor.dispatchCommand(INSERT_MENTION_COMMAND, {
-                    label: String(option.label),
-                    metadata: option.metadata,
-                  });
-                }
-              },
-              renderComp: MentionMenuComp,
-            }
-          : undefined
-      }
-      slashOption={{
-        items: slashItems,
-      }}
       style={{
         minHeight: defaultRows > 1 ? defaultRows * 23 : undefined,
       }}

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -159,6 +159,9 @@ const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
       input: string;
       selectionType: string;
     }): Promise<string | null> => {
+      // Skip autocomplete during IME composition (e.g. Chinese input method)
+      if (isComposingRef.current) return null;
+
       if (!input.trim()) return null;
 
       const { enabled: _, ...config } = systemAgentSelectors.inputCompletion(

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -188,7 +188,7 @@ const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
 
       if (abortSignal.aborted) return null;
 
-      return result || null;
+      return result.trimEnd() || null;
     },
     [],
   );


### PR DESCRIPTION
## Summary

- **Fix**: Memoize `mentionOption` and `slashOption` props in `InputEditor` to stabilize object references across re-renders
- **Root cause**: Inline objects and arrow functions caused new references every render → `Editor.memoSlash` recomputed → `ReactSlashPlugin` re-registered the slash plugin → update listener fired → `triggerOpen` called again → infinite loop when paste triggers autocomplete
- **Changes**: Extract `markdownWriter` and `onSelect` into `useCallback`, wrap both option objects with `useMemo`

- Fixes LOBE-6684
- fix LOBE-6693

## Test plan

- [ ] Paste text containing `@` or `/` into chat input — page should not freeze
- [ ] Verify mention autocomplete still works (type `@` then search)
- [ ] Verify slash command autocomplete still works (type `/` at line start)
- [ ] Verify paste file upload still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)