### PR TITLE
🐛 fix(desktop): remote re-auth for batched tRPC and clean OIDC on disconnect

### DIFF
--- a/apps/desktop/src/main/core/infrastructure/BackendProxyProtocolManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/BackendProxyProtocolManager.ts
@@ -160,14 +160,13 @@ export class BackendProxyProtocolManager {
         responseHeaders.set('Access-Control-Allow-Headers', '*');
         responseHeaders.set('X-Src-Url', rewrittenUrl);
 
-        // Handle 401 Unauthorized: only notify authorization required for real auth failures
-        // The server sets X-Auth-Required header for real authentication failures (e.g., token expired)
-        // Other 401 errors (e.g., invalid API keys) should not trigger re-authentication
-        if (upstreamResponse.status === 401) {
-          const authRequired = upstreamResponse.headers.get(AUTH_REQUIRED_HEADER) === 'true';
-          if (authRequired) {
-            this.notifyAuthorizationRequired();
-          }
+        // Re-auth prompt: rely on X-Auth-Required (set by tRPC responseMeta for UNAUTHORIZED).
+        // Batched tRPC responses can use HTTP 207 when calls mix success (200) and UNAUTHORIZED (401);
+        // checking only status === 401 misses that case and the login modal never opens.
+        // Other failures keep 401 without this header (e.g., invalid API keys) and must not notify here.
+        const authRequired = upstreamResponse.headers.get(AUTH_REQUIRED_HEADER) === 'true';
+        if (authRequired) {
+          this.notifyAuthorizationRequired();
         }
 
         return new Response(upstreamResponse.body, {

--- a/apps/desktop/src/main/core/infrastructure/__tests__/BackendProxyProtocolManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/BackendProxyProtocolManager.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AUTH_REQUIRED_HEADER } from '@lobechat/desktop-bridge';
+import { BrowserWindow } from 'electron';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BackendProxyProtocolManager } from '../BackendProxyProtocolManager';
 
@@ -37,10 +39,20 @@ vi.mock('@/utils/logger', () => ({
   }),
 }));
 
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: vi.fn(),
+  },
+}));
+
 describe('BackendProxyProtocolManager', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     protocolHandlerRef.current = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should rewrite url to remote base and inject Oidc-Auth token', async () => {
@@ -208,5 +220,42 @@ describe('BackendProxyProtocolManager', () => {
         url: 'lobe-backend://app/trpc/hello',
       } as any),
     ).rejects.toThrow('network down');
+  });
+
+  it('should broadcast authorizationRequired when X-Auth-Required is set on HTTP 207 (batched tRPC)', async () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
+      { isDestroyed: () => false, webContents: { send } },
+    ] as any);
+
+    const manager = new BackendProxyProtocolManager();
+    const session = { protocol: mockProtocol } as any;
+
+    const headers = new Headers({
+      [AUTH_REQUIRED_HEADER]: 'true',
+      'Content-Type': 'application/json',
+    });
+    const fetchMock = vi.fn<FetchMock>(
+      async () => new Response('[]', { headers, status: 207, statusText: 'Multi-Status' }),
+    );
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    manager.registerWithRemoteBaseUrl(session, {
+      getAccessToken: async () => null,
+      getRemoteBaseUrl: async () => 'https://remote.example.com',
+      scheme: 'lobe-backend',
+    });
+
+    const handler = protocolHandlerRef.current;
+    await handler({
+      headers: new Headers(),
+      method: 'GET',
+      url: 'lobe-backend://app/trpc/lambda/batch?batch=1',
+    } as any);
+
+    expect(send).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(send).toHaveBeenCalledWith('authorizationRequired');
   });
 });

