### PR TITLE
🐛 fix: support audio file uploads in MCP content processing

### DIFF
--- a/src/server/services/file/index.ts
+++ b/src/server/services/file/index.ts
@@ -241,6 +241,7 @@ export class FileService {
   public async uploadBase64(
     base64Data: string,
     pathname: string,
+    options?: { fileType?: string },
   ): Promise<{ fileId: string; key: string; url: string }> {
     let base64String: string;
 
@@ -267,7 +268,14 @@ export class FileService {
 
     // Calculate file metadata
     const size = buffer.length;
-    const fileType = inferContentTypeFromImageUrl(pathname) || 'application/octet-stream';
+    let fileType = options?.fileType || 'application/octet-stream';
+    if (!options?.fileType) {
+      try {
+        fileType = inferContentTypeFromImageUrl(pathname);
+      } catch {
+        // Non-image files (e.g. audio) won't match image extension whitelist
+      }
+    }
     const hash = sha256(buffer);
 
     // Generate UUID for cleaner URLs

--- a/src/server/services/mcp/contentProcessor.ts
+++ b/src/server/services/mcp/contentProcessor.ts
@@ -33,7 +33,9 @@ export const processContentBlocks = async (
       const pathname = `${fileEnv.NEXT_PUBLIC_S3_FILE_PATH}/mcp/images/${today}/${nanoid()}.${fileExtension}`;
 
       // Upload base64 image and get proxy URL
-      const { url } = await fileService.uploadBase64(imageBlock.data, pathname);
+      const { url } = await fileService.uploadBase64(imageBlock.data, pathname, {
+        fileType: imageBlock.mimeType,
+      });
 
       log(`Image uploaded, proxy URL: ${url}`);
 
@@ -49,8 +51,11 @@ export const processContentBlocks = async (
       // Generate unique pathname with date-based sharding
       const pathname = `${fileEnv.NEXT_PUBLIC_S3_FILE_PATH}/mcp/audio/${today}/${nanoid()}.${fileExtension}`;
 
-      // Upload base64 audio and get proxy URL
-      const { url } = await fileService.uploadBase64(audioBlock.data, pathname);
+      // Upload base64 audio and get proxy URL — pass mimeType directly since
+      // inferContentTypeFromImageUrl only supports image extensions
+      const { url } = await fileService.uploadBase64(audioBlock.data, pathname, {
+        fileType: audioBlock.mimeType,
+      });
 
       log(`Audio uploaded, proxy URL: ${url}`);
 


### PR DESCRIPTION
## Summary

- Fix `uploadBase64` throwing "Invalid image url" error on audio files (`.mp3`, `.wav`, etc.) from MCP
- Add optional `fileType` parameter to `uploadBase64` for caller-provided MIME types
- MCP contentProcessor now passes `mimeType` directly for both image and audio uploads

## Root Cause

`uploadBase64` calls `inferContentTypeFromImageUrl(pathname)` to determine file type. This function only recognizes image extensions and **throws** on anything else. When MCP returns audio content, the pathname has an audio extension (e.g. `.mp3`), triggering the error.

## Fix

- `uploadBase64` accepts optional `options.fileType` — when provided, skips extension inference
- Wrap `inferContentTypeFromImageUrl` in try/catch so non-image files fallback to `application/octet-stream`
- MCP contentProcessor passes `mimeType` from both image and audio content blocks

Closes #10778
Supersedes #11223

## Test plan

- [x] Type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)