### PR TITLE
fix: skip @mention for team members in PR assign and issue triage

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -18,6 +18,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Check if author is a team member
+        id: check-team
+        run: |
+          ISSUE_AUTHOR="${{ github.event.issue.user.login }}"
+          if grep -iq "^${ISSUE_AUTHOR}$" .github/maintainers.txt; then
+            echo "is_team=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_team=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Copy triage prompts
         run: |
           mkdir -p /tmp/claude-prompts
@@ -62,7 +72,7 @@ jobs:
             **IMPORTANT**:
             - Follow ALL steps in the issue-triage.md guide
             - Apply labels according to the guide's rules
-            - Post a mention comment to the appropriate team member(s) based on team-assignment.md
+            - ${{ steps.check-team.outputs.is_team == 'true' && 'The issue author is a team member. Do NOT post any @mention comment.' || 'Post a mention comment to the appropriate team member(s) based on team-assignment.md' }}
             - Replace [ISSUE_NUMBER] with: ${{ github.event.issue.number }}
 
             **Start the triage process now.**

--- a/.github/workflows/claude-pr-assign.yml
+++ b/.github/workflows/claude-pr-assign.yml
@@ -21,7 +21,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Check if author is a team member
+        id: check-team
+        run: |
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          if grep -iq "^${PR_AUTHOR}$" .github/maintainers.txt; then
+            echo "is_team=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_team=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Copy prompts
+        if: steps.check-team.outputs.is_team == 'false'
         run: |
           mkdir -p /tmp/claude-prompts
           cp .claude/prompts/pr-assign.md /tmp/claude-prompts/
@@ -29,6 +40,7 @@ jobs:
           cp .claude/prompts/security-rules.md /tmp/claude-prompts/
 
       - name: Run Claude Code for PR Reviewer Assignment
+        if: steps.check-team.outputs.is_team == 'false'
         uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

- **PR assign workflow**: Skip the entire Claude assignment process when PR author is in `.github/maintainers.txt` — team members know who to ask for review
- **Issue triage workflow**: Still apply labels normally, but skip @mention comment when issue author is a team member

## Test plan

- [ ] External contributor opens PR → Claude assigns reviewer as before
- [ ] Team member opens PR → No Claude comment posted
- [ ] External contributor opens issue → Labels applied + @mention comment
- [ ] Team member opens issue → Labels applied, no @mention comment