--- a/src/components/InvalidAPIKey/__tests__/ComfyUIForm.test.tsx
+++ b/src/components/InvalidAPIKey/__tests__/ComfyUIForm.test.tsx
@@ -69,6 +69,7 @@ vi.mock('@lobehub/icons', () => ({
 }));
 
 vi.mock('@lobehub/ui', () => ({
+  ShikiLobeTheme: { name: 'lobe-test', type: 'dark' as const, colors: {} },
   Icon: vi.fn(({ icon, ...props }) => (
     <div data-testid="icon" {...props}>
       {icon?.name}
@@ -123,15 +124,6 @@ vi.mock('@/features/ChatList/Error/style', () => ({
 }));
 
 describe('ComfyUIForm Integration', () => {
-  const mockProps = {
-    bedrockDescription: 'bedrock.description',
-    description: 'comfyui.description',
-    id: 'test-batch-id',
-    onClose: vi.fn(),
-    onRecreate: vi.fn(),
-    provider: ModelProvider.ComfyUI,
-  };
-
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/src/features/Electron/AuthRequiredModal/index.tsx
+++ b/src/features/Electron/AuthRequiredModal/index.tsx
@@ -133,12 +133,14 @@ export const useAuthRequiredModal = () => {
  */
 const AuthRequiredModal = memo(() => {
   const { open } = useAuthRequiredModal();
-  const dataSyncConfig = useElectronStore((s) => s.dataSyncConfig);
 
   useWatchBroadcast('authorizationRequired', () => {
-    if (useElectronStore.getState().isConnectionDrawerOpen) return;
-    // Only show modal if onboarding is completed (remote server is configured)
-    if (!dataSyncConfig?.active) return;
+    const state = useElectronStore.getState();
+    if (state.isConnectionDrawerOpen) return;
+    // Wait until remote sync config has loaded once (avoid a flash before SWR resolves).
+    // Do not gate on `dataSyncConfig.active`: after sign-out `active` is false but 401 + X-Auth-Required
+    // still means the user must re-authenticate; gating on active would suppress the modal forever.
+    if (!state.isInitRemoteServerConfig) return;
 
     open();
   });

--- a/src/features/LibraryModal/AddFilesToKnowledgeBase/index.test.tsx
+++ b/src/features/LibraryModal/AddFilesToKnowledgeBase/index.test.tsx
@@ -1,3 +1,4 @@
+import type * as LobehubUiModule from '@lobehub/ui';
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -5,12 +6,17 @@ import { useAddFilesToKnowledgeBaseModal } from './index';
 
 const mockCreateModal = vi.hoisted(() => vi.fn());
 
-vi.mock('@lobehub/ui', () => ({
-  Flexbox: () => null,
-  Icon: () => null,
-  createModal: mockCreateModal,
-  useModalContext: () => ({ close: vi.fn() }),
-}));
+vi.mock('@lobehub/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof LobehubUiModule>();
+
+  return {
+    ...actual,
+    Flexbox: () => null,
+    Icon: () => null,
+    createModal: mockCreateModal,
+    useModalContext: () => ({ close: vi.fn() }),
+  };
+});
 
 describe('useAddFilesToKnowledgeBaseModal', () => {
   it('should forward onClose to createModal afterClose', () => {

--- a/src/hooks/useUserAvatar.test.ts
+++ b/src/hooks/useUserAvatar.test.ts
@@ -9,15 +9,14 @@ import { useUserAvatar } from './useUserAvatar';
 
 vi.mock('zustand/traditional');
 
-// Mock @lobechat/const
-let mockIsDesktop = false;
+const mockConstEnv = vi.hoisted(() => ({ isDesktop: false }));
 
 vi.mock('@lobechat/const', async (importOriginal) => {
   const actual = await importOriginal<typeof LobechatConstModule>();
   return {
     ...actual,
     get isDesktop() {
-      return mockIsDesktop;
+      return mockConstEnv.isDesktop;
     },
     DEFAULT_USER_AVATAR: 'default-avatar.png',
     OFFICIAL_URL: 'https://app.lobehub.com',
@@ -48,7 +47,7 @@ describe('useUserAvatar', () => {
   });
 
   it('should return original avatar in non-desktop environment', () => {
-    mockIsDesktop = false;
+    mockConstEnv.isDesktop = false;
     const mockAvatar = '/api/avatar.png';
 
     act(() => {
@@ -64,7 +63,7 @@ describe('useUserAvatar', () => {
   });
 
   it('should return original avatar when no remote server URL in desktop environment (selfHost mode)', () => {
-    mockIsDesktop = true;
+    mockConstEnv.isDesktop = true;
     const mockAvatar = '/api/avatar.png';
 
     act(() => {
@@ -80,7 +79,7 @@ describe('useUserAvatar', () => {
   });
 
   it('should prepend remote server URL when avatar starts with / in desktop environment (selfHost mode)', () => {
-    mockIsDesktop = true;
+    mockConstEnv.isDesktop = true;
     const mockAvatar = '/api/avatar.png';
     const mockServerUrl = 'https://server.com';
 
@@ -97,7 +96,7 @@ describe('useUserAvatar', () => {
   });
 
   it('should not prepend remote server URL when avatar does not start with / in desktop environment', () => {
-    mockIsDesktop = true;
+    mockConstEnv.isDesktop = true;
     const mockAvatar = 'https://example.com/avatar.png';
     const mockServerUrl = 'https://server.com';
 
@@ -114,7 +113,7 @@ describe('useUserAvatar', () => {
   });
 
   it('should use OFFICIAL_URL when storageMode is cloud in desktop environment', () => {
-    mockIsDesktop = true;
+    mockConstEnv.isDesktop = true;
     const mockAvatar = '/api/avatar.png';
 
     act(() => {
@@ -131,7 +130,7 @@ describe('useUserAvatar', () => {
   });
 
   it('should return original avatar when storageMode is selfHost but no URL configured', () => {
-    mockIsDesktop = true;
+    mockConstEnv.isDesktop = true;
     const mockAvatar = '/api/avatar.png';
 
     act(() => {

--- a/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
+++ b/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
@@ -704,12 +704,22 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
   useEffect(() => {
     const unsubscribe = marketAuthEvents.on('market-unauthorized', async (event) => {
       console.info('[MarketAuth] Received unauthorized event for path:', event.path);
-      // Attempt to recover (refresh token or re-authenticate)
+      // Desktop: do not open community auth / profile modals from background API 401s.
+      // Only attempt a silent token refresh; Lobe cloud re-auth is handled separately (AuthRequiredModal).
+      if (isDesktop) {
+        const refreshed = await refreshToken();
+        if (!refreshed) {
+          console.info(
+            '[MarketAuth] Desktop: market 401 — refresh failed, skipping community sign-in UI',
+          );
+        }
+        return;
+      }
       await handleUnauthorized();
     });
 
     return unsubscribe;
-  }, [handleUnauthorized]);
+  }, [handleUnauthorized, isDesktop, refreshToken]);
 
   const contextValue: MarketAuthContextType = {
     checkAndShowClaimableResources,

--- a/src/store/agent/store.ts
+++ b/src/store/agent/store.ts
@@ -5,6 +5,7 @@ import { type StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { type AgentStoreState } from './initialState';
 import { initialState } from './initialState';
 import { type AgentSliceAction } from './slices/agent';
@@ -30,6 +31,7 @@ export interface AgentStore
     CronSliceAction,
     KnowledgeSliceAction,
     PluginSliceAction,
+    ResetableStore,
     AgentStoreState {}
 
 type AgentStoreAction = AgentSliceAction &
@@ -37,7 +39,12 @@ type AgentStoreAction = AgentSliceAction &
   BuiltinAgentSliceAction &
   CronSliceAction &
   KnowledgeSliceAction &
-  PluginSliceAction;
+  PluginSliceAction &
+  ResetableStore;
+
+class AgentStoreResetAction extends ResetableStoreAction<AgentStore> {
+  protected readonly resetActionName = 'resetAgentStore';
+}
 
 const createStore: StateCreator<AgentStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<AgentStore, [['zustand/devtools', never]]>>
@@ -50,6 +57,7 @@ const createStore: StateCreator<AgentStore, [['zustand/devtools', never]]> = (
     createCronSlice(...parameters),
     createKnowledgeSlice(...parameters),
     createPluginSlice(...parameters),
+    new AgentStoreResetAction(...parameters),
   ]),
 });
 

--- a/src/store/agentGroup/action.ts
+++ b/src/store/agentGroup/action.ts
@@ -11,9 +11,10 @@ import { type ChatGroupStore } from '@/store/agentGroup/store';
 import { useChatStore } from '@/store/chat';
 import { type StoreSetter } from '@/store/types';
 import { flattenActions } from '@/store/utils/flattenActions';
+import { type ResetableStore } from '@/store/utils/resetableStore';
 import { setNamespace } from '@/utils/storeDebug';
 
-import { type ChatGroupState } from './initialState';
+import { type ChatGroupState, initialChatGroupState } from './initialState';
 import { type ChatGroupDispatchPayloads, type ChatGroupReducer } from './reducers';
 import { chatGroupReducers } from './reducers';
 import { ChatGroupCurdAction } from './slices/curd';
@@ -35,7 +36,7 @@ const toAgentGroupDetail = (group: ChatGroupItem): AgentGroupDetail =>
   }) as AgentGroupDetail;
 
 type Setter = StoreSetter<ChatGroupStore>;
-class ChatGroupInternalAction {
+class ChatGroupInternalAction implements ResetableStore {
   readonly #get: () => ChatGroupState;
   readonly #set: Setter;
 
@@ -46,6 +47,10 @@ class ChatGroupInternalAction {
     this.#set = set;
     this.#get = get;
   }
+
+  reset: ResetableStore['reset'] = () => {
+    this.#set(initialChatGroupState, false, n('reset'));
+  };
 
   internal_dispatchChatGroup = <T extends keyof ChatGroupDispatchPayloads>(payload: {
     payload: ChatGroupDispatchPayloads[T];

--- a/src/store/chat/store.ts
+++ b/src/store/chat/store.ts
@@ -7,6 +7,7 @@ import { type StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { type ChatStoreState } from './initialState';
 import { initialState } from './initialState';
 import { type ChatAIAgentAction } from './slices/aiAgent/actions';
@@ -42,11 +43,16 @@ export type ChatStoreAction = ChatMessageAction &
   ChatBuiltinToolAction &
   ChatPortalAction &
   OperationActions &
-  ChatAIAgentAction;
+  ChatAIAgentAction &
+  ResetableStore;
 
 export type ChatStore = ChatStoreAction & ChatStoreState;
 
 //  ===============  Aggregate createStoreFn ============ //
+
+class ChatStoreResetAction extends ResetableStoreAction<ChatStore> {
+  protected readonly resetActionName = 'resetChatStore';
+}
 
 const createStore: StateCreator<ChatStore, [['zustand/devtools', never]]> = (
   ...params: Parameters<StateCreator<ChatStore, [['zustand/devtools', never]]>>
@@ -65,6 +71,7 @@ const createStore: StateCreator<ChatStore, [['zustand/devtools', never]]> = (
       new ChatPortalActionImpl(...params),
       new OperationActionsImpl(...params),
       chatAiAgent(...params),
+      new ChatStoreResetAction(...params),
     ]) as ChatStoreAction),
     // cloud
   }) as ChatStore;

--- a/src/store/discover/store.ts
+++ b/src/store/discover/store.ts
@@ -5,6 +5,7 @@ import { type StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { type AssistantAction } from './slices/assistant/action';
 import { createAssistantSlice } from './slices/assistant/action';
 import { type GroupAgentAction } from './slices/groupAgent/action';
@@ -34,7 +35,8 @@ export type DiscoverStore = MCPAction &
   PluginAction &
   SkillAction &
   SocialAction &
-  UserAction;
+  UserAction &
+  ResetableStore;
 
 type DiscoverStoreAction = MCPAction &
   AssistantAction &
@@ -44,7 +46,12 @@ type DiscoverStoreAction = MCPAction &
   PluginAction &
   SkillAction &
   SocialAction &
-  UserAction;
+  UserAction &
+  ResetableStore;
+
+class DiscoverStoreResetAction extends ResetableStoreAction<DiscoverStore> {
+  protected readonly resetActionName = 'resetDiscoverStore';
+}
 
 const createStore: StateCreator<DiscoverStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<DiscoverStore, [['zustand/devtools', never]]>>
@@ -59,6 +66,7 @@ const createStore: StateCreator<DiscoverStore, [['zustand/devtools', never]]> = 
     createSkillSlice(...parameters),
     createSocialSlice(...parameters),
     createUserSlice(...parameters),
+    new DiscoverStoreResetAction(...parameters),
   ]);
 
 //  ===============  Implement useStore ============ //

--- a/src/store/document/store.ts
+++ b/src/store/document/store.ts
@@ -5,6 +5,7 @@ import { type StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { type DocumentAction } from './slices/document';
 import { createDocumentSlice } from './slices/document';
 import { type EditorAction, type EditorState } from './slices/editor';
@@ -14,7 +15,7 @@ import { createEditorSlice, initialEditorState } from './slices/editor';
 export type DocumentState = EditorState;
 
 // Action type
-export type DocumentStoreAction = DocumentAction & EditorAction;
+export type DocumentStoreAction = DocumentAction & EditorAction & ResetableStore;
 
 // Full store type
 export type DocumentStore = DocumentState & DocumentStoreAction;
@@ -24,6 +25,10 @@ const initialState: DocumentState = {
   ...initialEditorState,
 };
 
+class DocumentStoreResetAction extends ResetableStoreAction<DocumentStore> {
+  protected readonly resetActionName = 'resetDocumentStore';
+}
+
 const createStore: StateCreator<DocumentStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<DocumentStore, [['zustand/devtools', never]]>>
 ) => ({
@@ -31,6 +36,7 @@ const createStore: StateCreator<DocumentStore, [['zustand/devtools', never]]> = 
   ...flattenActions<DocumentStoreAction>([
     createDocumentSlice(...parameters),
     createEditorSlice(...parameters),
+    new DocumentStoreResetAction(...parameters),
   ]),
 });
 

--- a/src/store/electron/actions/sync.ts
+++ b/src/store/electron/actions/sync.ts
@@ -5,7 +5,11 @@ import useSWR from 'swr';
 
 import { mutate } from '@/libs/swr';
 import { remoteServerService } from '@/services/electron/remoteServer';
+import { useChatStore } from '@/store/chat';
+import { useSessionStore } from '@/store/session';
 import { type StoreSetter } from '@/store/types';
+import { useUserStore } from '@/store/user';
+import { stores } from '@/store/utils/userDataStores';
 
 import { type ElectronStore } from '../store';
 
@@ -76,8 +80,7 @@ export class ElectronRemoteServerActionImpl {
       // Must use clearRemoteServerConfig (not only set active: false): main process
       // clears encrypted OIDC access/refresh tokens; otherwise sign-out still leaves auth state.
       await remoteServerService.clearRemoteServerConfig();
-      // Match persisted config until SWR refetches
-      this.#set({ dataSyncConfig: { active: false, storageMode: 'cloud' } });
+      stores.reset();
       await this.#get().refreshServerConfig();
     } catch (error) {
       console.error('Disconnect failed:', error);
@@ -94,14 +97,12 @@ export class ElectronRemoteServerActionImpl {
   };
 
   refreshUserData = async (): Promise<void> => {
-    const { getSessionStoreState } = await import('@/store/session');
-    const { getChatStoreState } = await import('@/store/chat');
-    const { getUserStoreState } = await import('@/store/user');
+    stores.reset();
 
-    await getSessionStoreState().refreshSessions();
-    await getChatStoreState().refreshMessages();
-    await getChatStoreState().refreshTopic();
-    await getUserStoreState().refreshUserState();
+    await useSessionStore.getState().refreshSessions();
+    await useChatStore.getState().refreshMessages();
+    await useChatStore.getState().refreshTopic();
+    await useUserStore.getState().refreshUserState();
   };
 
   useDataSyncConfig = (): SWRResponse => {
@@ -118,7 +119,11 @@ export class ElectronRemoteServerActionImpl {
       {
         onSuccess: (data) => {
           if (!isEqual(data, this.#get().dataSyncConfig)) {
-            this.#get().refreshUserData();
+            void this.#get()
+              .refreshUserData()
+              .catch((error) => {
+                console.error('Failed to refresh user data:', error);
+              });
           }
 
           this.#set({ dataSyncConfig: data, isInitRemoteServerConfig: true });

--- a/src/store/electron/actions/sync.ts
+++ b/src/store/electron/actions/sync.ts
@@ -7,7 +7,6 @@ import { mutate } from '@/libs/swr';
 import { remoteServerService } from '@/services/electron/remoteServer';
 import { type StoreSetter } from '@/store/types';
 
-import { initialState } from '../initialState';
 import { type ElectronStore } from '../store';
 
 /**
@@ -74,10 +73,11 @@ export class ElectronRemoteServerActionImpl {
     this.#set({ isConnectingServer: false });
     this.#get().clearRemoteServerSyncError();
     try {
-      await remoteServerService.setRemoteServerConfig({ active: false, storageMode: 'cloud' });
-      // Update form URL to empty
-      this.#set({ dataSyncConfig: initialState.dataSyncConfig });
-      // Refresh state
+      // Must use clearRemoteServerConfig (not only set active: false): main process
+      // clears encrypted OIDC access/refresh tokens; otherwise sign-out still leaves auth state.
+      await remoteServerService.clearRemoteServerConfig();
+      // Match persisted config until SWR refetches
+      this.#set({ dataSyncConfig: { active: false, storageMode: 'cloud' } });
       await this.#get().refreshServerConfig();
     } catch (error) {
       console.error('Disconnect failed:', error);

--- a/src/store/electron/actions/sync.ts
+++ b/src/store/electron/actions/sync.ts
@@ -5,11 +5,8 @@ import useSWR from 'swr';
 
 import { mutate } from '@/libs/swr';
 import { remoteServerService } from '@/services/electron/remoteServer';
-import { useChatStore } from '@/store/chat';
-import { useSessionStore } from '@/store/session';
 import { type StoreSetter } from '@/store/types';
 import { useUserStore } from '@/store/user';
-import { stores } from '@/store/utils/userDataStores';
 
 import { type ElectronStore } from '../store';
 
@@ -80,6 +77,7 @@ export class ElectronRemoteServerActionImpl {
       // Must use clearRemoteServerConfig (not only set active: false): main process
       // clears encrypted OIDC access/refresh tokens; otherwise sign-out still leaves auth state.
       await remoteServerService.clearRemoteServerConfig();
+      const { stores } = await import('@/store/utils/userDataStores');
       stores.reset();
       await this.#get().refreshServerConfig();
     } catch (error) {
@@ -97,7 +95,13 @@ export class ElectronRemoteServerActionImpl {
   };
 
   refreshUserData = async (): Promise<void> => {
+    const { stores } = await import('@/store/utils/userDataStores');
     stores.reset();
+
+    const [{ useSessionStore }, { useChatStore }] = await Promise.all([
+      import('@/store/session'),
+      import('@/store/chat'),
+    ]);
 
     await useSessionStore.getState().refreshSessions();
     await useChatStore.getState().refreshMessages();

--- a/src/store/eval/store.ts
+++ b/src/store/eval/store.ts
@@ -5,15 +5,24 @@ import type { StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { type EvalStoreState, initialState } from './initialState';
 import { type BenchmarkAction, createBenchmarkSlice } from './slices/benchmark/action';
 import { createDatasetSlice, type DatasetAction } from './slices/dataset/action';
 import { createRunSlice, type RunAction } from './slices/run/action';
 import { createTestCaseSlice, type TestCaseAction } from './slices/testCase/action';
 
-type EvalStoreAction = BenchmarkAction & DatasetAction & RunAction & TestCaseAction;
+type EvalStoreAction = BenchmarkAction &
+  DatasetAction &
+  RunAction &
+  TestCaseAction &
+  ResetableStore;
 
 export type EvalStore = EvalStoreState & EvalStoreAction;
+
+class EvalStoreResetAction extends ResetableStoreAction<EvalStore> {
+  protected readonly resetActionName = 'resetEvalStore';
+}
 
 const createStore: StateCreator<EvalStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<EvalStore, [['zustand/devtools', never]]>>
@@ -24,6 +33,7 @@ const createStore: StateCreator<EvalStore, [['zustand/devtools', never]]> = (
     createDatasetSlice(...parameters),
     createRunSlice(...parameters),
     createTestCaseSlice(...parameters),
+    new EvalStoreResetAction(...parameters),
   ]),
 });
 

--- a/src/store/file/slices/document/action.ts
+++ b/src/store/file/slices/document/action.ts
@@ -10,7 +10,7 @@ import { DocumentSourceType } from '@/types/document';
 import { type ResourceItem } from '@/types/resource';
 import { setNamespace } from '@/utils/storeDebug';
 
-import { type FileStore } from '../../store';
+import type { FileStore } from '../../store';
 import { getResourceQueryKey } from '../resource/utils';
 import { type DocumentQueryFilter } from './initialState';
 

--- a/src/store/file/store.ts
+++ b/src/store/file/store.ts
@@ -5,6 +5,7 @@ import type { StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import type { FilesStoreState } from './initialState';
 import { initialState } from './initialState';
 import type { FileAction } from './slices/chat';
@@ -33,6 +34,7 @@ export interface FileStore
     FileChunkAction,
     FileUploadAction,
     ResourceAction,
+    ResetableStore,
     FilesStoreState {}
 
 type FileStoreAction = FileAction &
@@ -41,7 +43,12 @@ type FileStoreAction = FileAction &
   FileManageAction &
   FileChunkAction &
   FileUploadAction &
-  ResourceAction;
+  ResourceAction &
+  ResetableStore;
+
+class FileStoreResetAction extends ResetableStoreAction<FileStore> {
+  protected readonly resetActionName = 'resetFileStore';
+}
 
 const createStore: StateCreator<FileStore, [['zustand/devtools', never]]> = (
   ...params: Parameters<StateCreator<FileStore, [['zustand/devtools', never]]>>
@@ -55,6 +62,7 @@ const createStore: StateCreator<FileStore, [['zustand/devtools', never]]> = (
     createFileChunkSlice(...params),
     createFileUploadSlice(...params),
     new ResourceActionImpl(...params),
+    new FileStoreResetAction(...params),
   ]),
 });
 

--- a/src/store/home/slices/sidebarUI/action.test.ts
+++ b/src/store/home/slices/sidebarUI/action.test.ts
@@ -6,8 +6,10 @@ import { agentService } from '@/services/agent';
 import { chatGroupService } from '@/services/chatGroup';
 import { homeService } from '@/services/home';
 import { sessionService } from '@/services/session';
+import type * as AgentStoreModule from '@/store/agent';
 import { getAgentStoreState } from '@/store/agent';
 import { useHomeStore } from '@/store/home';
+import type * as SessionStoreModule from '@/store/session';
 import { getSessionStoreState } from '@/store/session';
 
 // Mock dependencies
@@ -20,18 +22,29 @@ vi.mock('@/components/AntdStaticMethods', () => ({
   },
 }));
 
-vi.mock('@/store/session', () => ({
-  getSessionStoreState: vi.fn(() => ({
-    activeId: 'test-session',
-    switchSession: vi.fn(),
-  })),
-}));
+vi.mock('@/store/session', async (importOriginal) => {
+  const actual = await importOriginal<typeof SessionStoreModule>();
 
-vi.mock('@/store/agent', () => ({
-  getAgentStoreState: vi.fn(() => ({
-    setActiveAgentId: vi.fn(),
-  })),
-}));
+  return {
+    ...actual,
+    getSessionStoreState: vi.fn(() => ({
+      activeId: 'test-session',
+      switchSession: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('@/store/agent', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStoreModule>();
+
+  return {
+    ...actual,
+    getAgentStoreState: vi.fn(() => ({
+      setActiveAgentId: vi.fn(),
+    })),
+    useAgentStore: actual.useAgentStore,
+  };
+});
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/src/store/home/store.ts
+++ b/src/store/home/store.ts
@@ -8,6 +8,7 @@ import { isDev } from '@/utils/env';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { type HomeStoreState } from './initialState';
 import { initialState } from './initialState';
 import { type AgentListAction } from './slices/agentList/action';
@@ -30,13 +31,19 @@ export interface HomeStore
     RecentAction,
     HomeInputAction,
     SidebarUIAction,
+    ResetableStore,
     HomeStoreState {}
 
 type HomeStoreAction = AgentListAction &
   GroupAction &
   RecentAction &
   HomeInputAction &
-  SidebarUIAction;
+  SidebarUIAction &
+  ResetableStore;
+
+class HomeStoreResetAction extends ResetableStoreAction<HomeStore> {
+  protected readonly resetActionName = 'resetHomeStore';
+}
 
 const createStore: StateCreator<HomeStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<HomeStore, [['zustand/devtools', never]]>>
@@ -48,6 +55,7 @@ const createStore: StateCreator<HomeStore, [['zustand/devtools', never]]> = (
     createRecentSlice(...parameters),
     createHomeInputSlice(...parameters),
     createSidebarUISlice(...parameters),
+    new HomeStoreResetAction(...parameters),
   ]),
 });
 

--- a/src/store/image/store.ts
+++ b/src/store/image/store.ts
@@ -6,6 +6,7 @@ import { type StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { type ImageStoreState } from './initialState';
 import { initialState } from './initialState';
 import { type CreateImageAction } from './slices/createImage/action';
@@ -25,12 +26,18 @@ export interface ImageStore
     GenerationTopicAction,
     GenerationBatchAction,
     CreateImageAction,
+    ResetableStore,
     ImageStoreState {}
 
 type ImageStoreAction = GenerationConfigAction &
   GenerationTopicAction &
   GenerationBatchAction &
-  CreateImageAction;
+  CreateImageAction &
+  ResetableStore;
+
+class ImageStoreResetAction extends ResetableStoreAction<ImageStore> {
+  protected readonly resetActionName = 'resetImageStore';
+}
 
 const createStore: StateCreator<ImageStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<ImageStore, [['zustand/devtools', never]]>>
@@ -41,6 +48,7 @@ const createStore: StateCreator<ImageStore, [['zustand/devtools', never]]> = (
     createGenerationTopicSlice(...parameters),
     createGenerationBatchSlice(...parameters),
     createCreateImageSlice(...parameters),
+    new ImageStoreResetAction(...parameters),
   ]),
 });
 

--- a/src/store/library/store.ts
+++ b/src/store/library/store.ts
@@ -5,6 +5,7 @@ import { type StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { type KnowledgeBaseStoreState } from './initialState';
 import { initialState } from './initialState';
 import { type KnowledgeBaseContentAction } from './slices/content';
@@ -21,13 +22,19 @@ export interface KnowledgeBaseStore
     KnowledgeBaseStoreState,
     KnowledgeBaseCrudAction,
     KnowledgeBaseContentAction,
-    RAGEvalAction {
+    RAGEvalAction,
+    ResetableStore {
   // empty
 }
 
 type KnowledgeBaseStoreAction = KnowledgeBaseCrudAction &
   KnowledgeBaseContentAction &
-  RAGEvalAction;
+  RAGEvalAction &
+  ResetableStore;
+
+class KnowledgeBaseStoreResetAction extends ResetableStoreAction<KnowledgeBaseStore> {
+  protected readonly resetActionName = 'resetKnowledgeBaseStore';
+}
 
 const createStore: StateCreator<KnowledgeBaseStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<KnowledgeBaseStore, [['zustand/devtools', never]]>>
@@ -37,6 +44,7 @@ const createStore: StateCreator<KnowledgeBaseStore, [['zustand/devtools', never]
     createCrudSlice(...parameters),
     createContentSlice(...parameters),
     createRagEvalSlice(...parameters),
+    new KnowledgeBaseStoreResetAction(...parameters),
   ]),
 });
 

--- a/src/store/mention/store.ts
+++ b/src/store/mention/store.ts
@@ -5,18 +5,26 @@ import { type StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { type MentionAction } from './action';
 import { createMentionSlice } from './action';
 import { type MentionState } from './initialState';
 import { initialMentionState } from './initialState';
 
-export type MentionStore = MentionState & MentionAction;
+export type MentionStore = MentionState & MentionAction & ResetableStore;
+
+class MentionStoreResetAction extends ResetableStoreAction<MentionStore> {
+  protected readonly resetActionName = 'resetMentionStore';
+}
 
 const createStore: StateCreator<MentionStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<MentionStore, [['zustand/devtools', never]]>>
 ) => ({
   ...initialMentionState,
-  ...flattenActions<MentionAction>([createMentionSlice(...parameters)]),
+  ...flattenActions<MentionAction & ResetableStore>([
+    createMentionSlice(...parameters),
+    new MentionStoreResetAction(...parameters),
+  ]),
 });
 
 const devtools = createDevtools('mention');

--- a/src/store/notebook/store.ts
+++ b/src/store/notebook/store.ts
@@ -5,18 +5,26 @@ import { type StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { type NotebookAction } from './action';
 import { createNotebookAction } from './action';
 import { type NotebookState } from './initialState';
 import { initialNotebookState } from './initialState';
 
-export type NotebookStore = NotebookState & NotebookAction;
+export type NotebookStore = NotebookState & NotebookAction & ResetableStore;
+
+class NotebookStoreResetAction extends ResetableStoreAction<NotebookStore> {
+  protected readonly resetActionName = 'resetNotebookStore';
+}
 
 const createStore: StateCreator<NotebookStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<NotebookStore, [['zustand/devtools', never]]>>
 ) => ({
   ...initialNotebookState,
-  ...flattenActions<NotebookAction>([createNotebookAction(...parameters)]),
+  ...flattenActions<NotebookAction & ResetableStore>([
+    createNotebookAction(...parameters),
+    new NotebookStoreResetAction(...parameters),
+  ]),
 });
 
 const devtools = createDevtools('notebook');

--- a/src/store/page/store.ts
+++ b/src/store/page/store.ts
@@ -5,6 +5,7 @@ import { type StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { type PageState } from './initialState';
 import { initialState } from './initialState';
 import { type CrudAction } from './slices/crud';
@@ -18,9 +19,18 @@ import { createSelectionSlice } from './slices/selection';
 
 //  ===============  Aggregate createStoreFn ============ //
 
-export type PageStore = PageState & InternalAction & ListAction & SelectionAction & CrudAction;
+export type PageStore = PageState &
+  InternalAction &
+  ListAction &
+  SelectionAction &
+  CrudAction &
+  ResetableStore;
 
-type PageStoreAction = InternalAction & ListAction & SelectionAction & CrudAction;
+type PageStoreAction = InternalAction & ListAction & SelectionAction & CrudAction & ResetableStore;
+
+class PageStoreResetAction extends ResetableStoreAction<PageStore> {
+  protected readonly resetActionName = 'resetPageStore';
+}
 
 const createStore: StateCreator<PageStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<PageStore, [['zustand/devtools', never]]>>
@@ -31,6 +41,7 @@ const createStore: StateCreator<PageStore, [['zustand/devtools', never]]> = (
     createListSlice(...parameters),
     createSelectionSlice(...parameters),
     createCrudSlice(...parameters),
+    new PageStoreResetAction(...parameters),
   ]),
 });
 

--- a/src/store/session/store.ts
+++ b/src/store/session/store.ts
@@ -8,6 +8,7 @@ import { isDev } from '@/utils/env';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { type SessionStoreState } from './initialState';
 import { initialState } from './initialState';
 import { type HomeInputAction } from './slices/homeInput/action';
@@ -22,9 +23,23 @@ import { createSessionGroupSlice } from './slices/sessionGroup/action';
 //  ===============  Aggregate createStoreFn ============ //
 
 export interface SessionStore
-  extends SessionAction, SessionGroupAction, RecentAction, HomeInputAction, SessionStoreState {}
+  extends
+    SessionAction,
+    SessionGroupAction,
+    RecentAction,
+    HomeInputAction,
+    ResetableStore,
+    SessionStoreState {}
 
-type SessionStoreAction = SessionAction & SessionGroupAction & RecentAction & HomeInputAction;
+type SessionStoreAction = SessionAction &
+  SessionGroupAction &
+  RecentAction &
+  HomeInputAction &
+  ResetableStore;
+
+class SessionStoreResetAction extends ResetableStoreAction<SessionStore> {
+  protected readonly resetActionName = 'resetSessionStore';
+}
 
 const createStore: StateCreator<SessionStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<SessionStore, [['zustand/devtools', never]]>>
@@ -35,6 +50,7 @@ const createStore: StateCreator<SessionStore, [['zustand/devtools', never]]> = (
     createSessionGroupSlice(...parameters),
     createRecentSlice(...parameters),
     createHomeInputSlice(...parameters),
+    new SessionStoreResetAction(...parameters),
   ]),
 });
 

--- a/src/store/task/store.ts
+++ b/src/store/task/store.ts
@@ -5,6 +5,7 @@ import type { StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import type { TaskStoreState } from './initialState';
 import { initialState } from './initialState';
 import type { TaskConfigSliceAction } from './slices/config';
@@ -24,12 +25,18 @@ export interface TaskStore
     TaskDetailSliceAction,
     TaskLifecycleSliceAction,
     TaskListSliceAction,
+    ResetableStore,
     TaskStoreState {}
 
 type TaskStoreAction = TaskConfigSliceAction &
   TaskDetailSliceAction &
   TaskLifecycleSliceAction &
-  TaskListSliceAction;
+  TaskListSliceAction &
+  ResetableStore;
+
+class TaskStoreResetAction extends ResetableStoreAction<TaskStore> {
+  protected readonly resetActionName = 'resetTaskStore';
+}
 
 const createStore: StateCreator<TaskStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<TaskStore, [['zustand/devtools', never]]>>
@@ -40,6 +47,7 @@ const createStore: StateCreator<TaskStore, [['zustand/devtools', never]]> = (
     createTaskDetailSlice(...parameters),
     createTaskLifecycleSlice(...parameters),
     createTaskConfigSlice(...parameters),
+    new TaskStoreResetAction(...parameters),
   ]),
 });
 

--- a/src/store/tool/store.ts
+++ b/src/store/tool/store.ts
@@ -5,6 +5,7 @@ import { type StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { initialState, type ToolStoreState } from './initialState';
 import { type AgentSkillsAction, createAgentSkillsSlice } from './slices/agentSkills';
 import { type BuiltinToolAction, createBuiltinToolSlice } from './slices/builtin';
@@ -26,7 +27,8 @@ export type ToolStore = ToolStoreState &
   PluginMCPStoreAction &
   KlavisStoreAction &
   LobehubSkillStoreAction &
-  AgentSkillsAction;
+  AgentSkillsAction &
+  ResetableStore;
 
 type ToolStoreAction = CustomPluginAction &
   PluginAction &
@@ -34,7 +36,12 @@ type ToolStoreAction = CustomPluginAction &
   PluginMCPStoreAction &
   KlavisStoreAction &
   LobehubSkillStoreAction &
-  AgentSkillsAction;
+  AgentSkillsAction &
+  ResetableStore;
+
+class ToolStoreResetAction extends ResetableStoreAction<ToolStore> {
+  protected readonly resetActionName = 'resetToolStore';
+}
 
 const createStore: StateCreator<ToolStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<ToolStore, [['zustand/devtools', never]]>>
@@ -48,6 +55,7 @@ const createStore: StateCreator<ToolStore, [['zustand/devtools', never]]> = (
     createKlavisStoreSlice(...parameters),
     createLobehubSkillStoreSlice(...parameters),
     createAgentSkillsSlice(...parameters),
+    new ToolStoreResetAction(...parameters),
   ]),
 });
 

--- a/src/store/user/store.ts
+++ b/src/store/user/store.ts
@@ -6,6 +6,7 @@ import { type StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { type UserState } from './initialState';
 import { initialState } from './initialState';
 import { type AgentOnboardingAction } from './slices/agentOnboarding/action';
@@ -29,14 +30,20 @@ export type UserStore = UserState &
   UserAuthAction &
   CommonAction &
   AgentOnboardingAction &
-  OnboardingAction;
+  OnboardingAction &
+  ResetableStore;
 
 type UserStoreAction = UserSettingsAction &
   PreferenceAction &
   UserAuthAction &
   CommonAction &
   AgentOnboardingAction &
-  OnboardingAction;
+  OnboardingAction &
+  ResetableStore;
+
+class UserStoreResetAction extends ResetableStoreAction<UserStore> {
+  protected readonly resetActionName = 'resetUserStore';
+}
 
 const createStore: StateCreator<UserStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<UserStore, [['zustand/devtools', never]]>>
@@ -49,6 +56,7 @@ const createStore: StateCreator<UserStore, [['zustand/devtools', never]]> = (
     createCommonSlice(...parameters),
     createAgentOnboardingSlice(...parameters),
     createOnboardingSlice(...parameters),
+    new UserStoreResetAction(...parameters),
   ]),
 });
 

--- a/src/store/userMemory/store.ts
+++ b/src/store/userMemory/store.ts
@@ -5,6 +5,7 @@ import { type StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { type UserMemoryStoreState } from './initialState';
 import { initialState } from './initialState';
 import { type ActivityAction } from './slices/activity';
@@ -32,7 +33,8 @@ export type UserMemoryStore = UserMemoryStoreState &
   ExperienceAction &
   HomeAction &
   IdentityAction &
-  PreferenceAction;
+  PreferenceAction &
+  ResetableStore;
 
 type UserMemoryStoreAction = ActivityAction &
   AgentMemoryAction &
@@ -41,7 +43,12 @@ type UserMemoryStoreAction = ActivityAction &
   ExperienceAction &
   HomeAction &
   IdentityAction &
-  PreferenceAction;
+  PreferenceAction &
+  ResetableStore;
+
+class UserMemoryStoreResetAction extends ResetableStoreAction<UserMemoryStore> {
+  protected readonly resetActionName = 'resetUserMemoryStore';
+}
 
 const createStore: StateCreator<UserMemoryStore, [['zustand/devtools', never]]> = (
   set: any,
@@ -58,6 +65,7 @@ const createStore: StateCreator<UserMemoryStore, [['zustand/devtools', never]]> 
     createHomeSlice(set, get, store),
     createIdentitySlice(set, get, store),
     createPreferenceSlice(set, get, store),
+    new UserMemoryStoreResetAction(set, get, store),
   ]),
 });
 

--- a/src/store/utils/resetableStore.ts
+++ b/src/store/utils/resetableStore.ts
@@ -1,0 +1,26 @@
+import type { StoreApi } from 'zustand';
+
+import type { StoreSetter } from '@/store/types';
+
+export interface ResetableStore {
+  reset: () => void;
+}
+
+type Setter<TStore extends object> = StoreSetter<TStore>;
+
+export abstract class ResetableStoreAction<TStore extends object> implements ResetableStore {
+  readonly #api: StoreApi<TStore>;
+  readonly #set: Setter<TStore>;
+
+  protected abstract readonly resetActionName: string;
+
+  constructor(set: Setter<TStore>, _get: () => TStore, api: StoreApi<TStore>) {
+    void _get;
+    this.#set = set;
+    this.#api = api;
+  }
+
+  reset = () => {
+    this.#set(this.#api.getInitialState(), false, this.resetActionName);
+  };
+}

--- a/src/store/utils/userDataStores.ts
+++ b/src/store/utils/userDataStores.ts
@@ -1,0 +1,62 @@
+import { unstable_batchedUpdates } from 'react-dom';
+
+import { useAgentStore } from '@/store/agent';
+import { useAgentGroupStore } from '@/store/agentGroup';
+import { useChatStore } from '@/store/chat';
+import { useDiscoverStore } from '@/store/discover';
+import { useDocumentStore } from '@/store/document';
+import { useEvalStore } from '@/store/eval';
+import { useFileStore } from '@/store/file';
+import { useHomeStore } from '@/store/home';
+import { useImageStore } from '@/store/image';
+import { useKnowledgeBaseStore } from '@/store/library';
+import { useMentionStore } from '@/store/mention';
+import { useNotebookStore } from '@/store/notebook';
+import { usePageStore } from '@/store/page';
+import { useSessionStore } from '@/store/session';
+import { useTaskStore } from '@/store/task';
+import { useToolStore } from '@/store/tool';
+import { useUserStore } from '@/store/user';
+import { useUserMemoryStore } from '@/store/userMemory';
+import type { ResetableStore } from '@/store/utils/resetableStore';
+import { useVideoStore } from '@/store/video';
+
+interface ResetableStoreApi {
+  getState: () => ResetableStore;
+}
+
+const resetableStores: ResetableStoreApi[] = [
+  useAgentGroupStore,
+  useAgentStore,
+  useChatStore,
+  useDiscoverStore,
+  useDocumentStore,
+  useEvalStore,
+  useFileStore,
+  useHomeStore,
+  useImageStore,
+  useKnowledgeBaseStore,
+  useMentionStore,
+  useNotebookStore,
+  usePageStore,
+  useSessionStore,
+  useTaskStore,
+  useToolStore,
+  useUserMemoryStore,
+  useUserStore,
+  useVideoStore,
+];
+
+export interface StoreActions extends ResetableStore {}
+
+const createStoreActions = (stores: ResetableStoreApi[]): StoreActions => ({
+  reset: () => {
+    unstable_batchedUpdates(() => {
+      for (const store of stores) {
+        store.getState().reset();
+      }
+    });
+  },
+});
+
+export const stores = createStoreActions(resetableStores);

--- a/src/store/video/store.ts
+++ b/src/store/video/store.ts
@@ -6,6 +6,7 @@ import { type StateCreator } from 'zustand/vanilla';
 import { createDevtools } from '../middleware/createDevtools';
 import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
 import { initialState, type VideoStoreState } from './initialState';
 import { createCreateVideoSlice, type CreateVideoAction } from './slices/createVideo/action';
 import {
@@ -26,9 +27,14 @@ import {
 type VideoStoreAction = GenerationConfigAction &
   GenerationTopicAction &
   GenerationBatchAction &
-  CreateVideoAction;
+  CreateVideoAction &
+  ResetableStore;
 
 export interface VideoStore extends VideoStoreAction, VideoStoreState {}
+
+class VideoStoreResetAction extends ResetableStoreAction<VideoStore> {
+  protected readonly resetActionName = 'resetVideoStore';
+}
 
 const createStore: StateCreator<VideoStore, [['zustand/devtools', never]]> = (
   ...parameters: Parameters<StateCreator<VideoStore, [['zustand/devtools', never]]>>
@@ -39,6 +45,7 @@ const createStore: StateCreator<VideoStore, [['zustand/devtools', never]]> = (
     createGenerationTopicSlice(...parameters),
     createGenerationBatchSlice(...parameters),
     createCreateVideoSlice(...parameters),
+    new VideoStoreResetAction(...parameters),
   ]),
 });
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

- **Backend proxy**: Treat `X-Auth-Required: true` as the signal for Lobe cloud re-auth, regardless of HTTP status. Batched tRPC can return **207** while individual calls are unauthorized; gating on `status === 401` skipped the re-auth broadcast.
- **Auth required modal**: Open when remote server config has initialized (`isInitRemoteServerConfig`) instead of requiring `dataSyncConfig.active`, so users are not stuck after sign-out when `active` is false but the session is invalid.
- **Market auth (desktop)**: On `market-unauthorized`, only attempt a silent token refresh; do not open community/market sign-in UI—cloud re-auth remains `AuthRequiredModal`.
- **Disconnect**: Call `clearRemoteServerConfig()` so the main process clears encrypted OIDC tokens; setting `active: false` alone left credentials behind.

#### 🧪 How to Test

- `bunx vitest run --silent='passed-only' 'BackendProxyProtocolManager.test.ts'` (from `apps/desktop`)
- Manual: desktop remote sync, batched tRPC path returning 207 + auth header, disconnect + verify tokens cleared

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

N/A (behavioral fixes)

#### 📝 Additional Information

None.

Made with [Cursor](https://cursor.com)