### PR TITLE
🔨 chore: add GatewayStreamNotifier for Agent Gateway WebSocket push

### DIFF
--- a/src/envs/app.ts
+++ b/src/envs/app.ts
@@ -76,7 +76,7 @@ export const getAppConfig = () => {
       MARKET_TRUSTED_CLIENT_ID: z.string().optional(),
 
       AGENT_GATEWAY_SERVICE_TOKEN: z.string().optional(),
-      AGENT_GATEWAY_URL: z.string().url().optional(),
+      AGENT_GATEWAY_URL: z.string().url(),
       /**
        * Enable Queue-based Agent Runtime
        * When true, use QStash for async agent execution (production)
@@ -121,7 +121,7 @@ export const getAppConfig = () => {
       MARKET_TRUSTED_CLIENT_ID: process.env.MARKET_TRUSTED_CLIENT_ID,
 
       AGENT_GATEWAY_SERVICE_TOKEN: process.env.AGENT_GATEWAY_SERVICE_TOKEN,
-      AGENT_GATEWAY_URL: process.env.AGENT_GATEWAY_URL || undefined,
+      AGENT_GATEWAY_URL: process.env.AGENT_GATEWAY_URL || 'https://agent-gateway.lobehub.com',
       enableQueueAgentRuntime: process.env.AGENT_RUNTIME_MODE === 'queue',
       TELEMETRY_DISABLED: process.env.TELEMETRY_DISABLED === '1',
     },

--- a/src/envs/app.ts
+++ b/src/envs/app.ts
@@ -75,6 +75,8 @@ export const getAppConfig = () => {
        */
       MARKET_TRUSTED_CLIENT_ID: z.string().optional(),
 
+      AGENT_GATEWAY_SERVICE_TOKEN: z.string().optional(),
+      AGENT_GATEWAY_URL: z.string().url().optional(),
       /**
        * Enable Queue-based Agent Runtime
        * When true, use QStash for async agent execution (production)
@@ -118,6 +120,8 @@ export const getAppConfig = () => {
       MARKET_TRUSTED_CLIENT_SECRET: process.env.MARKET_TRUSTED_CLIENT_SECRET,
       MARKET_TRUSTED_CLIENT_ID: process.env.MARKET_TRUSTED_CLIENT_ID,
 
+      AGENT_GATEWAY_SERVICE_TOKEN: process.env.AGENT_GATEWAY_SERVICE_TOKEN,
+      AGENT_GATEWAY_URL: process.env.AGENT_GATEWAY_URL || undefined,
       enableQueueAgentRuntime: process.env.AGENT_RUNTIME_MODE === 'queue',
       TELEMETRY_DISABLED: process.env.TELEMETRY_DISABLED === '1',
     },

--- a/src/server/modules/AgentRuntime/GatewayStreamNotifier.ts
+++ b/src/server/modules/AgentRuntime/GatewayStreamNotifier.ts
@@ -1,0 +1,155 @@
+import debug from 'debug';
+
+import type { StreamChunkData, StreamEvent } from './StreamEventManager';
+import type { IStreamEventManager } from './types';
+
+const log = debug('lobe-server:agent-runtime:gateway-notifier');
+
+/**
+ * Decorator that wraps an IStreamEventManager and additionally
+ * pushes events to the Agent Gateway via HTTP (fire-and-forget).
+ *
+ * Redis SSE remains the primary event storage / subscription mechanism.
+ * The Gateway is an additional push channel for WebSocket delivery.
+ */
+export class GatewayStreamNotifier implements IStreamEventManager {
+  constructor(
+    private inner: IStreamEventManager,
+    private gatewayUrl: string,
+    private serviceToken: string,
+  ) {
+    log('Gateway notifier initialized: %s', gatewayUrl);
+  }
+
+  // ─── Publish methods: delegate to inner + notify gateway ───
+
+  async publishStreamEvent(
+    operationId: string,
+    event: Omit<StreamEvent, 'operationId' | 'timestamp'>,
+  ): Promise<string> {
+    const result = await this.inner.publishStreamEvent(operationId, event);
+    this.pushEvent(operationId, { ...event, operationId, timestamp: Date.now() });
+    return result;
+  }
+
+  async publishStreamChunk(
+    operationId: string,
+    stepIndex: number,
+    chunkData: StreamChunkData,
+  ): Promise<string> {
+    const result = await this.inner.publishStreamChunk(operationId, stepIndex, chunkData);
+    this.pushEvent(operationId, {
+      data: chunkData,
+      operationId,
+      stepIndex,
+      timestamp: Date.now(),
+      type: 'stream_chunk',
+    });
+    return result;
+  }
+
+  async publishAgentRuntimeInit(operationId: string, initialState: any): Promise<string> {
+    const result = await this.inner.publishAgentRuntimeInit(operationId, initialState);
+
+    this.httpPost('/api/operations/init', {
+      operationId,
+      userId: initialState?.userId || 'unknown',
+    });
+
+    this.pushEvent(operationId, {
+      data: initialState,
+      operationId,
+      stepIndex: 0,
+      timestamp: Date.now(),
+      type: 'agent_runtime_init',
+    });
+
+    return result;
+  }
+
+  async publishAgentRuntimeEnd(
+    operationId: string,
+    stepIndex: number,
+    finalState: any,
+    reason?: string,
+    reasonDetail?: string,
+  ): Promise<string> {
+    const result = await this.inner.publishAgentRuntimeEnd(
+      operationId,
+      stepIndex,
+      finalState,
+      reason,
+      reasonDetail,
+    );
+
+    this.pushEvent(operationId, {
+      data: { finalState, reason, reasonDetail },
+      operationId,
+      stepIndex,
+      timestamp: Date.now(),
+      type: 'agent_runtime_end',
+    });
+
+    const status =
+      reason === 'error' ? 'error' : reason === 'interrupted' ? 'interrupted' : 'completed';
+    this.httpPost('/api/operations/update-status', {
+      operationId,
+      status,
+      summary: reasonDetail,
+    });
+
+    return result;
+  }
+
+  // ─── Read / subscribe methods: delegate directly to inner ───
+
+  async subscribeStreamEvents(
+    operationId: string,
+    lastEventId: string,
+    onEvents: (events: StreamEvent[]) => void,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    return this.inner.subscribeStreamEvents(operationId, lastEventId, onEvents, signal);
+  }
+
+  async getStreamHistory(operationId: string, count?: number): Promise<StreamEvent[]> {
+    return this.inner.getStreamHistory(operationId, count);
+  }
+
+  async cleanupOperation(operationId: string): Promise<void> {
+    return this.inner.cleanupOperation(operationId);
+  }
+
+  async getActiveOperationsCount(): Promise<number> {
+    return this.inner.getActiveOperationsCount();
+  }
+
+  async disconnect(): Promise<void> {
+    return this.inner.disconnect();
+  }
+
+  // ─── Gateway HTTP helpers ───
+
+  private pushEvent(operationId: string, event: Record<string, unknown>) {
+    this.httpPost('/api/operations/push-event', { event, operationId }).catch(() => {});
+  }
+
+  private async httpPost(path: string, body: Record<string, unknown>): Promise<void> {
+    try {
+      const res = await fetch(`${this.gatewayUrl}${path}`, {
+        body: JSON.stringify(body),
+        headers: {
+          'Authorization': `Bearer ${this.serviceToken}`,
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      });
+
+      if (!res.ok) {
+        log('Gateway %s returned %d: %s', path, res.status, await res.text());
+      }
+    } catch (error) {
+      log('Gateway %s failed: %O', path, error);
+    }
+  }
+}

--- a/src/server/modules/AgentRuntime/GatewayStreamNotifier.ts
+++ b/src/server/modules/AgentRuntime/GatewayStreamNotifier.ts
@@ -1,9 +1,13 @@
 import debug from 'debug';
+import urlJoin from 'url-join';
 
 import type { StreamChunkData, StreamEvent } from './StreamEventManager';
 import type { IStreamEventManager } from './types';
 
 const log = debug('lobe-server:agent-runtime:gateway-notifier');
+
+const POST_TIMEOUT = 5000; // 5s per request
+const MAX_INFLIGHT = 20; // bounded concurrency
 
 /**
  * Decorator that wraps an IStreamEventManager and additionally
@@ -13,6 +17,8 @@ const log = debug('lobe-server:agent-runtime:gateway-notifier');
  * The Gateway is an additional push channel for WebSocket delivery.
  */
 export class GatewayStreamNotifier implements IStreamEventManager {
+  private inflight = 0;
+
   constructor(
     private inner: IStreamEventManager,
     private gatewayUrl: string,
@@ -135,14 +141,24 @@ export class GatewayStreamNotifier implements IStreamEventManager {
   }
 
   private async httpPost(path: string, body: Record<string, unknown>): Promise<void> {
+    if (this.inflight >= MAX_INFLIGHT) {
+      log('Gateway %s dropped: max inflight (%d) reached', path, MAX_INFLIGHT);
+      return;
+    }
+
+    this.inflight++;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), POST_TIMEOUT);
+
     try {
-      const res = await fetch(`${this.gatewayUrl}${path}`, {
+      const res = await fetch(urlJoin(this.gatewayUrl, path), {
         body: JSON.stringify(body),
         headers: {
           'Authorization': `Bearer ${this.serviceToken}`,
           'Content-Type': 'application/json',
         },
         method: 'POST',
+        signal: controller.signal,
       });
 
       if (!res.ok) {
@@ -150,6 +166,9 @@ export class GatewayStreamNotifier implements IStreamEventManager {
       }
     } catch (error) {
       log('Gateway %s failed: %O', path, error);
+    } finally {
+      clearTimeout(timer);
+      this.inflight--;
     }
   }
 }

--- a/src/server/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GatewayStreamNotifier } from '../GatewayStreamNotifier';
+import type { StreamChunkData } from '../StreamEventManager';
+import type { IStreamEventManager } from '../types';
+
+// Mock global fetch
+const mockFetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('') });
+vi.stubGlobal('fetch', mockFetch);
+
+function createMockInner(): IStreamEventManager & { calls: Record<string, any[][]> } {
+  const calls: Record<string, any[][]> = {};
+
+  const track = (name: string) => {
+    calls[name] = [];
+    return (...args: any[]) => {
+      calls[name].push(args);
+      return Promise.resolve(`${name}-result`);
+    };
+  };
+
+  return {
+    calls,
+    cleanupOperation: track('cleanupOperation') as any,
+    disconnect: track('disconnect') as any,
+    getActiveOperationsCount: track('getActiveOperationsCount') as any,
+    getStreamHistory: track('getStreamHistory') as any,
+    publishAgentRuntimeEnd: track('publishAgentRuntimeEnd') as any,
+    publishAgentRuntimeInit: track('publishAgentRuntimeInit') as any,
+    publishStreamChunk: track('publishStreamChunk') as any,
+    publishStreamEvent: track('publishStreamEvent') as any,
+    subscribeStreamEvents: track('subscribeStreamEvents') as any,
+  };
+}
+
+describe('GatewayStreamNotifier', () => {
+  let inner: ReturnType<typeof createMockInner>;
+  let notifier: GatewayStreamNotifier;
+  const gatewayUrl = 'https://gateway.test.com';
+  const serviceToken = 'test-token';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    inner = createMockInner();
+    notifier = new GatewayStreamNotifier(inner, gatewayUrl, serviceToken);
+  });
+
+  // ─── Publish methods: must always call inner first ───
+
+  describe('publishStreamEvent', () => {
+    it('delegates to inner and returns its result', async () => {
+      const event = { data: { foo: 'bar' }, stepIndex: 0, type: 'step_start' as const };
+
+      const result = await notifier.publishStreamEvent('op-1', event);
+
+      expect(result).toBe('publishStreamEvent-result');
+      expect(inner.calls.publishStreamEvent).toHaveLength(1);
+      expect(inner.calls.publishStreamEvent[0]).toEqual(['op-1', event]);
+    });
+
+    it('pushes event to gateway via HTTP', async () => {
+      await notifier.publishStreamEvent('op-1', {
+        data: {},
+        stepIndex: 0,
+        type: 'step_start' as const,
+      });
+
+      // Wait for fire-and-forget
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${gatewayUrl}/api/operations/push-event`,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${serviceToken}`,
+          }),
+          method: 'POST',
+        }),
+      );
+    });
+
+    it('still returns inner result even if gateway fails', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network error'));
+
+      const result = await notifier.publishStreamEvent('op-1', {
+        data: {},
+        stepIndex: 0,
+        type: 'step_start' as const,
+      });
+
+      expect(result).toBe('publishStreamEvent-result');
+      expect(inner.calls.publishStreamEvent).toHaveLength(1);
+    });
+  });
+
+  describe('publishStreamChunk', () => {
+    it('delegates to inner and returns its result', async () => {
+      const chunkData: StreamChunkData = { chunkType: 'text', content: 'hello' };
+
+      const result = await notifier.publishStreamChunk('op-1', 0, chunkData);
+
+      expect(result).toBe('publishStreamChunk-result');
+      expect(inner.calls.publishStreamChunk).toHaveLength(1);
+      expect(inner.calls.publishStreamChunk[0]).toEqual(['op-1', 0, chunkData]);
+    });
+  });
+
+  describe('publishAgentRuntimeInit', () => {
+    it('delegates to inner and returns its result', async () => {
+      const initialState = { userId: 'user-1' };
+
+      const result = await notifier.publishAgentRuntimeInit('op-1', initialState);
+
+      expect(result).toBe('publishAgentRuntimeInit-result');
+      expect(inner.calls.publishAgentRuntimeInit).toHaveLength(1);
+      expect(inner.calls.publishAgentRuntimeInit[0]).toEqual(['op-1', initialState]);
+    });
+
+    it('calls gateway init and push-event endpoints', async () => {
+      await notifier.publishAgentRuntimeInit('op-1', { userId: 'user-1' });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const urls = mockFetch.mock.calls.map((c: any[]) => c[0]);
+      expect(urls).toContain(`${gatewayUrl}/api/operations/init`);
+      expect(urls).toContain(`${gatewayUrl}/api/operations/push-event`);
+    });
+  });
+
+  describe('publishAgentRuntimeEnd', () => {
+    it('delegates to inner and returns its result', async () => {
+      const finalState = { status: 'done' };
+
+      const result = await notifier.publishAgentRuntimeEnd('op-1', 2, finalState, 'completed');
+
+      expect(result).toBe('publishAgentRuntimeEnd-result');
+      expect(inner.calls.publishAgentRuntimeEnd).toHaveLength(1);
+      expect(inner.calls.publishAgentRuntimeEnd[0]).toEqual([
+        'op-1',
+        2,
+        finalState,
+        'completed',
+        undefined,
+      ]);
+    });
+
+    it('calls gateway push-event and update-status endpoints', async () => {
+      await notifier.publishAgentRuntimeEnd('op-1', 2, {}, 'completed', 'All done');
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const urls = mockFetch.mock.calls.map((c: any[]) => c[0]);
+      expect(urls).toContain(`${gatewayUrl}/api/operations/push-event`);
+      expect(urls).toContain(`${gatewayUrl}/api/operations/update-status`);
+    });
+
+    it('maps error reason to error status', async () => {
+      await notifier.publishAgentRuntimeEnd('op-1', 0, {}, 'error', 'Something broke');
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const statusCall = mockFetch.mock.calls.find(
+        (c: any[]) => c[0] === `${gatewayUrl}/api/operations/update-status`,
+      );
+      const body = JSON.parse(statusCall[1].body);
+      expect(body.status).toBe('error');
+    });
+  });
+
+  // ─── Read/subscribe methods: must delegate directly to inner ───
+
+  describe('subscribeStreamEvents', () => {
+    it('delegates directly to inner', async () => {
+      const onEvents = vi.fn();
+      const signal = new AbortController().signal;
+
+      await notifier.subscribeStreamEvents('op-1', '0', onEvents, signal);
+
+      expect(inner.calls.subscribeStreamEvents).toHaveLength(1);
+      expect(inner.calls.subscribeStreamEvents[0]).toEqual(['op-1', '0', onEvents, signal]);
+    });
+
+    it('does not call gateway', async () => {
+      await notifier.subscribeStreamEvents('op-1', '0', vi.fn());
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getStreamHistory', () => {
+    it('delegates directly to inner', async () => {
+      await notifier.getStreamHistory('op-1', 50);
+
+      expect(inner.calls.getStreamHistory).toHaveLength(1);
+      expect(inner.calls.getStreamHistory[0]).toEqual(['op-1', 50]);
+    });
+  });
+
+  describe('cleanupOperation', () => {
+    it('delegates directly to inner', async () => {
+      await notifier.cleanupOperation('op-1');
+
+      expect(inner.calls.cleanupOperation).toHaveLength(1);
+    });
+  });
+
+  describe('getActiveOperationsCount', () => {
+    it('delegates directly to inner', async () => {
+      await notifier.getActiveOperationsCount();
+
+      expect(inner.calls.getActiveOperationsCount).toHaveLength(1);
+    });
+  });
+
+  describe('disconnect', () => {
+    it('delegates directly to inner', async () => {
+      await notifier.disconnect();
+
+      expect(inner.calls.disconnect).toHaveLength(1);
+    });
+  });
+
+  // ─── Gateway failure resilience ───
+
+  describe('gateway failure does not affect inner', () => {
+    it('publishStreamEvent succeeds when gateway is unreachable', async () => {
+      mockFetch.mockRejectedValue(new Error('connection refused'));
+
+      const result = await notifier.publishStreamEvent('op-1', {
+        data: {},
+        stepIndex: 0,
+        type: 'step_start' as const,
+      });
+
+      expect(result).toBe('publishStreamEvent-result');
+      expect(inner.calls.publishStreamEvent).toHaveLength(1);
+    });
+
+    it('publishAgentRuntimeInit succeeds when gateway returns 500', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 500, text: () => 'Internal Error' });
+
+      const result = await notifier.publishAgentRuntimeInit('op-1', { userId: 'u1' });
+
+      expect(result).toBe('publishAgentRuntimeInit-result');
+      expect(inner.calls.publishAgentRuntimeInit).toHaveLength(1);
+    });
+
+    it('publishAgentRuntimeEnd succeeds when gateway times out', async () => {
+      mockFetch.mockImplementation(
+        () => new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 10)),
+      );
+
+      const result = await notifier.publishAgentRuntimeEnd('op-1', 0, {}, 'completed');
+
+      expect(result).toBe('publishAgentRuntimeEnd-result');
+      expect(inner.calls.publishAgentRuntimeEnd).toHaveLength(1);
+    });
+  });
+});

