### PR TITLE
🔧 chore: disable input completion by default

### DIFF
--- a/packages/const/src/settings/systemAgent.ts
+++ b/packages/const/src/settings/systemAgent.ts
@@ -24,7 +24,7 @@ export const DEFAULT_QUERY_REWRITE_SYSTEM_AGENT_ITEM: QueryRewriteSystemAgent = 
 };
 
 export const DEFAULT_INPUT_COMPLETION_SYSTEM_AGENT_ITEM: SystemAgentItem = {
-  enabled: true,
+  enabled: false,
   model: DEFAULT_MINI_SYSTEM_AGENT_ITEM.model,
   provider: DEFAULT_MINI_SYSTEM_AGENT_ITEM.provider,
 };

--- a/src/store/user/slices/settings/selectors/__snapshots__/settings.test.ts.snap
+++ b/src/store/user/slices/settings/selectors/__snapshots__/settings.test.ts.snap
@@ -64,7 +64,7 @@ exports[`settingsSelectors > currentSystemAgent > should merge DEFAULT_SYSTEM_AG
     "provider": "anthropic",
   },
   "inputCompletion": {
-    "enabled": true,
+    "enabled": false,
     "model": "gpt-5.4-mini",
     "provider": "openai",
   },


### PR DESCRIPTION
## Summary
- Disable the input auto-completion agent by default (`enabled: false`)
- The feature experience is not polished enough yet for default-on
- Users can still manually enable it in Settings > Agent

## Changes
- `packages/const/src/settings/systemAgent.ts`: `DEFAULT_INPUT_COMPLETION_SYSTEM_AGENT_ITEM.enabled` changed from `true` to `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)