### PR TITLE
feat: enhance linear skill with image extraction and in-progress status

### DIFF
--- a/.agents/skills/linear/SKILL.md
+++ b/.agents/skills/linear/SKILL.md
@@ -20,7 +20,7 @@ This is NON-NEGOTIABLE. Skipping Linear comments is a workflow violation.
 ## Workflow
 
 1. **Retrieve issue details** before starting: `mcp__linear-server__get_issue`
-2. **Read images**: If the issue contains images, MUST use `mcp__linear-server__extract_images` to read image content for full context
+2. **Read images**: If the issue description contains images, MUST use `mcp__linear-server__extract_images` to read image content for full context
 3. **Check for sub-issues**: Use `mcp__linear-server__list_issues` with `parentId` filter
 4. **Mark as In Progress**: When starting to plan or implement an issue, immediately update status to **"In Progress"** via `mcp__linear-server__update_issue`
 5. **Update issue status** when completing: `mcp__linear-server__update_issue`

--- a/.agents/skills/linear/SKILL.md
+++ b/.agents/skills/linear/SKILL.md
@@ -20,9 +20,11 @@ This is NON-NEGOTIABLE. Skipping Linear comments is a workflow violation.
 ## Workflow
 
 1. **Retrieve issue details** before starting: `mcp__linear-server__get_issue`
-2. **Check for sub-issues**: Use `mcp__linear-server__list_issues` with `parentId` filter
-3. **Update issue status** when completing: `mcp__linear-server__update_issue`
-4. **Add completion comment** (REQUIRED): `mcp__linear-server__create_comment`
+2. **Read images**: If the issue contains images, MUST use `mcp__linear-server__extract_images` to read image content for full context
+3. **Check for sub-issues**: Use `mcp__linear-server__list_issues` with `parentId` filter
+4. **Mark as In Progress**: When starting to plan or implement an issue, immediately update status to **"In Progress"** via `mcp__linear-server__update_issue`
+5. **Update issue status** when completing: `mcp__linear-server__update_issue`
+6. **Add completion comment** (REQUIRED): `mcp__linear-server__create_comment`
 
 ## Creating Issues
 


### PR DESCRIPTION
## Summary

- Add `extract_images` step to read image content from Linear issues for full context
- Add "Mark as In Progress" step to update issue status when starting work

## Test plan

- [ ] Verify skill triggers correctly on Linear issue references