### PR TITLE
🐛 fix(desktop): use stored locale from URL parameter instead of syste…

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -68,7 +68,9 @@
         if (resolvedTheme === 'dark' || resolvedTheme === 'light') {
           document.documentElement.setAttribute('data-theme', resolvedTheme);
         }
-        var locale = navigator.language || 'en-US';
+        // Check URL query parameter for locale (set by Electron main process from stored settings)
+        var urlParams = new URLSearchParams(window.location.search);
+        var locale = urlParams.get('lng') || navigator.language || 'en-US';
         document.documentElement.lang = locale;
         var rtl = ['ar', 'arc', 'dv', 'fa', 'ha', 'he', 'khw', 'ks', 'ku', 'ps', 'ur', 'yi'];
         document.documentElement.dir =


### PR DESCRIPTION
…m language

When the desktop app restarts, the UI language was reverting to the system language instead of respecting the user's saved language preference.

Root cause: The inline script in index.html was setting document.documentElement.lang from navigator.language (system language) before i18n initialization could read the stored locale from Electron store.

Fix: Check the URL's `lng` query parameter first (which is set by Electron main process from stored settings in Browser.ts:buildUrlWithLocale()), then fall back to navigator.language.

Fixes #13616

https://claude.ai/code/session_0128LZAbJL1a5vkGboH4U5FP