--- a/src/server/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
@@ -256,4 +256,64 @@ describe('GatewayStreamNotifier', () => {
       expect(inner.calls.publishAgentRuntimeEnd).toHaveLength(1);
     });
   });
+
+  // ─── Timeout and concurrency ───
+
+  describe('timeout and concurrency control', () => {
+    it('passes AbortSignal to fetch', async () => {
+      await notifier.publishStreamEvent('op-1', {
+        data: {},
+        stepIndex: 0,
+        type: 'step_start' as const,
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const fetchCall = mockFetch.mock.calls[0];
+      expect(fetchCall[1].signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('drops requests when max inflight is reached', async () => {
+      // Hold all fetches pending
+      const resolvers: Array<() => void> = [];
+      mockFetch.mockImplementation(
+        () =>
+          new Promise<{ ok: boolean }>((resolve) => {
+            resolvers.push(() => resolve({ ok: true }));
+          }),
+      );
+
+      // Fire 25 events (max inflight is 20)
+      for (let i = 0; i < 25; i++) {
+        notifier.publishStreamEvent(`op-${i}`, {
+          data: {},
+          stepIndex: 0,
+          type: 'step_start' as const,
+        });
+      }
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Only 20 should have actually called fetch
+      expect(mockFetch).toHaveBeenCalledTimes(20);
+
+      // Release all pending
+      for (const r of resolvers) r();
+    });
+
+    it('uses url-join for URL construction', async () => {
+      await notifier.publishStreamEvent('op-1', {
+        data: {},
+        stepIndex: 0,
+        type: 'step_start' as const,
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const url = mockFetch.mock.calls[0][0];
+      expect(url).toBe(`${gatewayUrl}/api/operations/push-event`);
+      // No double slashes
+      expect(url).not.toContain('//api');
+    });
+  });
 });

--- a/src/server/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
@@ -162,7 +162,8 @@ describe('GatewayStreamNotifier', () => {
       const statusCall = mockFetch.mock.calls.find(
         (c: any[]) => c[0] === `${gatewayUrl}/api/operations/update-status`,
       );
-      const body = JSON.parse(statusCall[1].body);
+      expect(statusCall).toBeDefined();
+      const body = JSON.parse(statusCall![1].body);
       expect(body.status).toBe('error');
     });
   });

--- a/src/server/modules/AgentRuntime/__tests__/factory.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/factory.test.ts
@@ -21,7 +21,7 @@ const {
   MockStreamEventManager: vi.fn(() => ({ kind: 'redis-stream-event-manager' })),
   mockAppEnv: {
     AGENT_GATEWAY_SERVICE_TOKEN: undefined as string | undefined,
-    AGENT_GATEWAY_URL: undefined as string | undefined,
+    AGENT_GATEWAY_URL: 'https://agent-gateway.lobehub.com',
     enableQueueAgentRuntime: false,
   },
   mockGetAgentRuntimeRedisClient: vi.fn(),
@@ -104,7 +104,7 @@ describe('AgentRuntime factory', () => {
   describe('createStreamEventManager', () => {
     beforeEach(() => {
       mockAppEnv.AGENT_GATEWAY_SERVICE_TOKEN = undefined;
-      mockAppEnv.AGENT_GATEWAY_URL = undefined;
+      mockAppEnv.AGENT_GATEWAY_URL = 'https://agent-gateway.lobehub.com';
     });
 
     it('prefers Redis-backed streams when Redis is available in local mode', () => {

--- a/src/server/modules/AgentRuntime/__tests__/factory.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/factory.test.ts
@@ -20,6 +20,8 @@ const {
   })),
   MockStreamEventManager: vi.fn(() => ({ kind: 'redis-stream-event-manager' })),
   mockAppEnv: {
+    AGENT_GATEWAY_SERVICE_TOKEN: undefined as string | undefined,
+    AGENT_GATEWAY_URL: undefined as string | undefined,
     enableQueueAgentRuntime: false,
   },
   mockGetAgentRuntimeRedisClient: vi.fn(),
@@ -100,15 +102,9 @@ describe('AgentRuntime factory', () => {
   });
 
   describe('createStreamEventManager', () => {
-    const originalEnv = { ...process.env };
-
     beforeEach(() => {
-      delete process.env.AGENT_GATEWAY_SERVICE_TOKEN;
-      delete process.env.AGENT_GATEWAY_URL;
-    });
-
-    afterEach(() => {
-      process.env = { ...originalEnv };
+      mockAppEnv.AGENT_GATEWAY_SERVICE_TOKEN = undefined;
+      mockAppEnv.AGENT_GATEWAY_URL = undefined;
     });
 
     it('prefers Redis-backed streams when Redis is available in local mode', () => {
@@ -132,7 +128,7 @@ describe('AgentRuntime factory', () => {
     });
 
     it('wraps with GatewayStreamNotifier when AGENT_GATEWAY_SERVICE_TOKEN is set', () => {
-      process.env.AGENT_GATEWAY_SERVICE_TOKEN = 'my-token';
+      mockAppEnv.AGENT_GATEWAY_SERVICE_TOKEN = 'my-token';
       mockGetAgentRuntimeRedisClient.mockReturnValue({ ping: vi.fn() });
 
       const result = createStreamEventManager() as any;
@@ -144,8 +140,8 @@ describe('AgentRuntime factory', () => {
     });
 
     it('uses custom AGENT_GATEWAY_URL when set', () => {
-      process.env.AGENT_GATEWAY_SERVICE_TOKEN = 'my-token';
-      process.env.AGENT_GATEWAY_URL = 'https://custom-gateway.example.com';
+      mockAppEnv.AGENT_GATEWAY_SERVICE_TOKEN = 'my-token';
+      mockAppEnv.AGENT_GATEWAY_URL = 'https://custom-gateway.example.com';
       mockGetAgentRuntimeRedisClient.mockReturnValue({ ping: vi.fn() });
 
       const result = createStreamEventManager() as any;
@@ -155,7 +151,7 @@ describe('AgentRuntime factory', () => {
     });
 
     it('wraps in-memory manager with gateway when no Redis', () => {
-      process.env.AGENT_GATEWAY_SERVICE_TOKEN = 'my-token';
+      mockAppEnv.AGENT_GATEWAY_SERVICE_TOKEN = 'my-token';
 
       const result = createStreamEventManager() as any;
 

--- a/src/server/modules/AgentRuntime/__tests__/factory.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/factory.test.ts
@@ -4,6 +4,7 @@ import { createAgentStateManager, createStreamEventManager, isRedisAvailable } f
 
 const {
   MockAgentStateManager,
+  MockGatewayStreamNotifier,
   MockStreamEventManager,
   mockAppEnv,
   mockGetAgentRuntimeRedisClient,
@@ -11,6 +12,12 @@ const {
   mockInMemoryStreamEventManager,
 } = vi.hoisted(() => ({
   MockAgentStateManager: vi.fn(() => ({ kind: 'redis-state-manager' })),
+  MockGatewayStreamNotifier: vi.fn((inner: any, url: string, token: string) => ({
+    inner,
+    kind: 'gateway-stream-notifier',
+    token,
+    url,
+  })),
   MockStreamEventManager: vi.fn(() => ({ kind: 'redis-stream-event-manager' })),
   mockAppEnv: {
     enableQueueAgentRuntime: false,
@@ -42,6 +49,10 @@ vi.mock('../AgentStateManager', () => ({
 
 vi.mock('../StreamEventManager', () => ({
   StreamEventManager: MockStreamEventManager,
+}));
+
+vi.mock('../GatewayStreamNotifier', () => ({
+  GatewayStreamNotifier: MockGatewayStreamNotifier,
 }));
 
 describe('AgentRuntime factory', () => {
@@ -89,6 +100,17 @@ describe('AgentRuntime factory', () => {
   });
 
   describe('createStreamEventManager', () => {
+    const originalEnv = { ...process.env };
+
+    beforeEach(() => {
+      delete process.env.AGENT_GATEWAY_SERVICE_TOKEN;
+      delete process.env.AGENT_GATEWAY_URL;
+    });
+
+    afterEach(() => {
+      process.env = { ...originalEnv };
+    });
+
     it('prefers Redis-backed streams when Redis is available in local mode', () => {
       mockGetAgentRuntimeRedisClient.mockReturnValue({ ping: vi.fn() });
 
@@ -107,6 +129,47 @@ describe('AgentRuntime factory', () => {
       expect(() => createStreamEventManager()).toThrow(
         'Redis is required when AGENT_RUNTIME_MODE=queue. Please configure `REDIS_URL`.',
       );
+    });
+
+    it('wraps with GatewayStreamNotifier when AGENT_GATEWAY_SERVICE_TOKEN is set', () => {
+      process.env.AGENT_GATEWAY_SERVICE_TOKEN = 'my-token';
+      mockGetAgentRuntimeRedisClient.mockReturnValue({ ping: vi.fn() });
+
+      const result = createStreamEventManager() as any;
+
+      expect(result.kind).toBe('gateway-stream-notifier');
+      expect(result.inner).toEqual({ kind: 'redis-stream-event-manager' });
+      expect(result.token).toBe('my-token');
+      expect(result.url).toBe('https://agent-gateway.lobehub.com');
+    });
+
+    it('uses custom AGENT_GATEWAY_URL when set', () => {
+      process.env.AGENT_GATEWAY_SERVICE_TOKEN = 'my-token';
+      process.env.AGENT_GATEWAY_URL = 'https://custom-gateway.example.com';
+      mockGetAgentRuntimeRedisClient.mockReturnValue({ ping: vi.fn() });
+
+      const result = createStreamEventManager() as any;
+
+      expect(result.kind).toBe('gateway-stream-notifier');
+      expect(result.url).toBe('https://custom-gateway.example.com');
+    });
+
+    it('wraps in-memory manager with gateway when no Redis', () => {
+      process.env.AGENT_GATEWAY_SERVICE_TOKEN = 'my-token';
+
+      const result = createStreamEventManager() as any;
+
+      expect(result.kind).toBe('gateway-stream-notifier');
+      expect(result.inner).toBe(mockInMemoryStreamEventManager);
+    });
+
+    it('does not wrap when AGENT_GATEWAY_SERVICE_TOKEN is not set', () => {
+      mockGetAgentRuntimeRedisClient.mockReturnValue({ ping: vi.fn() });
+
+      const result = createStreamEventManager() as any;
+
+      expect(result.kind).toBe('redis-stream-event-manager');
+      expect(MockGatewayStreamNotifier).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/server/modules/AgentRuntime/factory.ts
+++ b/src/server/modules/AgentRuntime/factory.ts
@@ -73,9 +73,12 @@ export const createStreamEventManager = (): IStreamEventManager => {
 
   // Wrap with Gateway notifier when configured
   if (appEnv.AGENT_GATEWAY_SERVICE_TOKEN) {
-    const gatewayUrl = appEnv.AGENT_GATEWAY_URL || 'https://agent-gateway.lobehub.com';
-    log('Wrapping with GatewayStreamNotifier (%s)', gatewayUrl);
-    return new GatewayStreamNotifier(manager, gatewayUrl, appEnv.AGENT_GATEWAY_SERVICE_TOKEN);
+    log('Wrapping with GatewayStreamNotifier (%s)', appEnv.AGENT_GATEWAY_URL);
+    return new GatewayStreamNotifier(
+      manager,
+      appEnv.AGENT_GATEWAY_URL,
+      appEnv.AGENT_GATEWAY_SERVICE_TOKEN,
+    );
   }
 
   return manager;

--- a/src/server/modules/AgentRuntime/factory.ts
+++ b/src/server/modules/AgentRuntime/factory.ts
@@ -3,6 +3,7 @@ import debug from 'debug';
 import { appEnv } from '@/envs/app';
 
 import { AgentStateManager } from './AgentStateManager';
+import { GatewayStreamNotifier } from './GatewayStreamNotifier';
 import { inMemoryAgentStateManager } from './InMemoryAgentStateManager';
 import { inMemoryStreamEventManager } from './InMemoryStreamEventManager';
 import { getAgentRuntimeRedisClient } from './redis';
@@ -54,17 +55,29 @@ export const createAgentStateManager = (): IAgentStateManager => {
  * - If Redis is unavailable and enableQueueAgentRuntime=true: throw
  */
 export const createStreamEventManager = (): IStreamEventManager => {
+  let manager: IStreamEventManager;
+
   // Prefer Redis whenever it is available so the runtime worker and SSE route
   // can communicate through the same stream bus even in local mode.
   if (isRedisAvailable()) {
     log('Redis available, using StreamEventManager');
-    return new StreamEventManager();
-  }
-
-  if (!isQueueModeEnabled()) {
+    manager = new StreamEventManager();
+  } else if (!isQueueModeEnabled()) {
     log('Redis unavailable and queue mode disabled, using InMemoryStreamEventManager');
-    return inMemoryStreamEventManager;
+    manager = inMemoryStreamEventManager;
+  } else {
+    throw new Error(
+      'Redis is required when AGENT_RUNTIME_MODE=queue. Please configure `REDIS_URL`.',
+    );
   }
 
-  throw new Error('Redis is required when AGENT_RUNTIME_MODE=queue. Please configure `REDIS_URL`.');
+  // Wrap with Gateway notifier when configured
+  const gatewayToken = process.env.AGENT_GATEWAY_SERVICE_TOKEN;
+  if (gatewayToken) {
+    const gatewayUrl = process.env.AGENT_GATEWAY_URL || 'https://agent-gateway.lobehub.com';
+    log('Wrapping with GatewayStreamNotifier (%s)', gatewayUrl);
+    return new GatewayStreamNotifier(manager, gatewayUrl, gatewayToken);
+  }
+
+  return manager;
 };

--- a/src/server/modules/AgentRuntime/factory.ts
+++ b/src/server/modules/AgentRuntime/factory.ts
@@ -72,11 +72,10 @@ export const createStreamEventManager = (): IStreamEventManager => {
   }
 
   // Wrap with Gateway notifier when configured
-  const gatewayToken = process.env.AGENT_GATEWAY_SERVICE_TOKEN;
-  if (gatewayToken) {
-    const gatewayUrl = process.env.AGENT_GATEWAY_URL || 'https://agent-gateway.lobehub.com';
+  if (appEnv.AGENT_GATEWAY_SERVICE_TOKEN) {
+    const gatewayUrl = appEnv.AGENT_GATEWAY_URL || 'https://agent-gateway.lobehub.com';
     log('Wrapping with GatewayStreamNotifier (%s)', gatewayUrl);
-    return new GatewayStreamNotifier(manager, gatewayUrl, gatewayToken);
+    return new GatewayStreamNotifier(manager, gatewayUrl, appEnv.AGENT_GATEWAY_SERVICE_TOKEN);
   }
 
   return manager;

--- a/src/server/modules/AgentRuntime/index.ts
+++ b/src/server/modules/AgentRuntime/index.ts
@@ -2,6 +2,7 @@ export type { AgentRuntimeCoordinatorOptions } from './AgentRuntimeCoordinator';
 export { AgentRuntimeCoordinator } from './AgentRuntimeCoordinator';
 export { AgentStateManager } from './AgentStateManager';
 export { createAgentStateManager, createStreamEventManager, isRedisAvailable } from './factory';
+export { GatewayStreamNotifier } from './GatewayStreamNotifier';
 export { InMemoryAgentStateManager } from './InMemoryAgentStateManager';
 export { InMemoryStreamEventManager } from './InMemoryStreamEventManager';
 export { createRuntimeExecutors } from './RuntimeExecutors';


### PR DESCRIPTION
## Summary

- Add `GatewayStreamNotifier` decorator that wraps `IStreamEventManager` to push events to the Agent Gateway via HTTP (fire-and-forget)
- Update `createStreamEventManager` factory to auto-wrap with gateway notifier when `AGENT_GATEWAY_SERVICE_TOKEN` is configured
- Redis SSE remains the primary event channel; the gateway is an additive push layer for WebSocket delivery

## How it works

```
AgentRuntimeService.executeStep()
  → publishStreamEvent() / publishStreamChunk() / etc.
    → GatewayStreamNotifier
      ├→ inner.publish*()  [Redis Streams, unchanged]
      └→ HTTP POST → agent-gateway/api/operations/push-event  [new, fire-and-forget]
```

## Environment Variables

| Variable | Description |
|----------|-------------|
| `AGENT_GATEWAY_SERVICE_TOKEN` | Enables gateway push when set |
| `AGENT_GATEWAY_URL` | Gateway URL (default: `https://agent-gateway.lobehub.com`) |

## Test plan

- [x] Type check passes
- [x] Verified with local dev server + CLI agent execution
- [x] Confirmed events arrive at gateway (`/api/operations/status` returns `completed`)
- [x] Existing Redis SSE path unaffected (CLI still receives events via SSE)

Fixes LOBE-6723

🤖 Generated with [Claude Code](https://claude.com/claude-code)