### PR TITLE
fix(github-copilot): surface quota exhaustion 429 instead of retrying

### DIFF
--- a/packages/model-runtime/src/providers/githubCopilot/index.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.ts
@@ -25,6 +25,7 @@ const TOKEN_EXCHANGE_URL = 'https://api.github.com/copilot_internal/v2/token';
 
 const MAX_TOTAL_ATTEMPTS = 5;
 const MAX_RATE_LIMIT_RETRIES = 3;
+const QUOTA_EXHAUSTION_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
 const debugParams = {
   chatCompletion: () => process.env.DEBUG_GITHUBCOPILOT_CHAT_COMPLETION === '1',
@@ -456,6 +457,11 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
         if (status === 429 && rateLimitAttempts < MAX_RATE_LIMIT_RETRIES) {
           rateLimitAttempts++;
           const retryAfter = this.getRetryAfterMs(error) ?? 1000 * Math.pow(2, rateLimitAttempts);
+
+          // If retry-after exceeds the quota exhaustion threshold, surface immediately
+          if (retryAfter > QUOTA_EXHAUSTION_THRESHOLD_MS) {
+            throw this.mapError(error);
+          }
 
           await new Promise<void>((resolve) => {
             setTimeout(resolve, Math.min(retryAfter, 10_000));


### PR DESCRIPTION
Fixes #13572

## Problem

`executeWithRetry` in `packages/model-runtime/src/providers/githubCopilot/index.ts` reads the `Retry-After` header correctly, but caps the delay at 10 seconds via `Math.min(retryAfter, 10_000)`. When GitHub Copilot returns a 429 for quota exhaustion with a `Retry-After` of several hours, the client silently caps it to 10s and retries up to `MAX_RATE_LIMIT_RETRIES` times — consuming all retry budget without surfacing the real error to the user.

## Solution

Added a `QUOTA_EXHAUSTION_THRESHOLD_MS` constant (5 minutes). Before waiting to retry, we check if the parsed `retry-after` exceeds this threshold. If it does, we throw immediately (via `mapError`) instead of waiting and retrying, so the user sees the quota exhaustion error right away.

```ts
const QUOTA_EXHAUSTION_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes

// If retry-after exceeds the quota exhaustion threshold, surface immediately
if (retryAfter > QUOTA_EXHAUSTION_THRESHOLD_MS) {
  throw this.mapError(error);
}
```

## Testing

- Static analysis: verified the changed path handles quota-exhaustion 429 (retry-after > 5 min) by throwing immediately
- Transient rate limits (retry-after ≤ 5 min) still go through the existing exponential backoff path unchanged