### PR TITLE
🐛 fix(model-runtime): strip additionalProperties and leftover $ref in Google tool schemas

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/google.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.test.ts
@@ -1406,7 +1406,6 @@ describe('google contextBuilders', () => {
       expect(result.parameters?.properties).toEqual({
         query: { type: 'string' },
         timeIntent: {
-          additionalProperties: false,
           properties: {
             selector: { enum: ['today', 'yesterday', 'month'], type: 'string' },
             date: { format: 'date-time', type: 'string' },
@@ -1544,6 +1543,77 @@ describe('google contextBuilders', () => {
       expect(result.parameters?.properties).toEqual({
         field: { description: 'some field' },
       });
+    });
+
+    it('should strip additionalProperties from schemas', () => {
+      const tool: ChatCompletionTool = {
+        function: {
+          description: 'A tool with additionalProperties',
+          name: 'apTool',
+          parameters: {
+            properties: {
+              config: {
+                additionalProperties: false,
+                properties: {
+                  nested: {
+                    additionalProperties: { type: 'string' },
+                    type: 'object',
+                  },
+                },
+                type: 'object',
+              },
+            },
+            type: 'object',
+          },
+        },
+        type: 'function',
+      };
+
+      const result = buildGoogleTool(tool);
+
+      expect(result.parameters?.properties).toEqual({
+        config: {
+          properties: {
+            nested: {
+              type: 'object',
+            },
+          },
+          type: 'object',
+        },
+      });
+    });
+
+    it('should strip remaining $ref when resolveRefs exceeds depth limit', () => {
+      // Build a deeply recursive schema that exceeds depth limit of 10
+      const tool: ChatCompletionTool = {
+        function: {
+          description: 'A tool with deep recursive $ref',
+          name: 'deepRefTool',
+          parameters: {
+            definitions: {
+              node: {
+                properties: {
+                  child: { oneOf: [{ type: 'string' }, { $ref: '#/definitions/node' }] },
+                },
+                type: 'object',
+              },
+            },
+            properties: {
+              root: { $ref: '#/definitions/node' },
+            },
+            type: 'object',
+          },
+        },
+        type: 'function',
+      };
+
+      const result = buildGoogleTool(tool);
+
+      // Verify no $ref remains anywhere in the output
+      const json = JSON.stringify(result);
+      expect(json).not.toContain('"$ref"');
+      // Also verify no additionalProperties
+      expect(json).not.toContain('"additionalProperties"');
     });
   });
 

--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -252,7 +252,7 @@ export const buildGoogleMessages = async (messages: OpenAIChatMessage[]): Promis
  * JSON Schema keywords that cause Google GenAI / Vertex AI SDK validation errors.
  * Other unsupported keywords are silently ignored by the API, so only strip these.
  */
-const UNSUPPORTED_SCHEMA_KEYS = new Set(['examples', 'default']);
+const UNSUPPORTED_SCHEMA_KEYS = new Set(['examples', 'default', 'additionalProperties', '$ref']);
 
 /**
  * Resolve all `$ref` pointers in a JSON Schema tree by inlining definitions.


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up to #13524

#### 🔀 Description of Change

Google Gemini / Vertex AI rejects `additionalProperties` and `$ref` in function declaration schemas. PR #13524 resolved most `$ref` via `resolveRefs()` but missed two cases:

1. **`additionalProperties`** — was never stripped, causing `Unknown name "additionalProperties"` errors
2. **`$ref`** — survived when `resolveRefs` hit its depth limit (>10) on recursive schemas, causing `Unknown name "$ref"` errors

Fix: add both keys to `UNSUPPORTED_SCHEMA_KEYS` so `sanitizeSchemaForGoogle()` strips them after ref resolution.

#### 🧪 How to Test

- [x] Added/updated tests

```bash
cd packages/model-runtime && bunx vitest run src/core/contextBuilders/google.test.ts
```

2 new test cases:
- Strips `additionalProperties` from nested schemas
- Strips remaining `$ref` when `resolveRefs` exceeds depth limit on recursive schemas

#### 📝 Additional Information

Error reproduced with `gemini-3.1-pro-preview` model when user tools contain deeply nested recursive schemas with `additionalProperties` and `$ref`.