### PR TITLE
🐛 fix(agentDocuments): add progressive disclosure PolicyLoad mode

### DIFF
--- a/packages/agent-templates/src/types.ts
+++ b/packages/agent-templates/src/types.ts
@@ -38,6 +38,7 @@ export enum DocumentLoadFormat {
 export enum PolicyLoad {
   ALWAYS = 'always',
   DISABLED = 'disabled',
+  PROGRESSIVE = 'progressive',
 }
 
 /**

--- a/packages/context-engine/src/providers/AgentDocumentInjector/shared.ts
+++ b/packages/context-engine/src/providers/AgentDocumentInjector/shared.ts
@@ -23,11 +23,13 @@ export type AgentDocumentLoadFormat = 'file' | 'raw';
 
 export interface AgentContextDocument {
   content?: string;
+  description?: string;
   filename: string;
   id?: string;
   loadPosition?: AgentDocumentInjectionPosition;
   loadRules?: AgentDocumentLoadRules;
   policyId?: string | null;
+  policyLoad?: 'always' | 'progressive';
   policyLoadFormat?: AgentDocumentLoadFormat;
   title?: string;
 }
@@ -104,13 +106,43 @@ export function formatDocument(
 }
 
 /**
- * Combine multiple documents into a single string
+ * Format a single progressive document as an index entry
+ */
+function formatProgressiveEntry(doc: AgentContextDocument): string {
+  const parts: string[] = [];
+  if (doc.id) parts.push(`[${doc.id}]`);
+  parts.push(doc.filename);
+  if (doc.title && doc.title !== doc.filename) parts.push(`— "${doc.title}"`);
+  if (doc.description) parts.push(`: ${doc.description}`);
+  return `- ${parts.join(' ')}`;
+}
+
+/**
+ * Combine multiple documents into a single string.
+ * Progressive documents are grouped into a lightweight index block;
+ * full-content documents are formatted individually.
  */
 export function combineDocuments(
   docs: AgentContextDocument[],
   context: AgentDocumentFilterContext,
 ): string {
-  return docs.map((doc) => formatDocument(doc, context)).join('\n\n');
+  const fullDocs = docs.filter((d) => d.policyLoad !== 'progressive');
+  const progressiveDocs = docs.filter((d) => d.policyLoad === 'progressive');
+
+  const parts: string[] = [];
+
+  if (fullDocs.length > 0) {
+    parts.push(fullDocs.map((doc) => formatDocument(doc, context)).join('\n\n'));
+  }
+
+  if (progressiveDocs.length > 0) {
+    const entries = progressiveDocs.map(formatProgressiveEntry).join('\n');
+    parts.push(
+      `<agent_documents_index>\nThe following documents are available. Use readDocument tool to access full content.\n${entries}\n</agent_documents_index>`,
+    );
+  }
+
+  return parts.join('\n\n');
 }
 
 function approximateTokenTruncate(content: string, maxTokens: number): string {

--- a/packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts
@@ -173,6 +173,80 @@ describe('AgentDocumentInjector', () => {
       expect(result.messages[0].content).toContain('File mode content');
       expect(result.messages[0].content).toContain('</agent_document>');
     });
+
+    it('should inject progressive documents as index instead of full content', async () => {
+      const provider = new AgentDocumentContextInjector({
+        documents: [
+          {
+            content: 'Full content that should NOT appear',
+            description: 'Core safety rules',
+            filename: 'guardrails.md',
+            id: 'doc-1',
+            loadPosition: 'before-first-user',
+            loadRules: { rule: 'always' },
+            policyLoad: 'progressive',
+            title: 'Guardrails',
+          },
+          {
+            content: 'Another full content that should NOT appear',
+            filename: 'notes.txt',
+            id: 'doc-2',
+            loadPosition: 'before-first-user',
+            loadRules: { rule: 'always' },
+            policyLoad: 'progressive',
+            title: 'Notes',
+          },
+        ],
+      });
+
+      const context = createContext([{ content: 'Hello', id: 'user-1', role: 'user' }]);
+      const result = await provider.process(context);
+
+      const injected = result.messages[0].content;
+      expect(injected).toContain('<agent_documents_index>');
+      expect(injected).toContain('[doc-1]');
+      expect(injected).toContain('guardrails.md');
+      expect(injected).toContain('"Guardrails"');
+      expect(injected).toContain('Core safety rules');
+      expect(injected).toContain('[doc-2]');
+      expect(injected).toContain('notes.txt');
+      expect(injected).not.toContain('Full content that should NOT appear');
+      expect(injected).not.toContain('Another full content that should NOT appear');
+      expect(injected).toContain('</agent_documents_index>');
+    });
+
+    it('should mix full-content and progressive documents', async () => {
+      const provider = new AgentDocumentContextInjector({
+        documents: [
+          {
+            content: 'Always-loaded full content',
+            filename: 'full.md',
+            loadPosition: 'before-first-user',
+            loadRules: { rule: 'always' },
+            policyLoad: 'always',
+          },
+          {
+            content: 'Progressive content hidden',
+            description: 'A summary doc',
+            filename: 'summary.md',
+            id: 'doc-p',
+            loadPosition: 'before-first-user',
+            loadRules: { rule: 'always' },
+            policyLoad: 'progressive',
+            title: 'Summary',
+          },
+        ],
+      });
+
+      const context = createContext([{ content: 'Hello', id: 'user-1', role: 'user' }]);
+      const result = await provider.process(context);
+
+      const injected = result.messages[0].content;
+      expect(injected).toContain('Always-loaded full content');
+      expect(injected).toContain('<agent_documents_index>');
+      expect(injected).toContain('summary.md');
+      expect(injected).not.toContain('Progressive content hidden');
+    });
   });
 
   describe('AgentDocumentBeforeSystemInjector (before-system)', () => {

--- a/packages/database/src/models/agentDocuments/__tests__/agentDocument.test.ts
+++ b/packages/database/src/models/agentDocuments/__tests__/agentDocument.test.ts
@@ -326,6 +326,20 @@ describe('AgentDocumentModel', () => {
       expect(context).not.toContain('--- manual.md ---');
     });
 
+    it('should preserve progressive policyLoad when updating load rule without mode', async () => {
+      const doc = await agentDocumentModel.create(agentId, 'progressive.md', 'content');
+      expect(doc.policyLoad).toBe(PolicyLoad.PROGRESSIVE);
+
+      const updated = await agentDocumentModel.updateToolLoadRule(doc.id, {
+        rule: 'by-keywords',
+        keywords: ['test'],
+      });
+
+      expect(updated?.policyLoad).toBe(PolicyLoad.PROGRESSIVE);
+      expect(updated?.policy?.context?.keywords).toEqual(['test']);
+      expect(updated?.policyLoadRule).toBe(DocumentLoadRule.BY_KEYWORDS);
+    });
+
     it('should group docs by position and sort by priority ascending', async () => {
       await agentDocumentModel.create(
         agentId,

--- a/packages/database/src/models/agentDocuments/__tests__/agentDocument.test.ts
+++ b/packages/database/src/models/agentDocuments/__tests__/agentDocument.test.ts
@@ -80,7 +80,7 @@ describe('AgentDocumentModel', () => {
       expect(result.policy?.context?.position).toBe(DocumentLoadPosition.BEFORE_FIRST_USER);
       expect(result.policy?.context?.rule).toBe(DocumentLoadRule.ALWAYS);
       expect(result.policyLoadFormat).toBe(DocumentLoadFormat.RAW);
-      expect(result.policyLoad).toBe(PolicyLoad.ALWAYS);
+      expect(result.policyLoad).toBe(PolicyLoad.PROGRESSIVE);
       expect(result.accessShared).toBe(0);
       expect(result.accessPublic).toBe(0);
     });

--- a/packages/database/src/models/agentDocuments/agentDocument.ts
+++ b/packages/database/src/models/agentDocuments/agentDocument.ts
@@ -131,7 +131,7 @@ export class AgentDocumentModel {
         accessShared: 0,
         agentId,
         createdAt,
-        policyLoad: PolicyLoad.ALWAYS,
+        policyLoad: PolicyLoad.PROGRESSIVE,
         deleteReason: null,
         deletedAt: null,
         deletedByAgentId: null,

--- a/packages/database/src/models/agentDocuments/agentDocument.ts
+++ b/packages/database/src/models/agentDocuments/agentDocument.ts
@@ -272,7 +272,7 @@ export class AgentDocumentModel {
   ): Promise<AgentDocument | undefined> {
     const existing = await this.findById(documentId);
     if (!existing) return undefined;
-    const composedPolicy = composeToolPolicyUpdate(existing.policy, rule);
+    const composedPolicy = composeToolPolicyUpdate(existing.policy, rule, existing.policyLoad);
 
     await this.db
       .update(agentDocuments)

--- a/packages/database/src/models/agentDocuments/policy/__tests__/checks.test.ts
+++ b/packages/database/src/models/agentDocuments/policy/__tests__/checks.test.ts
@@ -110,4 +110,28 @@ describe('agentDocuments checks', () => {
 
     expect(isLoadableDocument(noReadDoc)).toBe(false);
   });
+
+  it('treats progressive policyLoad as auto-loadable', () => {
+    const progressiveDoc = {
+      accessSelf:
+        AgentAccess.EXECUTE |
+        AgentAccess.LIST |
+        AgentAccess.READ |
+        AgentAccess.WRITE |
+        AgentAccess.DELETE,
+      policyLoad: PolicyLoad.PROGRESSIVE,
+    };
+
+    expect(canAutoLoadDocument(progressiveDoc)).toBe(true);
+    expect(isLoadableDocument(progressiveDoc)).toBe(true);
+  });
+
+  it('composes tool policy update with progressive mode', () => {
+    const composed = composeToolPolicyUpdate(null, {
+      mode: 'progressive',
+      rule: 'always',
+    });
+
+    expect(composed.policyLoad).toBe(PolicyLoad.PROGRESSIVE);
+  });
 });

--- a/packages/database/src/models/agentDocuments/policy/__tests__/checks.test.ts
+++ b/packages/database/src/models/agentDocuments/policy/__tests__/checks.test.ts
@@ -134,4 +134,42 @@ describe('agentDocuments checks', () => {
 
     expect(composed.policyLoad).toBe(PolicyLoad.PROGRESSIVE);
   });
+
+  it('preserves existing policyLoad when rule.mode is omitted', () => {
+    const composed = composeToolPolicyUpdate(
+      { context: { loadMode: undefined } },
+      { rule: 'by-keywords', keywords: ['test'] },
+      PolicyLoad.PROGRESSIVE,
+    );
+
+    expect(composed.policyLoad).toBe(PolicyLoad.PROGRESSIVE);
+    expect(composed.policyLoadRule).toBe(DocumentLoadRule.BY_KEYWORDS);
+  });
+
+  it('preserves existing progressive loadMode in policy context', () => {
+    const composed = composeToolPolicyUpdate(
+      { context: { loadMode: 'progressive' } },
+      { rule: 'by-keywords', keywords: ['test'] },
+    );
+
+    expect(composed.policyLoad).toBe(PolicyLoad.PROGRESSIVE);
+    expect(composed.policy.context?.loadMode).toBe('progressive');
+  });
+
+  it('overrides policyLoad when rule.mode is explicitly set', () => {
+    const composed = composeToolPolicyUpdate(
+      { context: { loadMode: 'progressive' } },
+      { mode: 'always', rule: 'always' },
+      PolicyLoad.PROGRESSIVE,
+    );
+
+    expect(composed.policyLoad).toBe(PolicyLoad.ALWAYS);
+    expect(composed.policy.context?.loadMode).toBe('always');
+  });
+
+  it('defaults to ALWAYS when no mode, no context, no existingPolicyLoad', () => {
+    const composed = composeToolPolicyUpdate(null, { rule: 'always' });
+
+    expect(composed.policyLoad).toBe(PolicyLoad.ALWAYS);
+  });
 });

--- a/packages/database/src/models/agentDocuments/policy/permission.ts
+++ b/packages/database/src/models/agentDocuments/policy/permission.ts
@@ -22,7 +22,7 @@ export const canDeleteDocument = (doc: Pick<AgentDocument, 'accessSelf'>): boole
 };
 
 export const canAutoLoadDocument = (doc: Pick<AgentDocument, 'policyLoad'>): boolean => {
-  return doc.policyLoad === PolicyLoad.ALWAYS;
+  return doc.policyLoad === PolicyLoad.ALWAYS || doc.policyLoad === PolicyLoad.PROGRESSIVE;
 };
 
 export const isLoadableDocument = (

--- a/packages/database/src/models/agentDocuments/policy/policy.ts
+++ b/packages/database/src/models/agentDocuments/policy/policy.ts
@@ -35,6 +35,7 @@ export interface ToolPolicyCompositionResult {
 export const composeToolPolicyUpdate = (
   existingPolicy: AgentDocumentPolicy | null,
   rule: ToolUpdateLoadRule,
+  existingPolicyLoad?: PolicyLoad,
 ): ToolPolicyCompositionResult => {
   const resolvePolicyLoadFormat = (format?: string): DocumentLoadFormat => {
     if (format === 'file') {
@@ -45,8 +46,7 @@ export const composeToolPolicyUpdate = (
 
   const currentPolicy = existingPolicy || {};
   const existingContext = currentPolicy.context || {};
-  const loadMode =
-    rule.mode ?? (existingContext.loadMode as ToolUpdateLoadRule['mode']) ?? 'always';
+  const loadMode = rule.mode ?? (existingContext.loadMode as ToolUpdateLoadRule['mode']);
   const policyLoadFormat = resolvePolicyLoadFormat(
     rule.policyLoadFormat ??
       (existingContext.policyLoadFormat as DocumentLoadFormat | undefined) ??
@@ -60,7 +60,7 @@ export const composeToolPolicyUpdate = (
     ...currentPolicy,
     context: {
       ...existingContext,
-      loadMode,
+      loadMode: loadMode ?? existingContext.loadMode,
       keywordMatchMode: rule.keywordMatchMode ?? existingContext.keywordMatchMode,
       keywords: rule.keywords ?? existingContext.keywords,
       policyLoadFormat,
@@ -75,12 +75,13 @@ export const composeToolPolicyUpdate = (
   } satisfies AgentDocumentPolicy;
 
   return {
-    policyLoad:
-      loadMode === 'always'
+    policyLoad: loadMode
+      ? loadMode === 'always'
         ? PolicyLoad.ALWAYS
         : loadMode === 'progressive'
           ? PolicyLoad.PROGRESSIVE
-          : PolicyLoad.DISABLED,
+          : PolicyLoad.DISABLED
+      : (existingPolicyLoad ?? PolicyLoad.ALWAYS),
     policy,
     policyLoadFormat,
     policyLoadRule: documentLoadRule,

--- a/packages/database/src/models/agentDocuments/policy/policy.ts
+++ b/packages/database/src/models/agentDocuments/policy/policy.ts
@@ -75,7 +75,12 @@ export const composeToolPolicyUpdate = (
   } satisfies AgentDocumentPolicy;
 
   return {
-    policyLoad: loadMode === 'always' ? PolicyLoad.ALWAYS : PolicyLoad.DISABLED,
+    policyLoad:
+      loadMode === 'always'
+        ? PolicyLoad.ALWAYS
+        : loadMode === 'progressive'
+          ? PolicyLoad.PROGRESSIVE
+          : PolicyLoad.DISABLED,
     policy,
     policyLoadFormat,
     policyLoadRule: documentLoadRule,

--- a/packages/database/src/models/agentDocuments/types.ts
+++ b/packages/database/src/models/agentDocuments/types.ts
@@ -58,7 +58,7 @@ export interface ToolUpdateLoadRule {
   keywords?: string[];
   maxDocuments?: number;
   maxTokens?: number;
-  mode?: 'always' | 'manual' | 'on-demand';
+  mode?: 'always' | 'manual' | 'on-demand' | 'progressive';
   pinnedDocumentIds?: string[];
   policyLoadFormat?: 'file' | 'raw';
   priority?: number;

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -146,10 +146,7 @@ const executeToolWithRetry = async (
   throw new Error('Tool execution retry loop exited unexpectedly');
 };
 
-const buildToolDiscoveryConfig = (
-  operationToolSet: OperationToolSet,
-  enabledToolIds: string[],
-) => {
+const buildToolDiscoveryConfig = (operationToolSet: OperationToolSet, enabledToolIds: string[]) => {
   const enabledToolSet = new Set(enabledToolIds);
 
   if (!enabledToolSet.has(LobeActivatorIdentifier)) return undefined;
@@ -164,7 +161,7 @@ const buildToolDiscoveryConfig = (
 
   if (availableTools.length === 0) return undefined;
 
-  return { availableTools }
+  return { availableTools };
 };
 
 const formatErrorEventData = (error: unknown, phase: string) => {
@@ -385,6 +382,7 @@ export const createRuntimeExecutors = (
             if (docs.length > 0) {
               agentDocuments = docs.map((doc) => ({
                 content: doc.content,
+                description: doc.description ?? undefined,
                 filename: doc.filename,
                 id: doc.id,
                 loadPosition: normalizeDocumentPosition(
@@ -392,6 +390,7 @@ export const createRuntimeExecutors = (
                 ),
                 loadRules: doc.loadRules,
                 policyId: doc.templateId,
+                policyLoad: doc.policyLoad as 'always' | 'progressive',
                 policyLoadFormat: doc.policy?.context?.policyLoadFormat || doc.policyLoadFormat,
                 title: doc.title,
               }));

--- a/src/services/agentDocument.ts
+++ b/src/services/agentDocument.ts
@@ -132,6 +132,7 @@ export const mapAgentDocumentsToContext = (
 ): AgentContextDocument[] =>
   documents.map((doc) => ({
     content: doc.content,
+    description: doc.description ?? undefined,
     filename: doc.filename,
     id: doc.id,
     loadPosition: normalizeAgentDocumentPosition(
@@ -139,6 +140,7 @@ export const mapAgentDocumentsToContext = (
     ),
     loadRules: doc.loadRules,
     policyId: doc.templateId,
+    policyLoad: doc.policyLoad as 'always' | 'progressive',
     policyLoadFormat: doc.policy?.context?.policyLoadFormat || doc.policyLoadFormat || undefined,
     title: doc.title,
   }));


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Fixes LOBE-6702

#### 🔀 Description of Change

Add a new `PolicyLoad.PROGRESSIVE` mode for agent document prompt injection. Instead of injecting full document content into the prompt (which is costly for many/large documents), progressive mode injects only a lightweight index showing each document's title and description.

**Key changes:**
- New `PolicyLoad.PROGRESSIVE = 'progressive'` enum value
- Progressive documents are formatted as an `<agent_documents_index>` block with title + description per entry
- New documents now default to `PROGRESSIVE` instead of `ALWAYS` — reducing token usage out of the box
- Full content remains accessible via `readDocument` tool (on-demand)
- Existing `ALWAYS` documents are unaffected (backward compatible)

**Files changed (11):**
- `packages/agent-templates/src/types.ts` — enum addition
- `packages/context-engine/.../shared.ts` — progressive index formatting in `combineDocuments`
- `packages/database/.../permission.ts` — allow PROGRESSIVE in auto-load gate
- `packages/database/.../agentDocument.ts` — default policyLoad → PROGRESSIVE
- `packages/database/.../policy.ts` — support `mode: 'progressive'` in tool policy composition
- `packages/database/.../types.ts` — add 'progressive' to ToolUpdateLoadRule.mode
- `src/services/agentDocument.ts` — pass description + policyLoad to context
- `src/server/.../RuntimeExecutors.ts` — same for server-side mapping

#### 🧪 How to Test

- [x] Added/updated tests

```bash
# Permission tests (7 tests)
cd packages/database && bunx vitest run src/models/agentDocuments/policy/__tests__/checks.test.ts

# Injection formatting tests (14 tests)
cd packages/context-engine && bunx vitest run src/providers/__tests__/AgentDocumentInjector.test.ts

# Document creation default tests (14 tests)
cd packages/database && bunx vitest run src/models/agentDocuments/__tests__/agentDocument.test.ts
```

#### 📝 Additional Information

No database migration needed — `policy_load` is `varchar(30)` and accepts the new `'progressive'` string value. The Drizzle schema `.default()` is left unchanged to avoid migration; only the application-level default in `create()` is updated.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)