### PR TITLE
🐛 fix: correct thinkingLevel configKey in level slider components

### DIFF
--- a/packages/model-runtime/src/providers/google/index.test.ts
+++ b/packages/model-runtime/src/providers/google/index.test.ts
@@ -532,7 +532,7 @@ describe('thinkingConfig includeThoughts logic', () => {
     expect(config.thinkingConfig?.includeThoughts).toBe(true);
   });
 
-  it('should let API decide thinking for gemini-3-pro-image models without explicit params', async () => {
+  it('should enable includeThoughts for thinking-enabled gemini-3-pro-image models by default', async () => {
     const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
     vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
 
@@ -544,8 +544,8 @@ describe('thinkingConfig includeThoughts logic', () => {
 
     const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
     const config = callArgs[0].config;
-    // Gemini 3 models without explicit thinkingLevel/thinkingBudget → let API decide
-    expect(config.thinkingConfig?.includeThoughts).toBeUndefined();
+    // Thinking-enabled models need includeThoughts: true to return thinking content
+    expect(config.thinkingConfig?.includeThoughts).toBe(true);
   });
 
   it('should enable thinking for thinking-enabled models', async () => {

--- a/packages/model-runtime/src/providers/google/thinkingResolver.test.ts
+++ b/packages/model-runtime/src/providers/google/thinkingResolver.test.ts
@@ -238,15 +238,13 @@ describe('thinkingResolver', () => {
     describe('gemini-3-pro-preview (the original issue model)', () => {
       const model = 'gemini-3-pro-preview';
 
-      it('should not set thinkingBudget or includeThoughts by default for Gemini 3 (let API decide)', () => {
+      it('should enable includeThoughts by default for thinking-enabled Gemini 3 models', () => {
         const result = resolveGoogleThinkingConfig(model, {});
 
-        // For Gemini 3 models, when neither thinkingLevel nor thinkingBudget is set,
-        // don't set any thinking params - let API use its default behavior.
-        // includeThoughts must be undefined to avoid Vertex AI error:
-        // "include_thoughts is only enabled when thinking is enabled"
+        // Thinking-enabled models need includeThoughts: true to return thinking content,
+        // even without explicit thinkingLevel or thinkingBudget
         expect(result).toEqual({
-          includeThoughts: undefined,
+          includeThoughts: true,
           thinkingBudget: undefined,
         });
       });
@@ -276,12 +274,12 @@ describe('thinkingResolver', () => {
     describe('gemini-3-pro-image-preview (thinking-enabled model)', () => {
       const model = 'gemini-3-pro-image-preview';
 
-      it('should not set thinkingBudget or includeThoughts by default for Gemini 3 (let API decide)', () => {
+      it('should enable includeThoughts by default for thinking-enabled Gemini 3 models', () => {
         const result = resolveGoogleThinkingConfig(model, {});
 
-        // For Gemini 3 models, don't set thinkingBudget by default
+        // Thinking-enabled models need includeThoughts: true to return thinking content
         expect(result).toEqual({
-          includeThoughts: undefined,
+          includeThoughts: true,
           thinkingBudget: undefined,
         });
       });
@@ -351,12 +349,12 @@ describe('thinkingResolver', () => {
     describe('gemini-3-flash (supports thinking and thinkingLevel)', () => {
       const model = 'gemini-3-flash';
 
-      it('should not set thinkingBudget or includeThoughts by default for Gemini 3 (let API decide)', () => {
+      it('should enable includeThoughts by default for thinking-enabled Gemini 3 models', () => {
         const result = resolveGoogleThinkingConfig(model, {});
 
-        // For Gemini 3 models, don't set thinkingBudget by default
+        // Thinking-enabled models need includeThoughts: true to return thinking content
         expect(result).toEqual({
-          includeThoughts: undefined,
+          includeThoughts: true,
           thinkingBudget: undefined,
         });
       });
@@ -422,13 +420,12 @@ describe('thinkingResolver', () => {
     describe('nano-banana-pro-preview (thinking-enabled model)', () => {
       const model = 'nano-banana-pro-preview';
 
-      it('should not enable includeThoughts when thinkingBudget is undefined', () => {
+      it('should enable includeThoughts for thinking-enabled model even without explicit budget', () => {
         const result = resolveGoogleThinkingConfig(model, {});
 
-        // nano-banana-pro is 'other' category, so thinkingBudget is undefined.
-        // Without an actual thinking budget or level, includeThoughts should not be set
-        // to avoid Vertex AI error.
-        expect(result.includeThoughts).toBeUndefined();
+        // nano-banana-pro matches thinking-enabled pattern, so includeThoughts should be true
+        // even without explicit thinkingBudget
+        expect(result.includeThoughts).toBe(true);
       });
     });
   });

--- a/packages/model-runtime/src/providers/google/thinkingResolver.ts
+++ b/packages/model-runtime/src/providers/google/thinkingResolver.ts
@@ -237,8 +237,8 @@ const shouldIncludeThoughts = (
   if (typeof resolvedBudget === 'number') return resolvedBudget !== 0 ? true : undefined;
 
   // 3. Budget is undefined (Gemini 3 default / "other" category) →
-  //    only thinkingLevel can activate thinking without a numeric budget
-  return thinkingLevel ? true : undefined;
+  //    thinkingLevel or inherently thinking-enabled model → include thoughts
+  return thinkingLevel || isThinkingEnabledModel(model) ? true : undefined;
 };
 
 /**

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel2Slider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel2Slider.tsx
@@ -7,7 +7,7 @@ type ThinkingLevel2 = (typeof THINKING_LEVELS_2)[number];
 export type ThinkingLevel2SliderProps = CreatedLevelSliderProps<ThinkingLevel2>;
 
 const ThinkingLevel2Slider = createLevelSliderComponent<ThinkingLevel2>({
-  configKey: 'thinkingLevel',
+  configKey: 'thinkingLevel2',
   defaultValue: 'high',
   levels: THINKING_LEVELS_2,
   style: { minWidth: 110 },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel3Slider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel3Slider.tsx
@@ -7,7 +7,7 @@ type ThinkingLevel3 = (typeof THINKING_LEVELS_3)[number];
 export type ThinkingLevel3SliderProps = CreatedLevelSliderProps<ThinkingLevel3>;
 
 const ThinkingLevel3Slider = createLevelSliderComponent<ThinkingLevel3>({
-  configKey: 'thinkingLevel',
+  configKey: 'thinkingLevel3',
   defaultValue: 'high',
   levels: THINKING_LEVELS_3,
   style: { minWidth: 160 },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel4Slider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel4Slider.tsx
@@ -7,7 +7,7 @@ type ThinkingLevel4 = (typeof THINKING_LEVELS_4)[number];
 export type ThinkingLevel4SliderProps = CreatedLevelSliderProps<ThinkingLevel4>;
 
 const ThinkingLevel4Slider = createLevelSliderComponent<ThinkingLevel4>({
-  configKey: 'thinkingLevel',
+  configKey: 'thinkingLevel4',
   defaultValue: 'minimal',
   levels: THINKING_LEVELS_4,
   style: { minWidth: 110 },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel5Slider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingLevel5Slider.tsx
@@ -7,7 +7,7 @@ type ThinkingLevel5 = (typeof THINKING_LEVELS_5)[number];
 export type ThinkingLevel5SliderProps = CreatedLevelSliderProps<ThinkingLevel5>;
 
 const ThinkingLevel5Slider = createLevelSliderComponent<ThinkingLevel5>({
-  configKey: 'thinkingLevel',
+  configKey: 'thinkingLevel5',
   defaultValue: 'minimal',
   levels: THINKING_LEVELS_5,
   style: { minWidth: 200 },


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Closes LOBE-6818

#### 🔀 Description of Change

**问题**：Gemini 3.x 模型设置了 thinkingLevel 但实际请求中不带该参数，导致不输出 Thinking 内容。

**根因**：`ThinkingLevel2Slider`、`ThinkingLevel3Slider`、`ThinkingLevel4Slider`、`ThinkingLevel5Slider` 的 `configKey` 全部硬编码为 `'thinkingLevel'`，而应分别为 `'thinkingLevel2'`~`'thinkingLevel5'`。

这导致 UI 设置的值存入了错误的 `chatConfig` 字段，`modelParamsResolver` 读取各自对应的字段时读到空值，`thinkingLevel` 就不会被包含在 API 请求中。

**修复**：
1. 修正 4 个 Slider 组件的 `configKey` 为各自正确的 key
2. 修复 `thinkingResolver.ts` 的 `shouldIncludeThoughts()`，让 Gemini 3.x 思考模型在未显式设置参数时也默认返回 `includeThoughts: true`（兜底）

#### 🧪 How to Test

- [x] Added/updated tests

```bash
cd packages/model-runtime && bunx vitest run src/providers/google/thinkingResolver.test.ts src/providers/google/index.test.ts
```

手动验证：使用 `gemini-3.1-pro-preview` 模型，设置 thinkingLevel 为 high，确认请求中包含 `thinkingLevel: 'high'` 且响应中有 Thinking 输出。