### PR TITLE
🐛 fix: preserve backend traceId in error handler

### DIFF
--- a/src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
+++ b/src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
@@ -1727,4 +1727,110 @@ describe('call_llm executor', () => {
       expect(finalContent).toBe('Partial output');
     });
   });
+
+  describe('Error traceId preservation', () => {
+    it('should preserve backend traceId when local traceId is undefined', async () => {
+      // Given
+      const mockStore = createMockStore();
+      const context = createTestContext();
+      const instruction = createCallLLMInstruction();
+      const state = createInitialState();
+
+      mockStore.dbMessagesMap[context.messageKey] = [];
+
+      const backendTraceId = 'backend-trace-id-123';
+
+      vi.mocked(chatService.createAssistantMessageStream).mockImplementation(
+        async (params: any) => {
+          if (params.onErrorHandle) {
+            params.onErrorHandle({
+              body: {
+                traceId: backendTraceId,
+              },
+              message: 'Provider error',
+              type: 'ProviderBizError',
+            });
+          }
+
+          if (params.onFinish) {
+            await params.onFinish('', { type: 'error' });
+          }
+        },
+      );
+
+      // When
+      await executeWithMockContext({
+        executor: 'call_llm',
+        instruction,
+        state,
+        mockStore,
+        context,
+      });
+
+      // Then
+      expect(mockStore.optimisticUpdateMessageError).toHaveBeenCalled();
+      const errorCall = vi.mocked(mockStore.optimisticUpdateMessageError).mock.calls[0];
+      const errorArg = errorCall[1] as any;
+      expect(errorArg.body.traceId).toBe(backendTraceId);
+    });
+
+    it('should use local traceId when available', async () => {
+      // Given
+      const mockStore = createMockStore();
+      const localTraceId = 'local-trace-id-456';
+      const context = createTestContext();
+      const instruction = createCallLLMInstruction();
+      const state = createInitialState();
+
+      // Set traceId on operation metadata
+      mockStore.operations[context.operationId] = {
+        abortController: new AbortController(),
+        childOperationIds: [],
+        context: {
+          agentId: context.agentId,
+          messageId: context.parentId,
+          topicId: context.topicId,
+        },
+        id: context.operationId,
+        metadata: { startTime: Date.now(), traceId: localTraceId },
+        status: 'running',
+        type: 'execAgentRuntime',
+      };
+
+      mockStore.dbMessagesMap[context.messageKey] = [];
+
+      vi.mocked(chatService.createAssistantMessageStream).mockImplementation(
+        async (params: any) => {
+          if (params.onErrorHandle) {
+            params.onErrorHandle({
+              body: {
+                traceId: 'backend-trace-id',
+              },
+              message: 'Provider error',
+              type: 'ProviderBizError',
+            });
+          }
+
+          if (params.onFinish) {
+            await params.onFinish('', { type: 'error' });
+          }
+        },
+      );
+
+      // When
+      await executeWithMockContext({
+        executor: 'call_llm',
+        instruction,
+        state,
+        mockStore,
+        context,
+      });
+
+      // Then - local traceId should take precedence
+      expect(mockStore.optimisticUpdateMessageError).toHaveBeenCalled();
+      const errorCall = vi.mocked(mockStore.optimisticUpdateMessageError).mock.calls[0];
+      const errorArg = errorCall[1] as any;
+      expect(errorArg.body.traceId).toBe(localTraceId);
+    });
+  });
 });

--- a/src/store/chat/agents/createAgentExecutors.ts
+++ b/src/store/chat/agents/createAgentExecutors.ts
@@ -480,7 +480,7 @@ export const createAgentExecutors = (context: {
             ...error,
             body: {
               ...error.body,
-              traceId,
+              traceId: traceId ?? error.body?.traceId,
             },
           };
           const localizedError = localizeError(enrichedError);


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Regression from https://github.com/lobehub/lobehub/pull/13468

#### 🔀 Description of Change

`onErrorHandle` in `createAgentExecutors.ts` unconditionally overwrites `error.body.traceId` with a local `traceId` variable that is always `undefined` (from `operation.metadata?.traceId`). This destroys the backend-provided traceId (error log ID), causing the frontend to display `{}` instead of the trace ID.

Fix: fall back to `error.body?.traceId` when local traceId is undefined.

#### 🧪 How to Test

- [x] No tests needed

Trigger a provider error (e.g. send invalid tool schema to Vertex AI) and verify the error UI now shows the traceId instead of `{}`.