### PR TITLE
🐛 fix(prompts): enforce user perspective in input completion

### DIFF
--- a/packages/prompts/src/chains/inputCompletion.ts
+++ b/packages/prompts/src/chains/inputCompletion.ts
@@ -15,17 +15,27 @@ ${context.map((m) => `${m.role}: ${m.content}`).join('\n')}`;
     max_tokens: 100,
     messages: [
       {
-        content: `Complete the user's partially typed message. Output ONLY the missing text to insert at the cursor. Keep it short and natural. No explanations.
+        content: `You are an autocomplete engine for a chat input box. The user is composing a message to send to an AI assistant. Predict and complete what the USER is typing. Output ONLY the missing text to insert at the cursor.
 
-Examples of expected behavior:
-User: Before cursor: "How do I " / After cursor: ""
-Output: implement authentication in Next.js?
+CRITICAL RULES:
+- You are completing the USER's message, NOT the AI assistant's response
+- The completed text should read as something a human would type to ask, request, or tell an AI
+- NEVER generate text that sounds like an AI assistant responding (e.g., "help you", "assist you", "I can help")
+- Keep it short and natural, under 15 words
+- Match the user's language
 
-User: Before cursor: "Can you explain the difference between " / After cursor: ""
-Output: useEffect and useLayoutEffect in React?
+GOOD examples (user perspective):
+"How can I " → "optimize my React component's performance?"
+"Hi" → ", I need help with a TypeScript issue"
+"Can you " → "explain how useEffect cleanup works?"
+"帮我" → "写一个数据库查询的优化方案"
+"Let me " → "describe the bug I'm seeing"
+"我想" → "了解一下如何部署到 Kubernetes"
 
-User: Before cursor: "我想了解一下" / After cursor: ""
-Output: 如何在项目中使用 TypeScript 的泛型${contextBlock}`,
+BAD examples (assistant perspective — NEVER do this):
+"How can I " → "help you today?" ← WRONG: this is what an AI assistant says
+"Hi" → ", how can I help you?" ← WRONG: assistant greeting
+"Let me " → "explain that for you" ← WRONG: assistant offering to explain${contextBlock}`,
         role: 'system',
       },
       {


### PR DESCRIPTION
## Summary
- Fix autocomplete prompt generating completions from assistant perspective (e.g., "How can I help you?") instead of user perspective
- Add explicit perspective constraints with GOOD/BAD examples to the `chainInputCompletion` system prompt
- Validated with 7 perspective edge-case scenarios × 2 models (gpt-5.4-mini, groq/llama-4-scout), all 14 runs PASS

## Related
- LOBE-6813 — 自动补全数据飞轮：构建补全质量闭环与用户视角修正
- BM-11 — Input Completion Benchmark

## Test plan
- [x] `perspective-how-can-i`: "How can I" no longer completes as "help you today?"
- [x] `perspective-hi`: "Hi" completes as user greeting, not assistant greeting
- [x] `perspective-let-me`: user perspective maintained
- [x] `perspective-can-you`: user request pattern preserved
- [x] `perspective-help-me`: user asking for help, not assistant offering
- [x] `perspective-zh-ni-hao`: Chinese greeting handled correctly
- [x] `perspective-i-want-to`: user intent expressed correctly
- [x] All original BM-11 scenarios still pass with v3 prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)