### PR TITLE
🔨 chore: integrate Gateway connection management into chat store

### DIFF
--- a/.agents/skills/local-testing/SKILL.md
+++ b/.agents/skills/local-testing/SKILL.md
@@ -1069,48 +1069,16 @@ Each script: activates the app, navigates to the channel/contact, pastes the mes
 
 # Screen Recording
 
-Record automated demos by combining `ffmpeg` + `agent-browser` screenshots.
-
-### record-app-screen.sh (Recommended)
-
-General-purpose screen recording with start/stop lifecycle. Captures CDP screenshots as video frames and gallery snapshots. Works on any screen including external monitors.
+Record automated demos using `record-app-screen.sh` (start/stop lifecycle, CDP screenshots + ffmpeg assembly). See [references/record-app-screen.md](references/record-app-screen.md) for full documentation.
 
 ```bash
-# Start Electron first
 ./.agents/skills/local-testing/scripts/electron-dev.sh start
-
-# Start recording
 ./.agents/skills/local-testing/scripts/record-app-screen.sh start my-demo
-
-# ... run your automation via agent-browser ...
-
-# Stop recording — assembles frames into video
+# ... run automation ...
 ./.agents/skills/local-testing/scripts/record-app-screen.sh stop
-
-# Check status
-./.agents/skills/local-testing/scripts/record-app-screen.sh status
 ```
 
-Outputs to `.records/` directory (gitignored):
-
-- `.records/<name>.mp4` — Video assembled from screenshots (\~2 fps)
-- `.records/<name>/` — Gallery screenshots every 3 seconds
-
-Environment variables:
-
-| Variable               | Default | Description                         |
-| ---------------------- | ------- | ----------------------------------- |
-| `CDP_PORT`             | `9222`  | Chrome DevTools Protocol port       |
-| `SCREENSHOT_INTERVAL`  | `3`     | Seconds between gallery screenshots |
-| `VIDEO_FRAME_INTERVAL` | `0.5`   | Seconds between video frames        |
-
-### record-electron-demo.sh
-
-Records a custom automation script against the Electron app using ffmpeg avfoundation.
-
-```bash
-./.agents/skills/local-testing/scripts/record-electron-demo.sh ./my-demo.sh .records/my-demo.mp4
-```
+Outputs to `.records/` directory (gitignored): `<name>.mp4` (video) + `<name>/` (screenshots every 3s).
 
 ---
 

--- a/.agents/skills/local-testing/SKILL.md
+++ b/.agents/skills/local-testing/SKILL.md
@@ -1006,6 +1006,7 @@ Ready-to-use scripts in `.agents/skills/local-testing/scripts/`:
 | `electron-dev.sh`         | Manage Electron dev env (start/stop/status/restart) |
 | `capture-app-window.sh`   | Capture screenshot of a specific app window         |
 | `record-electron-demo.sh` | Record Electron app demo with ffmpeg                |
+| `record-gateway-demo.sh`  | Record Gateway streaming demo (agent + web search)  |
 | `test-discord-bot.sh`     | Send message to Discord bot via osascript           |
 | `test-slack-bot.sh`       | Send message to Slack bot via osascript             |
 | `test-telegram-bot.sh`    | Send message to Telegram bot via osascript          |
@@ -1068,25 +1069,51 @@ Each script: activates the app, navigates to the channel/contact, pastes the mes
 
 # Screen Recording
 
-Record automated demos by combining `ffmpeg` screen capture with `agent-browser` automation. The script `.agents/skills/local-testing/scripts/record-electron-demo.sh` handles the full lifecycle for Electron.
+Record automated demos by combining `ffmpeg` screen capture with `agent-browser` automation.
 
-### Usage
+### Gateway Streaming Demo
+
+`record-gateway-demo.sh` records a complete Gateway agent execution flow: Electron startup → agent navigation → message send → streaming response → tool calls → completion.
 
 ```bash
-# Run the built-in demo (queue-edit feature)
-./.agents/skills/local-testing/scripts/record-electron-demo.sh
+# Default: web search demo
+./.agents/skills/local-testing/scripts/record-gateway-demo.sh
 
-# Run a custom automation script
-./.agents/skills/local-testing/scripts/record-electron-demo.sh ./my-demo.sh /tmp/my-demo.mp4
+# Custom message
+./.agents/skills/local-testing/scripts/record-gateway-demo.sh "explain how HTTPS works"
+
+# Custom message + output path
+./.agents/skills/local-testing/scripts/record-gateway-demo.sh "explain DNS" .records/dns-demo.mp4
 ```
+
+Environment variables:
+
+| Variable      | Default                           | Description                              |
+| ------------- | --------------------------------- | ---------------------------------------- |
+| `GATEWAY_URL` | `wss://agent-gateway.lobehub.com` | Gateway WebSocket URL                    |
+| `CDP_PORT`    | `9222`                            | Chrome DevTools Protocol port            |
+| `AGENT_REF`   | (auto-detect)                     | agent-browser ref for the agent link     |
+| `FRAMERATE`   | `15`                              | Recording framerate                      |
+| `MAX_WAIT`    | `120`                             | Max seconds to wait for agent completion |
 
 The script automatically:
 
 1. Starts Electron with CDP and waits for SPA to load
-2. Detects window position, screen, and Retina scale via Swift/CGWindowList
-3. Records only the Electron window region using `ffmpeg -f avfoundation` with crop
-4. Runs the demo (built-in or custom script receiving CDP port as `$1`)
-5. Stops recording and cleans up
+2. Injects the Gateway URL into server config
+3. Auto-detects which screen the Electron window is on (supports external monitors)
+4. Records the screen using `ffmpeg -f avfoundation`
+5. Navigates to an agent, sends the message, waits for completion
+6. Crops the recording to the Electron window region and compresses
+7. Outputs to `.records/` directory (gitignored)
+
+### General Electron Demo
+
+`record-electron-demo.sh` records a custom automation script against the Electron app.
+
+```bash
+# Run a custom automation script
+./.agents/skills/local-testing/scripts/record-electron-demo.sh ./my-demo.sh .records/my-demo.mp4
+```
 
 ---
 

--- a/.agents/skills/local-testing/SKILL.md
+++ b/.agents/skills/local-testing/SKILL.md
@@ -1006,7 +1006,7 @@ Ready-to-use scripts in `.agents/skills/local-testing/scripts/`:
 | `electron-dev.sh`         | Manage Electron dev env (start/stop/status/restart) |
 | `capture-app-window.sh`   | Capture screenshot of a specific app window         |
 | `record-electron-demo.sh` | Record Electron app demo with ffmpeg                |
-| `record-gateway-demo.sh`  | Record Gateway streaming demo (agent + web search)  |
+| `record-app-screen.sh`    | Record app screen (video + screenshots, start/stop) |
 | `test-discord-bot.sh`     | Send message to Discord bot via osascript           |
 | `test-slack-bot.sh`       | Send message to Slack bot via osascript             |
 | `test-telegram-bot.sh`    | Send message to Telegram bot via osascript          |
@@ -1069,49 +1069,46 @@ Each script: activates the app, navigates to the channel/contact, pastes the mes
 
 # Screen Recording
 
-Record automated demos by combining `ffmpeg` screen capture with `agent-browser` automation.
+Record automated demos by combining `ffmpeg` + `agent-browser` screenshots.
 
-### Gateway Streaming Demo
+### record-app-screen.sh (Recommended)
 
-`record-gateway-demo.sh` records a complete Gateway agent execution flow: Electron startup → agent navigation → message send → streaming response → tool calls → completion.
+General-purpose screen recording with start/stop lifecycle. Captures CDP screenshots as video frames and gallery snapshots. Works on any screen including external monitors.
 
 ```bash
-# Default: web search demo
-./.agents/skills/local-testing/scripts/record-gateway-demo.sh
+# Start Electron first
+./.agents/skills/local-testing/scripts/electron-dev.sh start
 
-# Custom message
-./.agents/skills/local-testing/scripts/record-gateway-demo.sh "explain how HTTPS works"
+# Start recording
+./.agents/skills/local-testing/scripts/record-app-screen.sh start my-demo
 
-# Custom message + output path
-./.agents/skills/local-testing/scripts/record-gateway-demo.sh "explain DNS" .records/dns-demo.mp4
+# ... run your automation via agent-browser ...
+
+# Stop recording — assembles frames into video
+./.agents/skills/local-testing/scripts/record-app-screen.sh stop
+
+# Check status
+./.agents/skills/local-testing/scripts/record-app-screen.sh status
 ```
+
+Outputs to `.records/` directory (gitignored):
+
+- `.records/<name>.mp4` — Video assembled from screenshots (\~2 fps)
+- `.records/<name>/` — Gallery screenshots every 3 seconds
 
 Environment variables:
 
-| Variable      | Default                           | Description                              |
-| ------------- | --------------------------------- | ---------------------------------------- |
-| `GATEWAY_URL` | `wss://agent-gateway.lobehub.com` | Gateway WebSocket URL                    |
-| `CDP_PORT`    | `9222`                            | Chrome DevTools Protocol port            |
-| `AGENT_REF`   | (auto-detect)                     | agent-browser ref for the agent link     |
-| `FRAMERATE`   | `15`                              | Recording framerate                      |
-| `MAX_WAIT`    | `120`                             | Max seconds to wait for agent completion |
+| Variable               | Default | Description                         |
+| ---------------------- | ------- | ----------------------------------- |
+| `CDP_PORT`             | `9222`  | Chrome DevTools Protocol port       |
+| `SCREENSHOT_INTERVAL`  | `3`     | Seconds between gallery screenshots |
+| `VIDEO_FRAME_INTERVAL` | `0.5`   | Seconds between video frames        |
 
-The script automatically:
+### record-electron-demo.sh
 
-1. Starts Electron with CDP and waits for SPA to load
-2. Injects the Gateway URL into server config
-3. Auto-detects which screen the Electron window is on (supports external monitors)
-4. Records the screen using `ffmpeg -f avfoundation`
-5. Navigates to an agent, sends the message, waits for completion
-6. Crops the recording to the Electron window region and compresses
-7. Outputs to `.records/` directory (gitignored)
-
-### General Electron Demo
-
-`record-electron-demo.sh` records a custom automation script against the Electron app.
+Records a custom automation script against the Electron app using ffmpeg avfoundation.
 
 ```bash
-# Run a custom automation script
 ./.agents/skills/local-testing/scripts/record-electron-demo.sh ./my-demo.sh .records/my-demo.mp4
 ```
 

--- a/.agents/skills/local-testing/references/record-app-screen.md
+++ b/.agents/skills/local-testing/references/record-app-screen.md
@@ -1,0 +1,142 @@
+# record-app-screen.sh
+
+General-purpose screen recording tool for the Electron app. Captures CDP screenshots as video frames and gallery snapshots, then assembles into an MP4 on stop.
+
+## Why CDP Screenshots Instead of ffmpeg Screen Capture
+
+- **Works on any screen** — CDP screenshots capture the browser viewport directly, so external monitors, Retina scaling, and window positioning are all handled automatically
+- **No signal handling issues** — ffmpeg-static (npm) produces corrupt MP4 files when killed (missing moov atom). CDP screenshots avoid this entirely
+- **Consistent output** — Screenshots are resolution-independent and don't require crop coordinate calculations
+
+## Commands
+
+```bash
+# Start recording (Electron must be running with CDP)
+.agents/skills/local-testing/scripts/record-app-screen.sh start [output_name]
+
+# Stop recording and assemble video
+.agents/skills/local-testing/scripts/record-app-screen.sh stop
+
+# Check if recording is active
+.agents/skills/local-testing/scripts/record-app-screen.sh status
+```
+
+### Arguments
+
+| Argument      | Default                     | Description                |
+| ------------- | --------------------------- | -------------------------- |
+| `output_name` | `recording-YYYYMMDD-HHMMSS` | Base name for output files |
+
+### Environment Variables
+
+| Variable               | Default | Description                            |
+| ---------------------- | ------- | -------------------------------------- |
+| `CDP_PORT`             | `9222`  | Chrome DevTools Protocol port          |
+| `SCREENSHOT_INTERVAL`  | `3`     | Seconds between gallery screenshots    |
+| `VIDEO_FRAME_INTERVAL` | `0.5`   | Seconds between video frames (\~2 fps) |
+
+## Output Structure
+
+```
+.records/
+  <name>.mp4          # Video assembled from frames (~2 fps)
+  <name>/             # Gallery screenshots (every 3s)
+    0000.png
+    0001.png
+    0002.png
+    ...
+```
+
+The `.records/` directory is at the project root and is gitignored.
+
+## How It Works
+
+### Start
+
+1. Creates two background loops:
+   - **Video frames** — `agent-browser screenshot` every `VIDEO_FRAME_INTERVAL` seconds into a temp directory (`/tmp/record-frames-XXXXXX/`)
+   - **Gallery screenshots** — `agent-browser screenshot` every `SCREENSHOT_INTERVAL` seconds into `.records/<name>/`
+2. Saves PIDs and paths to `/tmp/record-app-screen.pids` and `/tmp/record-app-screen.state`
+
+### Stop
+
+1. Kills both background loops
+2. Assembles video frames into MP4 using ffmpeg:
+   ```
+   ffmpeg -framerate 2 -i frame_%06d.png -c:v libx264 -crf 23 -pix_fmt yuv420p <output>.mp4
+   ```
+3. Cleans up temp frame directory
+4. Reports file sizes and paths
+
+## Usage Examples
+
+### Basic Test Recording
+
+```bash
+# Start Electron
+.agents/skills/local-testing/scripts/electron-dev.sh start
+
+# Start recording
+.agents/skills/local-testing/scripts/record-app-screen.sh start my-test
+
+# Run automation
+agent-browser --cdp 9222 click @e61
+agent-browser --cdp 9222 type @e42 "hello"
+agent-browser --cdp 9222 press Enter
+sleep 10
+
+# Stop and get results
+.agents/skills/local-testing/scripts/record-app-screen.sh stop
+# → .records/my-test.mp4 + .records/my-test/*.png
+```
+
+### Gateway Streaming Demo
+
+```bash
+.agents/skills/local-testing/scripts/electron-dev.sh start
+
+# Inject gateway URL
+agent-browser --cdp 9222 eval --stdin << 'EOF'
+(function() {
+  var store = window.global_serverConfigStore;
+  store.setState({ serverConfig: { ...store.getState().serverConfig,
+    agentGatewayUrl: 'https://agent-gateway.lobehub.com' } });
+  return 'ready';
+})()
+EOF
+
+# Record
+.agents/skills/local-testing/scripts/record-app-screen.sh start gateway-demo
+
+# Navigate to agent, send message, wait for completion...
+# (automation commands here)
+
+.agents/skills/local-testing/scripts/record-app-screen.sh stop
+open .records/gateway-demo.mp4
+```
+
+### Check Active Recording
+
+```bash
+.agents/skills/local-testing/scripts/record-app-screen.sh status
+# [record] Active recording
+#   Frames:      42 captured (running: yes)
+#   Screenshots: 14 captured (running: yes)
+#   Output:      .records/my-test.mp4
+```
+
+## Prerequisites
+
+- **ffmpeg** — For video assembly. Install via `bun add -g ffmpeg-static` or `brew install ffmpeg`
+- **agent-browser** — For CDP screenshots. Install via `npm i -g agent-browser`
+- **Electron app running** — With CDP enabled (use `electron-dev.sh start`)
+
+## Troubleshooting
+
+| Problem                             | Solution                                                                                                     |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| "No active recording found" on stop | PID file was cleaned up. Check if background processes are still running with `ps aux \| grep agent-browser` |
+| "A recording is already active"     | Run `stop` first, or manually clean: `rm /tmp/record-app-screen.pids /tmp/record-app-screen.state`           |
+| Video is 0 bytes                    | No frames were captured. Ensure Electron is running and CDP port is correct                                  |
+| Screenshots are blank/white         | SPA may not have loaded yet. Wait for `electron-dev.sh` to report "Renderer ready"                           |
+| ffmpeg assembly fails               | Check `/tmp/ffmpeg-assemble.log`. Ensure ffmpeg is installed and frames exist                                |

--- a/.agents/skills/local-testing/scripts/record-app-screen.sh
+++ b/.agents/skills/local-testing/scripts/record-app-screen.sh
@@ -2,8 +2,8 @@
 #
 # record-app-screen.sh — Record the Electron app window (video + screenshots)
 #
-# A general-purpose screen recording tool with start/stop lifecycle.
-# The caller starts Electron and drives automation; this script handles recording.
+# Captures screenshots via agent-browser (CDP), then assembles into video on stop.
+# Works on any screen (including external monitors) since it uses CDP, not screen capture.
 #
 # Usage:
 #   ./record-app-screen.sh start [output_name]   # Begin recording
@@ -11,18 +11,18 @@
 #   ./record-app-screen.sh status                 # Check recording state
 #
 # Outputs to .records/ directory:
-#   .records/<name>.mp4   — Cropped video of Electron window
+#   .records/<name>.mp4   — Video assembled from screenshots (~2 fps)
 #   .records/<name>/      — Screenshots every SCREENSHOT_INTERVAL seconds
 #
 # Prerequisites:
 #   - ffmpeg installed (bun add -g ffmpeg-static, or brew install ffmpeg)
-#   - agent-browser CLI installed (for screenshots)
+#   - agent-browser CLI installed
 #   - Electron app already running with CDP enabled
 #
 # Environment variables:
 #   CDP_PORT              — Chrome DevTools Protocol port (default: 9222)
-#   FRAMERATE             — Recording framerate (default: 30)
-#   SCREENSHOT_INTERVAL   — Seconds between screenshots (default: 3)
+#   SCREENSHOT_INTERVAL   — Seconds between gallery screenshots (default: 3)
+#   VIDEO_FRAME_INTERVAL  — Seconds between video frames (default: 0.5)
 #
 # Examples:
 #   ./electron-dev.sh start
@@ -40,55 +40,10 @@ PID_FILE="/tmp/record-app-screen.pids"
 STATE_FILE="/tmp/record-app-screen.state"
 
 CDP_PORT="${CDP_PORT:-9222}"
-FRAMERATE="${FRAMERATE:-30}"
 SCREENSHOT_INTERVAL="${SCREENSHOT_INTERVAL:-3}"
+VIDEO_FRAME_INTERVAL="${VIDEO_FRAME_INTERVAL:-0.5}"
 
 AB="agent-browser --cdp $CDP_PORT"
-
-# ─── Window Detection ───
-
-get_window_and_screen_info() {
-  # Returns: rel_x rel_y width height screen_index backing_scale
-  swift -e '
-    import Cocoa
-    let windowList = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as! [[String: Any]]
-    for w in windowList {
-      let owner = w["kCGWindowOwnerName"] as? String ?? ""
-      let layer = w["kCGWindowLayer"] as? Int ?? -1
-      let bounds = w["kCGWindowBounds"] as? [String: Any] ?? [:]
-      let wx = bounds["X"] as? Double ?? 0
-      let wy = bounds["Y"] as? Double ?? 0
-      let ww = bounds["Width"] as? Double ?? 0
-      let wh = bounds["Height"] as? Double ?? 0
-      if (owner == "Electron" || owner == "LobeHub") && layer == 0 && ww > 200 && wh > 200 {
-        let screens = NSScreen.screens
-        var screenIdx = 0
-        let windowCenter = NSPoint(x: wx + ww / 2, y: wy + wh / 2)
-        for (i, screen) in screens.enumerated() {
-          let frame = screen.frame
-          let mainHeight = screens[0].frame.height
-          let screenTop = mainHeight - frame.origin.y - frame.height
-          let screenBottom = screenTop + frame.height
-          let screenLeft = frame.origin.x
-          let screenRight = screenLeft + frame.width
-          if windowCenter.x >= screenLeft && windowCenter.x <= screenRight &&
-             windowCenter.y >= screenTop && windowCenter.y <= screenBottom {
-            screenIdx = i
-            break
-          }
-        }
-        let screen = screens[screenIdx]
-        let mainHeight = screens[0].frame.height
-        let screenTop = mainHeight - screen.frame.origin.y - screen.frame.height
-        let relX = wx - screen.frame.origin.x
-        let relY = wy - screenTop
-        let scale = Int(screen.backingScaleFactor)
-        print("\(Int(relX)) \(Int(relY)) \(Int(ww)) \(Int(wh)) \(screenIdx) \(scale)")
-        break
-      }
-    }
-  '
-}
 
 # ─── Commands ───
 
@@ -96,6 +51,8 @@ cmd_start() {
   local output_name="${1:-recording-$(date +%Y%m%d-%H%M%S)}"
   local output_video="$RECORDS_DIR/${output_name}.mp4"
   local screenshot_dir="$RECORDS_DIR/${output_name}"
+  local frames_dir
+  frames_dir=$(mktemp -d /tmp/record-frames-XXXXXX)
 
   if [ -f "$PID_FILE" ]; then
     echo "[record] A recording is already active. Run '$0 stop' first."
@@ -104,76 +61,40 @@ cmd_start() {
 
   mkdir -p "$RECORDS_DIR" "$screenshot_dir"
 
-  # Detect window
-  echo "[record] Detecting Electron window..."
-  local win_info
-  win_info=$(get_window_and_screen_info)
-  if [ -z "$win_info" ]; then
-    echo "[error] Could not find Electron window. Is the app running?"
-    exit 1
-  fi
-
-  local rel_x rel_y w h screen_idx scale
-  read -r rel_x rel_y w h screen_idx scale <<< "$win_info"
-  echo "[record] Window: ${rel_x},${rel_y} ${w}x${h} on screen ${screen_idx} (${scale}x)"
-
-  # Find ffmpeg capture device
-  local device_idx
-  device_idx=$(ffmpeg -f avfoundation -list_devices true -i "" 2>&1 \
-    | grep "Capture screen ${screen_idx}" \
-    | grep -oE '\[[0-9]+\]' | tr -d '[]' || true)
-  if [ -z "$device_idx" ]; then
-    echo "[warn] Could not find device for screen $screen_idx, trying index 3"
-    device_idx=3
-  fi
-
-  # Crop coordinates at native (Retina) resolution
-  local cx=$((rel_x * scale))
-  local cy=$((rel_y * scale))
-  local cw=$((w * scale))
-  local ch=$((h * scale))
-
-  # Start ffmpeg
-  local raw_video
-  raw_video=$(mktemp /tmp/record-raw-XXXXXX.mp4)
-
-  ffmpeg -y \
-    -f avfoundation -framerate "$FRAMERATE" -capture_cursor 1 -i "${device_idx}:" \
-    -vf "crop=${cw}:${ch}:${cx}:${cy},scale=${w}:${h}" \
-    -c:v libx264 -crf 23 -preset fast -an \
-    "$raw_video" \
-    > /tmp/ffmpeg-record.log 2>&1 &
-  local ffmpeg_pid=$!
-  sleep 2
-
-  if ! kill -0 "$ffmpeg_pid" 2>/dev/null; then
-    echo "[error] ffmpeg failed to start:"
-    cat /tmp/ffmpeg-record.log
-    rm -f "$raw_video"
-    exit 1
-  fi
-
-  # Start screenshot loop
+  # Video frames loop (~2 fps via agent-browser CDP screenshots)
   (
     local idx=0
     while true; do
-      local filename
-      filename=$(printf "%s/%04d.png" "$screenshot_dir" "$idx")
-      $AB screenshot "$filename" 2>/dev/null || true
+      local fname
+      fname=$(printf "%s/frame_%06d.png" "$frames_dir" "$idx")
+      $AB screenshot "$fname" 2>/dev/null || true
+      idx=$((idx + 1))
+      sleep "$VIDEO_FRAME_INTERVAL"
+    done
+  ) &
+  local frames_pid=$!
+
+  # Gallery screenshots loop (every N seconds for human review)
+  (
+    local idx=0
+    while true; do
+      local fname
+      fname=$(printf "%s/%04d.png" "$screenshot_dir" "$idx")
+      $AB screenshot "$fname" 2>/dev/null || true
       idx=$((idx + 1))
       sleep "$SCREENSHOT_INTERVAL"
     done
   ) &
   local screenshot_pid=$!
 
-  # Save state for stop command
-  echo "$ffmpeg_pid $screenshot_pid" > "$PID_FILE"
-  echo "$output_video $raw_video $screenshot_dir" > "$STATE_FILE"
+  # Save state
+  echo "$frames_pid $screenshot_pid" > "$PID_FILE"
+  echo "$output_video $frames_dir $screenshot_dir" > "$STATE_FILE"
 
   echo "[record] Started!"
-  echo "  Video:       recording (PID $ffmpeg_pid)"
-  echo "  Screenshots: every ${SCREENSHOT_INTERVAL}s → $screenshot_dir/"
-  echo "  Stop with:   $0 stop"
+  echo "  Video frames: every ${VIDEO_FRAME_INTERVAL}s (PID $frames_pid)"
+  echo "  Screenshots:  every ${SCREENSHOT_INTERVAL}s → $screenshot_dir/"
+  echo "  Stop with:    $0 stop"
 }
 
 cmd_stop() {
@@ -182,25 +103,37 @@ cmd_stop() {
     return 0
   fi
 
-  local ffmpeg_pid screenshot_pid
-  read -r ffmpeg_pid screenshot_pid < "$PID_FILE"
+  local frames_pid screenshot_pid
+  read -r frames_pid screenshot_pid < "$PID_FILE"
 
-  local output_video raw_video screenshot_dir
-  read -r output_video raw_video screenshot_dir < "$STATE_FILE"
+  local output_video frames_dir screenshot_dir
+  read -r output_video frames_dir screenshot_dir < "$STATE_FILE"
 
-  # Stop screenshot loop
+  # Stop both capture loops
+  kill "$frames_pid" 2>/dev/null || true
   kill "$screenshot_pid" 2>/dev/null || true
+  wait "$frames_pid" 2>/dev/null || true
   wait "$screenshot_pid" 2>/dev/null || true
 
-  # Stop ffmpeg gracefully
-  kill -INT "$ffmpeg_pid" 2>/dev/null || true
-  wait "$ffmpeg_pid" 2>/dev/null || true
+  # Assemble frames into video
+  local frame_count
+  frame_count=$(ls -1 "$frames_dir"/frame_*.png 2>/dev/null | wc -l | tr -d ' ')
 
-  # Move raw video to final location
-  if [ -f "$raw_video" ]; then
-    mv "$raw_video" "$output_video"
+  if [ "$frame_count" -gt 0 ]; then
+    echo "[record] Assembling $frame_count frames into video..."
+    ffmpeg -y -framerate 2 -i "$frames_dir/frame_%06d.png" \
+      -c:v libx264 -crf 23 -pix_fmt yuv420p -an \
+      "$output_video" > /tmp/ffmpeg-assemble.log 2>&1
+
+    if [ ! -s "$output_video" ]; then
+      echo "  [warn] Video assembly failed. Check /tmp/ffmpeg-assemble.log"
+      echo "  Frames preserved in: $frames_dir/"
+    fi
+  else
+    echo "  [warn] No frames captured."
   fi
 
+  rm -rf "$frames_dir" 2>/dev/null
   rm -f "$PID_FILE" "$STATE_FILE"
 
   local video_size screenshot_count
@@ -219,22 +152,24 @@ cmd_status() {
     return 0
   fi
 
-  local ffmpeg_pid screenshot_pid
-  read -r ffmpeg_pid screenshot_pid < "$PID_FILE"
+  local frames_pid screenshot_pid
+  read -r frames_pid screenshot_pid < "$PID_FILE"
 
-  local ffmpeg_ok="no" screenshot_ok="no"
-  kill -0 "$ffmpeg_pid" 2>/dev/null && ffmpeg_ok="yes"
+  local frames_ok="no" screenshot_ok="no"
+  kill -0 "$frames_pid" 2>/dev/null && frames_ok="yes"
   kill -0 "$screenshot_pid" 2>/dev/null && screenshot_ok="yes"
 
-  local output_video raw_video screenshot_dir
-  read -r output_video raw_video screenshot_dir < "$STATE_FILE"
-  local count
-  count=$(ls -1 "$screenshot_dir"/*.png 2>/dev/null | wc -l | tr -d ' ' || echo "0")
-
-  echo "[record] Active recording"
-  echo "  Video:       PID $ffmpeg_pid (running: $ffmpeg_ok)"
-  echo "  Screenshots: PID $screenshot_pid (running: $screenshot_ok), ${count} captured"
-  echo "  Output:      $output_video"
+  if [ -f "$STATE_FILE" ]; then
+    local output_video frames_dir screenshot_dir
+    read -r output_video frames_dir screenshot_dir < "$STATE_FILE"
+    local frame_count ss_count
+    frame_count=$(ls -1 "$frames_dir"/frame_*.png 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+    ss_count=$(ls -1 "$screenshot_dir"/*.png 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+    echo "[record] Active recording"
+    echo "  Frames:      $frame_count captured (running: $frames_ok)"
+    echo "  Screenshots: $ss_count captured (running: $screenshot_ok)"
+    echo "  Output:      $output_video"
+  fi
 }
 
 # ─── Main ───

--- a/.agents/skills/local-testing/scripts/record-app-screen.sh
+++ b/.agents/skills/local-testing/scripts/record-app-screen.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+#
+# record-app-screen.sh — Record the Electron app window (video + screenshots)
+#
+# A general-purpose screen recording tool with start/stop lifecycle.
+# The caller starts Electron and drives automation; this script handles recording.
+#
+# Usage:
+#   ./record-app-screen.sh start [output_name]   # Begin recording
+#   ./record-app-screen.sh stop                   # Stop and save
+#   ./record-app-screen.sh status                 # Check recording state
+#
+# Outputs to .records/ directory:
+#   .records/<name>.mp4   — Cropped video of Electron window
+#   .records/<name>/      — Screenshots every SCREENSHOT_INTERVAL seconds
+#
+# Prerequisites:
+#   - ffmpeg installed (bun add -g ffmpeg-static, or brew install ffmpeg)
+#   - agent-browser CLI installed (for screenshots)
+#   - Electron app already running with CDP enabled
+#
+# Environment variables:
+#   CDP_PORT              — Chrome DevTools Protocol port (default: 9222)
+#   FRAMERATE             — Recording framerate (default: 30)
+#   SCREENSHOT_INTERVAL   — Seconds between screenshots (default: 3)
+#
+# Examples:
+#   ./electron-dev.sh start
+#   ./record-app-screen.sh start gateway-demo
+#   # ... run automation via agent-browser ...
+#   ./record-app-screen.sh stop
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+RECORDS_DIR="$PROJECT_DIR/.records"
+PID_FILE="/tmp/record-app-screen.pids"
+STATE_FILE="/tmp/record-app-screen.state"
+
+CDP_PORT="${CDP_PORT:-9222}"
+FRAMERATE="${FRAMERATE:-30}"
+SCREENSHOT_INTERVAL="${SCREENSHOT_INTERVAL:-3}"
+
+AB="agent-browser --cdp $CDP_PORT"
+
+# ─── Window Detection ───
+
+get_window_and_screen_info() {
+  # Returns: rel_x rel_y width height screen_index backing_scale
+  swift -e '
+    import Cocoa
+    let windowList = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as! [[String: Any]]
+    for w in windowList {
+      let owner = w["kCGWindowOwnerName"] as? String ?? ""
+      let layer = w["kCGWindowLayer"] as? Int ?? -1
+      let bounds = w["kCGWindowBounds"] as? [String: Any] ?? [:]
+      let wx = bounds["X"] as? Double ?? 0
+      let wy = bounds["Y"] as? Double ?? 0
+      let ww = bounds["Width"] as? Double ?? 0
+      let wh = bounds["Height"] as? Double ?? 0
+      if (owner == "Electron" || owner == "LobeHub") && layer == 0 && ww > 200 && wh > 200 {
+        let screens = NSScreen.screens
+        var screenIdx = 0
+        let windowCenter = NSPoint(x: wx + ww / 2, y: wy + wh / 2)
+        for (i, screen) in screens.enumerated() {
+          let frame = screen.frame
+          let mainHeight = screens[0].frame.height
+          let screenTop = mainHeight - frame.origin.y - frame.height
+          let screenBottom = screenTop + frame.height
+          let screenLeft = frame.origin.x
+          let screenRight = screenLeft + frame.width
+          if windowCenter.x >= screenLeft && windowCenter.x <= screenRight &&
+             windowCenter.y >= screenTop && windowCenter.y <= screenBottom {
+            screenIdx = i
+            break
+          }
+        }
+        let screen = screens[screenIdx]
+        let mainHeight = screens[0].frame.height
+        let screenTop = mainHeight - screen.frame.origin.y - screen.frame.height
+        let relX = wx - screen.frame.origin.x
+        let relY = wy - screenTop
+        let scale = Int(screen.backingScaleFactor)
+        print("\(Int(relX)) \(Int(relY)) \(Int(ww)) \(Int(wh)) \(screenIdx) \(scale)")
+        break
+      }
+    }
+  '
+}
+
+# ─── Commands ───
+
+cmd_start() {
+  local output_name="${1:-recording-$(date +%Y%m%d-%H%M%S)}"
+  local output_video="$RECORDS_DIR/${output_name}.mp4"
+  local screenshot_dir="$RECORDS_DIR/${output_name}"
+
+  if [ -f "$PID_FILE" ]; then
+    echo "[record] A recording is already active. Run '$0 stop' first."
+    exit 1
+  fi
+
+  mkdir -p "$RECORDS_DIR" "$screenshot_dir"
+
+  # Detect window
+  echo "[record] Detecting Electron window..."
+  local win_info
+  win_info=$(get_window_and_screen_info)
+  if [ -z "$win_info" ]; then
+    echo "[error] Could not find Electron window. Is the app running?"
+    exit 1
+  fi
+
+  local rel_x rel_y w h screen_idx scale
+  read -r rel_x rel_y w h screen_idx scale <<< "$win_info"
+  echo "[record] Window: ${rel_x},${rel_y} ${w}x${h} on screen ${screen_idx} (${scale}x)"
+
+  # Find ffmpeg capture device
+  local device_idx
+  device_idx=$(ffmpeg -f avfoundation -list_devices true -i "" 2>&1 \
+    | grep "Capture screen ${screen_idx}" \
+    | grep -oE '\[[0-9]+\]' | tr -d '[]' || true)
+  if [ -z "$device_idx" ]; then
+    echo "[warn] Could not find device for screen $screen_idx, trying index 3"
+    device_idx=3
+  fi
+
+  # Crop coordinates at native (Retina) resolution
+  local cx=$((rel_x * scale))
+  local cy=$((rel_y * scale))
+  local cw=$((w * scale))
+  local ch=$((h * scale))
+
+  # Start ffmpeg
+  local raw_video
+  raw_video=$(mktemp /tmp/record-raw-XXXXXX.mp4)
+
+  ffmpeg -y \
+    -f avfoundation -framerate "$FRAMERATE" -capture_cursor 1 -i "${device_idx}:" \
+    -vf "crop=${cw}:${ch}:${cx}:${cy},scale=${w}:${h}" \
+    -c:v libx264 -crf 23 -preset fast -an \
+    "$raw_video" \
+    > /tmp/ffmpeg-record.log 2>&1 &
+  local ffmpeg_pid=$!
+  sleep 2
+
+  if ! kill -0 "$ffmpeg_pid" 2>/dev/null; then
+    echo "[error] ffmpeg failed to start:"
+    cat /tmp/ffmpeg-record.log
+    rm -f "$raw_video"
+    exit 1
+  fi
+
+  # Start screenshot loop
+  (
+    local idx=0
+    while true; do
+      local filename
+      filename=$(printf "%s/%04d.png" "$screenshot_dir" "$idx")
+      $AB screenshot "$filename" 2>/dev/null || true
+      idx=$((idx + 1))
+      sleep "$SCREENSHOT_INTERVAL"
+    done
+  ) &
+  local screenshot_pid=$!
+
+  # Save state for stop command
+  echo "$ffmpeg_pid $screenshot_pid" > "$PID_FILE"
+  echo "$output_video $raw_video $screenshot_dir" > "$STATE_FILE"
+
+  echo "[record] Started!"
+  echo "  Video:       recording (PID $ffmpeg_pid)"
+  echo "  Screenshots: every ${SCREENSHOT_INTERVAL}s → $screenshot_dir/"
+  echo "  Stop with:   $0 stop"
+}
+
+cmd_stop() {
+  if [ ! -f "$PID_FILE" ] || [ ! -f "$STATE_FILE" ]; then
+    echo "[record] No active recording found."
+    return 0
+  fi
+
+  local ffmpeg_pid screenshot_pid
+  read -r ffmpeg_pid screenshot_pid < "$PID_FILE"
+
+  local output_video raw_video screenshot_dir
+  read -r output_video raw_video screenshot_dir < "$STATE_FILE"
+
+  # Stop screenshot loop
+  kill "$screenshot_pid" 2>/dev/null || true
+  wait "$screenshot_pid" 2>/dev/null || true
+
+  # Stop ffmpeg gracefully
+  kill -INT "$ffmpeg_pid" 2>/dev/null || true
+  wait "$ffmpeg_pid" 2>/dev/null || true
+
+  # Move raw video to final location
+  if [ -f "$raw_video" ]; then
+    mv "$raw_video" "$output_video"
+  fi
+
+  rm -f "$PID_FILE" "$STATE_FILE"
+
+  local video_size screenshot_count
+  video_size=$(ls -lh "$output_video" 2>/dev/null | awk '{print $5}' || echo "?")
+  screenshot_count=$(ls -1 "$screenshot_dir"/*.png 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+
+  echo "[record] Stopped!"
+  echo "  Video:       $output_video ($video_size)"
+  echo "  Screenshots: ${screenshot_count} files in $screenshot_dir/"
+  echo "  Play:        open $output_video"
+}
+
+cmd_status() {
+  if [ ! -f "$PID_FILE" ]; then
+    echo "[record] No active recording."
+    return 0
+  fi
+
+  local ffmpeg_pid screenshot_pid
+  read -r ffmpeg_pid screenshot_pid < "$PID_FILE"
+
+  local ffmpeg_ok="no" screenshot_ok="no"
+  kill -0 "$ffmpeg_pid" 2>/dev/null && ffmpeg_ok="yes"
+  kill -0 "$screenshot_pid" 2>/dev/null && screenshot_ok="yes"
+
+  local output_video raw_video screenshot_dir
+  read -r output_video raw_video screenshot_dir < "$STATE_FILE"
+  local count
+  count=$(ls -1 "$screenshot_dir"/*.png 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+
+  echo "[record] Active recording"
+  echo "  Video:       PID $ffmpeg_pid (running: $ffmpeg_ok)"
+  echo "  Screenshots: PID $screenshot_pid (running: $screenshot_ok), ${count} captured"
+  echo "  Output:      $output_video"
+}
+
+# ─── Main ───
+
+case "${1:-}" in
+  start)  shift; cmd_start "$@" ;;
+  stop)   cmd_stop ;;
+  status) cmd_status ;;
+  *)
+    echo "Usage: $0 {start [name] | stop | status}"
+    echo ""
+    echo "  start [name]  Start recording (default: recording-YYYYMMDD-HHMMSS)"
+    echo "  stop          Stop recording and save outputs"
+    echo "  status        Check if recording is active"
+    exit 1
+    ;;
+esac

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ Desktop.ini
 *.code-workspace
 .vscode/sessions.json
 prd
+# Recordings
+.records/
+
 # Temporary files
 .temp/
 temp/

--- a/packages/types/src/serverConfig.ts
+++ b/packages/types/src/serverConfig.ts
@@ -47,6 +47,12 @@ export interface ServerModelProviderConfig {
 export type ServerLanguageModel = Partial<Record<GlobalLLMProviderKey, ServerModelProviderConfig>>;
 
 export interface GlobalServerConfig {
+  /**
+   * Agent Gateway URL for WebSocket-based agent execution.
+   * When set, the SPA can offload agent execution to the server and receive
+   * events via the Gateway instead of running the agent loop client-side.
+   */
+  agentGatewayUrl?: string;
   aiProvider: ServerLanguageModel;
   defaultAgent?: PartialDeep<UserDefaultAgent>;
   disableEmailPassword?: boolean;

--- a/packages/types/src/user/preference.ts
+++ b/packages/types/src/user/preference.ts
@@ -39,6 +39,10 @@ export type UserGuide = z.infer<typeof UserGuideSchema>;
 
 export const UserLabSchema = z.object({
   /**
+   * enable server-side agent execution via Gateway WebSocket
+   */
+  enableGatewayMode: z.boolean().optional(),
+  /**
    * enable multi-agent group chat mode
    */
   enableGroupChat: z.boolean().optional(),

--- a/src/envs/app.ts
+++ b/src/envs/app.ts
@@ -76,7 +76,7 @@ export const getAppConfig = () => {
       MARKET_TRUSTED_CLIENT_ID: z.string().optional(),
 
       AGENT_GATEWAY_SERVICE_TOKEN: z.string().optional(),
-      AGENT_GATEWAY_URL: z.string().url(),
+      AGENT_GATEWAY_URL: z.string().url().optional(),
       /**
        * Enable Queue-based Agent Runtime
        * When true, use QStash for async agent execution (production)
@@ -121,7 +121,7 @@ export const getAppConfig = () => {
       MARKET_TRUSTED_CLIENT_ID: process.env.MARKET_TRUSTED_CLIENT_ID,
 
       AGENT_GATEWAY_SERVICE_TOKEN: process.env.AGENT_GATEWAY_SERVICE_TOKEN,
-      AGENT_GATEWAY_URL: process.env.AGENT_GATEWAY_URL || 'https://agent-gateway.lobehub.com',
+      AGENT_GATEWAY_URL: process.env.AGENT_GATEWAY_URL,
       enableQueueAgentRuntime: process.env.AGENT_RUNTIME_MODE === 'queue',
       TELEMETRY_DISABLED: process.env.TELEMETRY_DISABLED === '1',
     },

--- a/src/libs/agent-stream/client.ts
+++ b/src/libs/agent-stream/client.ts
@@ -126,6 +126,7 @@ export class AgentStreamClient extends TypedEmitter {
     this.intentionalDisconnect = true;
     this.cleanup();
     this.setStatus('disconnected');
+    this.emit('disconnected');
   }
 
   /**

--- a/src/libs/agent-stream/client.ts
+++ b/src/libs/agent-stream/client.ts
@@ -169,6 +169,12 @@ export class AgentStreamClient extends TypedEmitter {
   }
 
   private buildWsUrl(): string {
+    // If the URL already has a ws/wss protocol, use it directly
+    if (this.gatewayUrl.startsWith('ws://') || this.gatewayUrl.startsWith('wss://')) {
+      const base = this.gatewayUrl.replace(/\/+$/, '');
+      return `${base}/ws?operationId=${encodeURIComponent(this.operationId)}`;
+    }
+    // Otherwise convert http(s) to ws(s)
     const wsProtocol = this.gatewayUrl.startsWith('https') ? 'wss' : 'ws';
     const host = this.gatewayUrl.replace(/^https?:\/\//, '');
     return `${wsProtocol}://${host}/ws?operationId=${encodeURIComponent(this.operationId)}`;

--- a/src/libs/agent-stream/index.ts
+++ b/src/libs/agent-stream/index.ts
@@ -5,6 +5,10 @@ export type {
   AgentStreamEvent,
   AgentStreamEventType,
   ConnectionStatus,
+  StepCompleteData,
   StreamChunkData,
   StreamChunkType,
+  StreamStartData,
+  ToolEndData,
+  ToolStartData,
 } from './types';

--- a/src/libs/agent-stream/types.ts
+++ b/src/libs/agent-stream/types.ts
@@ -44,6 +44,33 @@ export interface StreamChunkData {
   toolsCalling?: any[];
 }
 
+// ─── Typed Event Data ───
+
+export interface StreamStartData {
+  assistantMessage: { id: string };
+  model?: string;
+  provider?: string;
+}
+
+export interface ToolStartData {
+  parentMessageId: string;
+  toolCalling: Record<string, unknown>;
+}
+
+export interface ToolEndData {
+  executionTime?: number;
+  isSuccess: boolean;
+  payload?: Record<string, unknown>;
+  result?: unknown;
+}
+
+export interface StepCompleteData {
+  finalState?: unknown;
+  phase: string;
+  reason?: string;
+  reasonDetail?: string;
+}
+
 // ─── WebSocket Protocol Messages ───
 
 // Client → Server

--- a/src/locales/default/labs.ts
+++ b/src/locales/default/labs.ts
@@ -2,6 +2,9 @@ export default {
   'features.assistantMessageGroup.desc':
     'Group agent messages and their tool call results together for display',
   'features.assistantMessageGroup.title': 'Agent Message Grouping',
+  'features.gatewayMode.desc':
+    'Execute agent tasks on the server via Gateway WebSocket instead of running locally. Enables faster execution and reduces client resource usage.',
+  'features.gatewayMode.title': 'Server-Side Agent Execution (Gateway)',
   'features.groupChat.desc': 'Enable multi-agent group chat coordination.',
   'features.groupChat.title': 'Group Chat (Multi-Agent)',
   'features.inputMarkdown.desc':

--- a/src/routes/(main)/settings/advanced/index.tsx
+++ b/src/routes/(main)/settings/advanced/index.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { FORM_STYLE } from '@/const/layoutTokens';
 import SettingHeader from '@/routes/(main)/settings/features/SettingHeader';
 import { autoUpdateService } from '@/services/electron/autoUpdate';
+import { useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { labPreferSelectors, preferenceSelectors, settingsSelectors } from '@/store/user/selectors';
 
@@ -42,6 +43,8 @@ const Page = memo(() => {
       s.updateLab,
     ],
   );
+
+  const hasGatewayUrl = useServerConfigStore((s) => !!s.serverConfig.agentGatewayUrl);
 
   const [channel, setChannel] = useState<UpdateChannelValue>('stable');
 
@@ -95,19 +98,23 @@ const Page = memo(() => {
 
   const labsGroup: FormGroupItemType = {
     children: [
-      {
-        children: (
-          <Switch
-            checked={enableGatewayMode}
-            loading={!isPreferenceInit}
-            onChange={(checked) => updateLab({ enableGatewayMode: checked })}
-          />
-        ),
-        className: styles.labItem,
-        desc: tLabs('features.gatewayMode.desc'),
-        label: tLabs('features.gatewayMode.title'),
-        minWidth: undefined,
-      },
+      ...(hasGatewayUrl
+        ? [
+            {
+              children: (
+                <Switch
+                  checked={enableGatewayMode}
+                  loading={!isPreferenceInit}
+                  onChange={(checked: boolean) => updateLab({ enableGatewayMode: checked })}
+                />
+              ),
+              className: styles.labItem,
+              desc: tLabs('features.gatewayMode.desc'),
+              label: tLabs('features.gatewayMode.title'),
+              minWidth: undefined,
+            },
+          ]
+        : []),
       {
         avatar: (
           <img

--- a/src/routes/(main)/settings/advanced/index.tsx
+++ b/src/routes/(main)/settings/advanced/index.tsx
@@ -34,11 +34,14 @@ const Page = memo(() => {
   const [setSettings, isUserStateInit] = useUserStore((s) => [s.setSettings, s.isUserStateInit]);
   const [loading, setLoading] = useState(false);
 
-  const [isPreferenceInit, enableInputMarkdown, updateLab] = useUserStore((s) => [
-    preferenceSelectors.isPreferenceInit(s),
-    labPreferSelectors.enableInputMarkdown(s),
-    s.updateLab,
-  ]);
+  const [isPreferenceInit, enableInputMarkdown, enableGatewayMode, updateLab] = useUserStore(
+    (s) => [
+      preferenceSelectors.isPreferenceInit(s),
+      labPreferSelectors.enableInputMarkdown(s),
+      labPreferSelectors.enableGatewayMode(s),
+      s.updateLab,
+    ],
+  );
 
   const [channel, setChannel] = useState<UpdateChannelValue>('stable');
 
@@ -92,6 +95,19 @@ const Page = memo(() => {
 
   const labsGroup: FormGroupItemType = {
     children: [
+      {
+        children: (
+          <Switch
+            checked={enableGatewayMode}
+            loading={!isPreferenceInit}
+            onChange={(checked) => updateLab({ enableGatewayMode: checked })}
+          />
+        ),
+        className: styles.labItem,
+        desc: tLabs('features.gatewayMode.desc'),
+        label: tLabs('features.gatewayMode.title'),
+        minWidth: undefined,
+      },
       {
         avatar: (
           <img

--- a/src/routes/(main)/settings/advanced/index.tsx
+++ b/src/routes/(main)/settings/advanced/index.tsx
@@ -98,23 +98,6 @@ const Page = memo(() => {
 
   const labsGroup: FormGroupItemType = {
     children: [
-      ...(hasGatewayUrl
-        ? [
-            {
-              children: (
-                <Switch
-                  checked={enableGatewayMode}
-                  loading={!isPreferenceInit}
-                  onChange={(checked: boolean) => updateLab({ enableGatewayMode: checked })}
-                />
-              ),
-              className: styles.labItem,
-              desc: tLabs('features.gatewayMode.desc'),
-              label: tLabs('features.gatewayMode.title'),
-              minWidth: undefined,
-            },
-          ]
-        : []),
       {
         avatar: (
           <img
@@ -135,6 +118,23 @@ const Page = memo(() => {
         label: tLabs('features.inputMarkdown.title'),
         minWidth: undefined,
       },
+      ...(hasGatewayUrl
+        ? [
+            {
+              children: (
+                <Switch
+                  checked={enableGatewayMode}
+                  loading={!isPreferenceInit}
+                  onChange={(checked: boolean) => updateLab({ enableGatewayMode: checked })}
+                />
+              ),
+              className: styles.labItem,
+              desc: tLabs('features.gatewayMode.desc'),
+              label: tLabs('features.gatewayMode.title'),
+              minWidth: undefined,
+            },
+          ]
+        : []),
     ],
     title: tLabs('title'),
   };

--- a/src/server/globalConfig/index.ts
+++ b/src/server/globalConfig/index.ts
@@ -85,6 +85,11 @@ export const getServerGlobalConfig = async () => {
     ),
     enableUploadFileToServer: !!fileEnv.S3_SECRET_ACCESS_KEY,
 
+    // Expose Agent Gateway URL to client when queue-based agent runtime is enabled
+    ...(appEnv.enableQueueAgentRuntime && appEnv.AGENT_GATEWAY_URL
+      ? { agentGatewayUrl: appEnv.AGENT_GATEWAY_URL }
+      : undefined),
+
     image: cleanObject({
       defaultImageNum: imageEnv.AI_IMAGE_DEFAULT_IMAGE_NUM,
     }),

--- a/src/server/modules/AgentRuntime/factory.ts
+++ b/src/server/modules/AgentRuntime/factory.ts
@@ -72,7 +72,7 @@ export const createStreamEventManager = (): IStreamEventManager => {
   }
 
   // Wrap with Gateway notifier when configured
-  if (appEnv.AGENT_GATEWAY_SERVICE_TOKEN) {
+  if (appEnv.AGENT_GATEWAY_URL && appEnv.AGENT_GATEWAY_SERVICE_TOKEN) {
     log('Wrapping with GatewayStreamNotifier (%s)', appEnv.AGENT_GATEWAY_URL);
     return new GatewayStreamNotifier(
       manager,

--- a/src/services/aiAgent.ts
+++ b/src/services/aiAgent.ts
@@ -89,11 +89,21 @@ export interface UpdateClientTaskThreadStatusParams {
   threadId: string;
 }
 
+export interface ExecAgentResult {
+  agentId: string;
+  assistantMessageId: string;
+  autoStarted: boolean;
+  operationId: string;
+  topicId: string;
+  userMessageId: string;
+}
+
 class AiAgentService {
   /**
-   * Execute a single Agent task
+   * Execute a single Agent task.
+   * Returns the operationId needed to connect to the Agent Gateway.
    */
-  async execAgentTask(params: ExecAgentTaskParams) {
+  async execAgentTask(params: ExecAgentTaskParams): Promise<ExecAgentResult> {
     return await lambdaClient.aiAgent.execAgent.mutate(params);
   }
 

--- a/src/services/aiAgent.ts
+++ b/src/services/aiAgent.ts
@@ -1,4 +1,8 @@
+import type { ExecAgentResult } from '@lobechat/types';
+
 import { lambdaClient } from '@/libs/trpc/client';
+
+export type { ExecAgentResult };
 
 export interface ExecAgentTaskParams {
   agentId?: string;
@@ -87,15 +91,6 @@ export interface UpdateClientTaskThreadStatusParams {
   };
   resultContent?: string;
   threadId: string;
-}
-
-export interface ExecAgentResult {
-  agentId: string;
-  assistantMessageId: string;
-  autoStarted: boolean;
-  operationId: string;
-  topicId: string;
-  userMessageId: string;
 }
 
 class AiAgentService {

--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentStreamEvent } from '@/libs/agent-stream';
+
+import type { GatewayConnection } from '../gateway';
+import { GatewayActionImpl } from '../gateway';
+
+// ─── Mock Client Factory ───
+
+function createMockClient(): GatewayConnection['client'] & {
+  emitEvent: (event: string, ...args: any[]) => void;
+} {
+  const listeners = new Map<string, Set<(...args: any[]) => void>>();
+
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    emitEvent(event: string, ...args: any[]) {
+      listeners.get(event)?.forEach((listener) => listener(...args));
+    },
+    on: vi.fn((event: string, listener: (...args: any[]) => void) => {
+      let set = listeners.get(event);
+      if (!set) {
+        set = new Set();
+        listeners.set(event, set);
+      }
+      set.add(listener);
+    }),
+    sendInterrupt: vi.fn(),
+  };
+}
+
+// ─── Test Helpers ───
+
+function createTestAction() {
+  const state: Record<string, any> = { gatewayConnections: {} };
+  const set = vi.fn((updater: any) => {
+    if (typeof updater === 'function') {
+      Object.assign(state, updater(state));
+    } else {
+      Object.assign(state, updater);
+    }
+  });
+  const get = vi.fn(() => state as any);
+
+  const action = new GatewayActionImpl(set as any, get, undefined);
+
+  // Inject mock client factory
+  const mockClient = createMockClient();
+  action.createClient = vi.fn(() => mockClient);
+
+  return { action, get, mockClient, set, state };
+}
+
+describe('GatewayActionImpl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('connectToGateway', () => {
+    it('should create client and add to store', () => {
+      const { action, mockClient, state } = createTestAction();
+
+      action.connectToGateway({
+        gatewayUrl: 'https://gateway.test.com',
+        operationId: 'op-1',
+        token: 'test-token',
+      });
+
+      expect(state.gatewayConnections['op-1']).toBeDefined();
+      expect(state.gatewayConnections['op-1'].status).toBe('connecting');
+      expect(mockClient.connect).toHaveBeenCalledOnce();
+    });
+
+    it('should wire up status_changed listener', () => {
+      const { action, mockClient, state } = createTestAction();
+
+      action.connectToGateway({
+        gatewayUrl: 'https://gateway.test.com',
+        operationId: 'op-1',
+        token: 'test-token',
+      });
+
+      mockClient.emitEvent('status_changed', 'connected');
+      expect(state.gatewayConnections['op-1'].status).toBe('connected');
+    });
+
+    it('should forward agent events to onEvent callback', () => {
+      const { action, mockClient } = createTestAction();
+      const events: AgentStreamEvent[] = [];
+
+      action.connectToGateway({
+        gatewayUrl: 'https://gateway.test.com',
+        onEvent: (e) => events.push(e),
+        operationId: 'op-1',
+        token: 'test-token',
+      });
+
+      const testEvent: AgentStreamEvent = {
+        data: { content: 'hello' },
+        operationId: 'op-1',
+        stepIndex: 0,
+        timestamp: Date.now(),
+        type: 'stream_chunk',
+      };
+      mockClient.emitEvent('agent_event', testEvent);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual(testEvent);
+    });
+
+    it('should cleanup on session_complete', () => {
+      const { action, mockClient, state } = createTestAction();
+      const onComplete = vi.fn();
+
+      action.connectToGateway({
+        gatewayUrl: 'https://gateway.test.com',
+        onSessionComplete: onComplete,
+        operationId: 'op-1',
+        token: 'test-token',
+      });
+
+      mockClient.emitEvent('session_complete');
+      expect(state.gatewayConnections['op-1']).toBeUndefined();
+      expect(onComplete).toHaveBeenCalledOnce();
+    });
+
+    it('should cleanup on disconnected', () => {
+      const { action, mockClient, state } = createTestAction();
+
+      action.connectToGateway({
+        gatewayUrl: 'https://gateway.test.com',
+        operationId: 'op-1',
+        token: 'test-token',
+      });
+
+      mockClient.emitEvent('disconnected');
+      expect(state.gatewayConnections['op-1']).toBeUndefined();
+    });
+
+    it('should cleanup on auth_failed', () => {
+      const { action, mockClient, state } = createTestAction();
+
+      action.connectToGateway({
+        gatewayUrl: 'https://gateway.test.com',
+        operationId: 'op-1',
+        token: 'test-token',
+      });
+
+      mockClient.emitEvent('auth_failed', 'invalid token');
+      expect(state.gatewayConnections['op-1']).toBeUndefined();
+    });
+
+    it('should disconnect existing connection before creating new one', () => {
+      const { action, state } = createTestAction();
+
+      // First connection with its own mock
+      const firstMock = createMockClient();
+      action.createClient = vi.fn(() => firstMock);
+      action.connectToGateway({
+        gatewayUrl: 'https://gateway.test.com',
+        operationId: 'op-1',
+        token: 'token-1',
+      });
+
+      // Second connection
+      const secondMock = createMockClient();
+      action.createClient = vi.fn(() => secondMock);
+      action.connectToGateway({
+        gatewayUrl: 'https://gateway.test.com',
+        operationId: 'op-1',
+        token: 'token-2',
+      });
+
+      expect(firstMock.disconnect).toHaveBeenCalled();
+      expect(state.gatewayConnections['op-1'].client).toBe(secondMock);
+    });
+  });
+
+  describe('disconnectFromGateway', () => {
+    it('should disconnect and cleanup', () => {
+      const { action, mockClient, state } = createTestAction();
+
+      action.connectToGateway({
+        gatewayUrl: 'https://gateway.test.com',
+        operationId: 'op-1',
+        token: 'test-token',
+      });
+
+      action.disconnectFromGateway('op-1');
+      expect(mockClient.disconnect).toHaveBeenCalled();
+      expect(state.gatewayConnections['op-1']).toBeUndefined();
+    });
+
+    it('should be a no-op for unknown operationId', () => {
+      const { action } = createTestAction();
+      action.disconnectFromGateway('nonexistent');
+    });
+  });
+
+  describe('interruptGatewayAgent', () => {
+    it('should send interrupt to the client', () => {
+      const { action, mockClient } = createTestAction();
+
+      action.connectToGateway({
+        gatewayUrl: 'https://gateway.test.com',
+        operationId: 'op-1',
+        token: 'test-token',
+      });
+
+      action.interruptGatewayAgent('op-1');
+      expect(mockClient.sendInterrupt).toHaveBeenCalledOnce();
+    });
+
+    it('should be a no-op for unknown operationId', () => {
+      const { action } = createTestAction();
+      action.interruptGatewayAgent('nonexistent');
+    });
+  });
+
+  describe('getGatewayConnectionStatus', () => {
+    it('should return status for active connection', () => {
+      const { action } = createTestAction();
+
+      action.connectToGateway({
+        gatewayUrl: 'https://gateway.test.com',
+        operationId: 'op-1',
+        token: 'test-token',
+      });
+
+      expect(action.getGatewayConnectionStatus('op-1')).toBe('connecting');
+    });
+
+    it('should return undefined for unknown operationId', () => {
+      const { action } = createTestAction();
+      expect(action.getGatewayConnectionStatus('nonexistent')).toBeUndefined();
+    });
+  });
+});

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -15,7 +15,6 @@ function createMockStore() {
     associateMessageWithOperation: vi.fn(),
     completeOperation: vi.fn(),
     internal_dispatchMessage: vi.fn(),
-    internal_toggleMessageLoading: vi.fn(),
     internal_toggleToolCallingStreaming: vi.fn(),
     replaceMessages: vi.fn(),
   };
@@ -48,7 +47,7 @@ const flush = async () => {
 
 describe('createGatewayEventHandler', () => {
   describe('stream_start', () => {
-    it('should associate new message with operation and show loading', async () => {
+    it('should associate new message with operation', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
@@ -56,7 +55,6 @@ describe('createGatewayEventHandler', () => {
       await flush();
 
       expect(store.associateMessageWithOperation).toHaveBeenCalledWith('msg-step2', 'op-1');
-      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-step2');
       expect(store.replaceMessages).toHaveBeenCalled();
     });
 
@@ -67,7 +65,9 @@ describe('createGatewayEventHandler', () => {
       handler(makeEvent('stream_start', {}));
       await flush();
 
-      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-initial');
+      // No new message to associate, but fetch still happens
+      expect(store.associateMessageWithOperation).not.toHaveBeenCalled();
+      expect(store.replaceMessages).toHaveBeenCalled();
     });
 
     it('should reset accumulators on each stream_start', async () => {
@@ -170,15 +170,13 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('stream_end', () => {
-    it('should clear tool streaming but keep message loading active', async () => {
+    it('should clear tool streaming only', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('stream_end'));
       await flush();
 
-      // Loading stays active until agent_runtime_end
-      expect(store.internal_toggleMessageLoading).not.toHaveBeenCalled();
       expect(store.internal_toggleToolCallingStreaming).toHaveBeenCalledWith(
         'msg-initial',
         undefined,
@@ -200,7 +198,7 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('tool_end', () => {
-    it('should refresh messages and re-apply loading', async () => {
+    it('should refresh messages to pull tool results', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
@@ -208,8 +206,6 @@ describe('createGatewayEventHandler', () => {
       await flush();
 
       expect(store.replaceMessages).toHaveBeenCalled();
-      // Re-apply loading after refresh so UI stays active until next stream_start
-      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-initial');
     });
   });
 
@@ -236,14 +232,13 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('agent_runtime_end', () => {
-    it('should toggle loading off, complete operation, and refresh messages', async () => {
+    it('should complete operation and refresh messages', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('agent_runtime_end'));
       await flush();
 
-      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-initial');
       expect(store.completeOperation).toHaveBeenCalledWith('op-1');
       expect(store.replaceMessages).toHaveBeenCalled();
     });
@@ -267,7 +262,6 @@ describe('createGatewayEventHandler', () => {
         },
         { operationId: 'op-1' },
       );
-      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-initial');
     });
 
     it('should dispatch error to switched message ID', async () => {
@@ -300,8 +294,8 @@ describe('createGatewayEventHandler', () => {
       store.internal_dispatchMessage.mockImplementation(() => {
         callOrder.push('dispatch');
       });
-      store.internal_toggleMessageLoading.mockImplementation(() => {
-        callOrder.push('loading');
+      store.associateMessageWithOperation.mockImplementation(() => {
+        callOrder.push('associate');
       });
 
       const handler = createHandler(store);
@@ -325,7 +319,7 @@ describe('createGatewayEventHandler', () => {
       // Step 1: LLM call
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-1' } }));
       await flush();
-      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-1');
+      expect(store.associateMessageWithOperation).toHaveBeenCalledWith('msg-1', 'op-1');
 
       handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'Let me search.' }));
       await flush();
@@ -355,7 +349,7 @@ describe('createGatewayEventHandler', () => {
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-2' } }));
       await flush();
       expect(store.replaceMessages).toHaveBeenCalled();
-      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-2');
+      expect(store.associateMessageWithOperation).toHaveBeenCalledWith('msg-2', 'op-1');
 
       handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'Here are the results.' }));
       await flush();
@@ -367,7 +361,7 @@ describe('createGatewayEventHandler', () => {
       handler(makeEvent('stream_end'));
       handler(makeEvent('agent_runtime_end'));
       await flush();
-      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-2');
+      expect(store.completeOperation).toHaveBeenCalledWith('op-1');
     });
   });
 });

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -47,15 +47,17 @@ const flush = async () => {
 
 describe('createGatewayEventHandler', () => {
   describe('stream_start', () => {
-    it('should switch assistantMessageId from event data', async () => {
+    it('should show loading on old message immediately, then switch to new after fetch', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-step2' } }));
       await flush();
 
-      expect(store.replaceMessages).toHaveBeenCalled();
+      // Should have been called twice: first on old msg (optimistic), then on new msg (after fetch)
+      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-initial');
       expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-step2');
+      expect(store.replaceMessages).toHaveBeenCalled();
     });
 
     it('should keep current ID if event data has no assistantMessage', async () => {

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AgentStreamEvent } from '@/libs/agent-stream';
+
+import { createGatewayEventHandler } from '../gatewayEventHandler';
+
+// ─── Test Helpers ───
+
+function createMockStore() {
+  return {
+    internal_dispatchMessage: vi.fn(),
+    internal_toggleMessageLoading: vi.fn(),
+    internal_toggleToolCallingStreaming: vi.fn(),
+    refreshMessages: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createHandler(
+  store: ReturnType<typeof createMockStore>,
+  overrides?: { assistantMessageId?: string },
+) {
+  const get = vi.fn(() => store) as any;
+  return createGatewayEventHandler(get, {
+    assistantMessageId: overrides?.assistantMessageId ?? 'msg-initial',
+    context: { agentId: 'agent-1', scope: 'session', topicId: 'topic-1' } as any,
+    operationId: 'op-1',
+  });
+}
+
+function makeEvent(type: AgentStreamEvent['type'], data?: any): AgentStreamEvent {
+  return { data, id: '1', operationId: 'op-1', stepIndex: 0, timestamp: Date.now(), type };
+}
+
+// ─── Tests ───
+
+describe('createGatewayEventHandler', () => {
+  describe('stream_start', () => {
+    it('should switch assistantMessageId from event data', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-step2' } }));
+
+      // Loading should target the new message ID
+      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-step2');
+      expect(store.refreshMessages).toHaveBeenCalled();
+    });
+
+    it('should keep current ID if event data has no assistantMessage', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_start', {}));
+
+      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-initial');
+    });
+
+    it('should reset accumulators on each stream_start', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      // Accumulate some content
+      handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'hello' }));
+      expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ value: { content: 'hello' } }),
+      );
+
+      // New stream_start resets
+      handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-step2' } }));
+      handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'world' }));
+
+      // Content should be 'world', not 'helloworld'
+      expect(store.internal_dispatchMessage).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          id: 'msg-step2',
+          value: { content: 'world' },
+        }),
+      );
+    });
+  });
+
+  describe('stream_chunk', () => {
+    it('should accumulate text content', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'Hello' }));
+      handler(makeEvent('stream_chunk', { chunkType: 'text', content: ' world' }));
+
+      expect(store.internal_dispatchMessage).toHaveBeenLastCalledWith({
+        id: 'msg-initial',
+        type: 'updateMessage',
+        value: { content: 'Hello world' },
+      });
+    });
+
+    it('should accumulate reasoning content', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: 'Think' }));
+      handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: 'ing...' }));
+
+      expect(store.internal_dispatchMessage).toHaveBeenLastCalledWith({
+        id: 'msg-initial',
+        type: 'updateMessage',
+        value: { reasoning: { content: 'Thinking...' } },
+      });
+    });
+
+    it('should dispatch tools and toggle tool calling streaming', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      const toolsCalling = [{ id: 'tc-1' }, { id: 'tc-2' }];
+      handler(makeEvent('stream_chunk', { chunkType: 'tools_calling', toolsCalling }));
+
+      expect(store.internal_dispatchMessage).toHaveBeenCalledWith({
+        id: 'msg-initial',
+        type: 'updateMessage',
+        value: { tools: toolsCalling },
+      });
+
+      expect(store.internal_toggleToolCallingStreaming).toHaveBeenCalledWith('msg-initial', [
+        true,
+        true,
+      ]);
+    });
+
+    it('should ignore chunk with no data', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_chunk', undefined));
+
+      expect(store.internal_dispatchMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('stream_end', () => {
+    it('should toggle loading off and clear tool streaming', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_end'));
+
+      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-initial');
+      expect(store.internal_toggleToolCallingStreaming).toHaveBeenCalledWith(
+        'msg-initial',
+        undefined,
+      );
+    });
+  });
+
+  describe('tool_start', () => {
+    it('should be a no-op', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('tool_start', { parentMessageId: 'msg-initial', toolCalling: {} }));
+
+      expect(store.internal_dispatchMessage).not.toHaveBeenCalled();
+      expect(store.refreshMessages).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tool_end', () => {
+    it('should refresh messages to pull tool results', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('tool_end', { isSuccess: true }));
+
+      expect(store.refreshMessages).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: 'agent-1', topicId: 'topic-1' }),
+      );
+    });
+  });
+
+  describe('step_complete', () => {
+    it('should refresh on execution_complete phase', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('step_complete', { phase: 'execution_complete', reason: 'done' }));
+
+      expect(store.refreshMessages).toHaveBeenCalled();
+    });
+
+    it('should not refresh on other phases', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('step_complete', { phase: 'human_approval' }));
+
+      expect(store.refreshMessages).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('agent_runtime_end', () => {
+    it('should toggle loading off and refresh messages', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('agent_runtime_end'));
+
+      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-initial');
+      expect(store.refreshMessages).toHaveBeenCalled();
+    });
+  });
+
+  describe('error', () => {
+    it('should dispatch error to current message', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('error', { message: 'Something went wrong' }));
+
+      expect(store.internal_dispatchMessage).toHaveBeenCalledWith({
+        id: 'msg-initial',
+        type: 'updateMessage',
+        value: {
+          error: { body: { message: 'Something went wrong' }, type: 'AgentRuntimeError' },
+        },
+      });
+      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-initial');
+    });
+
+    it('should dispatch error to switched message ID', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      // Switch to step 2
+      handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-step2' } }));
+
+      handler(makeEvent('error', { error: 'Timeout' }));
+
+      expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'msg-step2' }),
+      );
+    });
+  });
+
+  describe('multi-step integration', () => {
+    it('should handle full LLM → tools → LLM cycle', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      // Step 1: LLM call
+      handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-1' } }));
+      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-1');
+
+      handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'Let me search.' }));
+      expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'msg-1', value: { content: 'Let me search.' } }),
+      );
+
+      const tools = [{ id: 'tc-1' }];
+      handler(makeEvent('stream_chunk', { chunkType: 'tools_calling', toolsCalling: tools }));
+      expect(store.internal_toggleToolCallingStreaming).toHaveBeenCalledWith('msg-1', [true]);
+
+      handler(makeEvent('stream_end'));
+      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-1');
+      expect(store.internal_toggleToolCallingStreaming).toHaveBeenCalledWith('msg-1', undefined);
+
+      // Tool execution
+      handler(makeEvent('tool_start', { parentMessageId: 'msg-1', toolCalling: tools[0] }));
+      handler(makeEvent('tool_end', { isSuccess: true }));
+      expect(store.refreshMessages).toHaveBeenCalled();
+
+      // Step 2: Next LLM call with new assistant message
+      vi.clearAllMocks();
+      handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-2' } }));
+      expect(store.refreshMessages).toHaveBeenCalled();
+      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-2');
+
+      handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'Here are the results.' }));
+      expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'msg-2', value: { content: 'Here are the results.' } }),
+      );
+
+      handler(makeEvent('stream_end'));
+      handler(makeEvent('agent_runtime_end'));
+      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-2');
+    });
+  });
+});

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -185,7 +185,7 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('tool_start', () => {
-    it('should be a no-op', async () => {
+    it('should be a no-op (loading already active from stream_start)', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
@@ -198,7 +198,7 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('tool_end', () => {
-    it('should refresh messages to pull tool results', async () => {
+    it('should refresh messages and re-apply loading', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
@@ -206,6 +206,8 @@ describe('createGatewayEventHandler', () => {
       await flush();
 
       expect(store.replaceMessages).toHaveBeenCalled();
+      // Re-apply loading after refresh so UI stays active until next stream_start
+      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-initial');
     });
   });
 

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -33,7 +33,6 @@ function makeEvent(type: AgentStreamEvent['type'], data?: any): AgentStreamEvent
 
 /** Flush the async processing queue by draining microtasks + setTimeout queue */
 const flush = async () => {
-  // Multiple rounds to drain chained promises and setTimeout-based delays
   for (let i = 0; i < 5; i++) {
     await new Promise((r) => setTimeout(r, 15));
   }
@@ -73,6 +72,7 @@ describe('createGatewayEventHandler', () => {
       await flush();
       expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
         expect.objectContaining({ value: { content: 'hello' } }),
+        { operationId: 'op-1' },
       );
 
       // New stream_start resets
@@ -86,12 +86,13 @@ describe('createGatewayEventHandler', () => {
           id: 'msg-step2',
           value: { content: 'world' },
         }),
+        { operationId: 'op-1' },
       );
     });
   });
 
   describe('stream_chunk', () => {
-    it('should accumulate text content', async () => {
+    it('should accumulate text content and pass operationId context', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
@@ -99,11 +100,14 @@ describe('createGatewayEventHandler', () => {
       handler(makeEvent('stream_chunk', { chunkType: 'text', content: ' world' }));
       await flush();
 
-      expect(store.internal_dispatchMessage).toHaveBeenLastCalledWith({
-        id: 'msg-initial',
-        type: 'updateMessage',
-        value: { content: 'Hello world' },
-      });
+      expect(store.internal_dispatchMessage).toHaveBeenLastCalledWith(
+        {
+          id: 'msg-initial',
+          type: 'updateMessage',
+          value: { content: 'Hello world' },
+        },
+        { operationId: 'op-1' },
+      );
     });
 
     it('should accumulate reasoning content', async () => {
@@ -114,11 +118,14 @@ describe('createGatewayEventHandler', () => {
       handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: 'ing...' }));
       await flush();
 
-      expect(store.internal_dispatchMessage).toHaveBeenLastCalledWith({
-        id: 'msg-initial',
-        type: 'updateMessage',
-        value: { reasoning: { content: 'Thinking...' } },
-      });
+      expect(store.internal_dispatchMessage).toHaveBeenLastCalledWith(
+        {
+          id: 'msg-initial',
+          type: 'updateMessage',
+          value: { reasoning: { content: 'Thinking...' } },
+        },
+        { operationId: 'op-1' },
+      );
     });
 
     it('should dispatch tools and toggle tool calling streaming', async () => {
@@ -129,11 +136,14 @@ describe('createGatewayEventHandler', () => {
       handler(makeEvent('stream_chunk', { chunkType: 'tools_calling', toolsCalling }));
       await flush();
 
-      expect(store.internal_dispatchMessage).toHaveBeenCalledWith({
-        id: 'msg-initial',
-        type: 'updateMessage',
-        value: { tools: toolsCalling },
-      });
+      expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
+        {
+          id: 'msg-initial',
+          type: 'updateMessage',
+          value: { tools: toolsCalling },
+        },
+        { operationId: 'op-1' },
+      );
 
       expect(store.internal_toggleToolCallingStreaming).toHaveBeenCalledWith('msg-initial', [
         true,
@@ -231,20 +241,23 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('error', () => {
-    it('should dispatch error to current message', async () => {
+    it('should dispatch error to current message with operationId context', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('error', { message: 'Something went wrong' }));
       await flush();
 
-      expect(store.internal_dispatchMessage).toHaveBeenCalledWith({
-        id: 'msg-initial',
-        type: 'updateMessage',
-        value: {
-          error: { body: { message: 'Something went wrong' }, type: 'AgentRuntimeError' },
+      expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
+        {
+          id: 'msg-initial',
+          type: 'updateMessage',
+          value: {
+            error: { body: { message: 'Something went wrong' }, type: 'AgentRuntimeError' },
+          },
         },
-      });
+        { operationId: 'op-1' },
+      );
       expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-initial');
     });
 
@@ -252,13 +265,13 @@ describe('createGatewayEventHandler', () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
-      // Switch to step 2
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-step2' } }));
       handler(makeEvent('error', { error: 'Timeout' }));
       await flush();
 
       expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'msg-step2' }),
+        { operationId: 'op-1' },
       );
     });
   });
@@ -268,7 +281,6 @@ describe('createGatewayEventHandler', () => {
       const store = createMockStore();
       const callOrder: string[] = [];
 
-      // Make refreshMessages take some time and track call order
       store.refreshMessages.mockImplementation(async () => {
         callOrder.push('refresh_start');
         await new Promise((r) => setTimeout(r, 10));
@@ -283,12 +295,10 @@ describe('createGatewayEventHandler', () => {
 
       const handler = createHandler(store);
 
-      // Fire stream_start and chunk rapidly
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-new' } }));
       handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'Hello' }));
       await flush();
 
-      // Dispatch must happen AFTER refresh completes
       const refreshEndIdx = callOrder.indexOf('refresh_end');
       const dispatchIdx = callOrder.indexOf('dispatch');
       expect(refreshEndIdx).toBeGreaterThan(-1);
@@ -310,6 +320,7 @@ describe('createGatewayEventHandler', () => {
       await flush();
       expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'msg-1', value: { content: 'Let me search.' } }),
+        { operationId: 'op-1' },
       );
 
       const tools = [{ id: 'tc-1' }];
@@ -339,6 +350,7 @@ describe('createGatewayEventHandler', () => {
       await flush();
       expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'msg-2', value: { content: 'Here are the results.' } }),
+        { operationId: 'op-1' },
       );
 
       handler(makeEvent('stream_end'));

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -31,36 +31,46 @@ function makeEvent(type: AgentStreamEvent['type'], data?: any): AgentStreamEvent
   return { data, id: '1', operationId: 'op-1', stepIndex: 0, timestamp: Date.now(), type };
 }
 
+/** Flush the async processing queue by draining microtasks + setTimeout queue */
+const flush = async () => {
+  // Multiple rounds to drain chained promises and setTimeout-based delays
+  for (let i = 0; i < 5; i++) {
+    await new Promise((r) => setTimeout(r, 15));
+  }
+};
+
 // ─── Tests ───
 
 describe('createGatewayEventHandler', () => {
   describe('stream_start', () => {
-    it('should switch assistantMessageId from event data', () => {
+    it('should switch assistantMessageId from event data', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-step2' } }));
+      await flush();
 
-      // Loading should target the new message ID
-      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-step2');
       expect(store.refreshMessages).toHaveBeenCalled();
+      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-step2');
     });
 
-    it('should keep current ID if event data has no assistantMessage', () => {
+    it('should keep current ID if event data has no assistantMessage', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('stream_start', {}));
+      await flush();
 
       expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-initial');
     });
 
-    it('should reset accumulators on each stream_start', () => {
+    it('should reset accumulators on each stream_start', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       // Accumulate some content
       handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'hello' }));
+      await flush();
       expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
         expect.objectContaining({ value: { content: 'hello' } }),
       );
@@ -68,6 +78,7 @@ describe('createGatewayEventHandler', () => {
       // New stream_start resets
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-step2' } }));
       handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'world' }));
+      await flush();
 
       // Content should be 'world', not 'helloworld'
       expect(store.internal_dispatchMessage).toHaveBeenLastCalledWith(
@@ -80,12 +91,13 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('stream_chunk', () => {
-    it('should accumulate text content', () => {
+    it('should accumulate text content', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'Hello' }));
       handler(makeEvent('stream_chunk', { chunkType: 'text', content: ' world' }));
+      await flush();
 
       expect(store.internal_dispatchMessage).toHaveBeenLastCalledWith({
         id: 'msg-initial',
@@ -94,12 +106,13 @@ describe('createGatewayEventHandler', () => {
       });
     });
 
-    it('should accumulate reasoning content', () => {
+    it('should accumulate reasoning content', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: 'Think' }));
       handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: 'ing...' }));
+      await flush();
 
       expect(store.internal_dispatchMessage).toHaveBeenLastCalledWith({
         id: 'msg-initial',
@@ -108,12 +121,13 @@ describe('createGatewayEventHandler', () => {
       });
     });
 
-    it('should dispatch tools and toggle tool calling streaming', () => {
+    it('should dispatch tools and toggle tool calling streaming', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       const toolsCalling = [{ id: 'tc-1' }, { id: 'tc-2' }];
       handler(makeEvent('stream_chunk', { chunkType: 'tools_calling', toolsCalling }));
+      await flush();
 
       expect(store.internal_dispatchMessage).toHaveBeenCalledWith({
         id: 'msg-initial',
@@ -127,22 +141,24 @@ describe('createGatewayEventHandler', () => {
       ]);
     });
 
-    it('should ignore chunk with no data', () => {
+    it('should ignore chunk with no data', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('stream_chunk', undefined));
+      await flush();
 
       expect(store.internal_dispatchMessage).not.toHaveBeenCalled();
     });
   });
 
   describe('stream_end', () => {
-    it('should toggle loading off and clear tool streaming', () => {
+    it('should toggle loading off and clear tool streaming', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('stream_end'));
+      await flush();
 
       expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-initial');
       expect(store.internal_toggleToolCallingStreaming).toHaveBeenCalledWith(
@@ -153,11 +169,12 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('tool_start', () => {
-    it('should be a no-op', () => {
+    it('should be a no-op', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('tool_start', { parentMessageId: 'msg-initial', toolCalling: {} }));
+      await flush();
 
       expect(store.internal_dispatchMessage).not.toHaveBeenCalled();
       expect(store.refreshMessages).not.toHaveBeenCalled();
@@ -165,11 +182,12 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('tool_end', () => {
-    it('should refresh messages to pull tool results', () => {
+    it('should refresh messages to pull tool results', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('tool_end', { isSuccess: true }));
+      await flush();
 
       expect(store.refreshMessages).toHaveBeenCalledWith(
         expect.objectContaining({ agentId: 'agent-1', topicId: 'topic-1' }),
@@ -178,31 +196,34 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('step_complete', () => {
-    it('should refresh on execution_complete phase', () => {
+    it('should refresh on execution_complete phase', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('step_complete', { phase: 'execution_complete', reason: 'done' }));
+      await flush();
 
       expect(store.refreshMessages).toHaveBeenCalled();
     });
 
-    it('should not refresh on other phases', () => {
+    it('should not refresh on other phases', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('step_complete', { phase: 'human_approval' }));
+      await flush();
 
       expect(store.refreshMessages).not.toHaveBeenCalled();
     });
   });
 
   describe('agent_runtime_end', () => {
-    it('should toggle loading off and refresh messages', () => {
+    it('should toggle loading off and refresh messages', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('agent_runtime_end'));
+      await flush();
 
       expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-initial');
       expect(store.refreshMessages).toHaveBeenCalled();
@@ -210,11 +231,12 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('error', () => {
-    it('should dispatch error to current message', () => {
+    it('should dispatch error to current message', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('error', { message: 'Something went wrong' }));
+      await flush();
 
       expect(store.internal_dispatchMessage).toHaveBeenCalledWith({
         id: 'msg-initial',
@@ -226,14 +248,14 @@ describe('createGatewayEventHandler', () => {
       expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-initial');
     });
 
-    it('should dispatch error to switched message ID', () => {
+    it('should dispatch error to switched message ID', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       // Switch to step 2
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-step2' } }));
-
       handler(makeEvent('error', { error: 'Timeout' }));
+      await flush();
 
       expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'msg-step2' }),
@@ -241,46 +263,87 @@ describe('createGatewayEventHandler', () => {
     });
   });
 
+  describe('sequential processing', () => {
+    it('should process stream_chunk only after stream_start refresh completes', async () => {
+      const store = createMockStore();
+      const callOrder: string[] = [];
+
+      // Make refreshMessages take some time and track call order
+      store.refreshMessages.mockImplementation(async () => {
+        callOrder.push('refresh_start');
+        await new Promise((r) => setTimeout(r, 10));
+        callOrder.push('refresh_end');
+      });
+      store.internal_dispatchMessage.mockImplementation(() => {
+        callOrder.push('dispatch');
+      });
+      store.internal_toggleMessageLoading.mockImplementation(() => {
+        callOrder.push('loading');
+      });
+
+      const handler = createHandler(store);
+
+      // Fire stream_start and chunk rapidly
+      handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-new' } }));
+      handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'Hello' }));
+      await flush();
+
+      // Dispatch must happen AFTER refresh completes
+      const refreshEndIdx = callOrder.indexOf('refresh_end');
+      const dispatchIdx = callOrder.indexOf('dispatch');
+      expect(refreshEndIdx).toBeGreaterThan(-1);
+      expect(dispatchIdx).toBeGreaterThan(refreshEndIdx);
+    });
+  });
+
   describe('multi-step integration', () => {
-    it('should handle full LLM → tools → LLM cycle', () => {
+    it('should handle full LLM → tools → LLM cycle', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       // Step 1: LLM call
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-1' } }));
+      await flush();
       expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-1');
 
       handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'Let me search.' }));
+      await flush();
       expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'msg-1', value: { content: 'Let me search.' } }),
       );
 
       const tools = [{ id: 'tc-1' }];
       handler(makeEvent('stream_chunk', { chunkType: 'tools_calling', toolsCalling: tools }));
+      await flush();
       expect(store.internal_toggleToolCallingStreaming).toHaveBeenCalledWith('msg-1', [true]);
 
       handler(makeEvent('stream_end'));
+      await flush();
       expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-1');
       expect(store.internal_toggleToolCallingStreaming).toHaveBeenCalledWith('msg-1', undefined);
 
       // Tool execution
       handler(makeEvent('tool_start', { parentMessageId: 'msg-1', toolCalling: tools[0] }));
       handler(makeEvent('tool_end', { isSuccess: true }));
+      await flush();
       expect(store.refreshMessages).toHaveBeenCalled();
 
       // Step 2: Next LLM call with new assistant message
       vi.clearAllMocks();
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-2' } }));
+      await flush();
       expect(store.refreshMessages).toHaveBeenCalled();
       expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-2');
 
       handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'Here are the results.' }));
+      await flush();
       expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'msg-2', value: { content: 'Here are the results.' } }),
       );
 
       handler(makeEvent('stream_end'));
       handler(makeEvent('agent_runtime_end'));
+      await flush();
       expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-2');
     });
   });

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -4,14 +4,19 @@ import type { AgentStreamEvent } from '@/libs/agent-stream';
 
 import { createGatewayEventHandler } from '../gatewayEventHandler';
 
+vi.mock('@/services/message', () => ({
+  messageService: { getMessages: vi.fn().mockResolvedValue([]) },
+}));
+
 // ─── Test Helpers ───
 
 function createMockStore() {
   return {
+    completeOperation: vi.fn(),
     internal_dispatchMessage: vi.fn(),
     internal_toggleMessageLoading: vi.fn(),
     internal_toggleToolCallingStreaming: vi.fn(),
-    refreshMessages: vi.fn().mockResolvedValue(undefined),
+    replaceMessages: vi.fn(),
   };
 }
 
@@ -49,7 +54,7 @@ describe('createGatewayEventHandler', () => {
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-step2' } }));
       await flush();
 
-      expect(store.refreshMessages).toHaveBeenCalled();
+      expect(store.replaceMessages).toHaveBeenCalled();
       expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-step2');
     });
 
@@ -163,14 +168,15 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('stream_end', () => {
-    it('should toggle loading off and clear tool streaming', async () => {
+    it('should clear tool streaming but keep message loading active', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('stream_end'));
       await flush();
 
-      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-initial');
+      // Loading stays active until agent_runtime_end
+      expect(store.internal_toggleMessageLoading).not.toHaveBeenCalled();
       expect(store.internal_toggleToolCallingStreaming).toHaveBeenCalledWith(
         'msg-initial',
         undefined,
@@ -187,7 +193,7 @@ describe('createGatewayEventHandler', () => {
       await flush();
 
       expect(store.internal_dispatchMessage).not.toHaveBeenCalled();
-      expect(store.refreshMessages).not.toHaveBeenCalled();
+      expect(store.replaceMessages).not.toHaveBeenCalled();
     });
   });
 
@@ -199,9 +205,7 @@ describe('createGatewayEventHandler', () => {
       handler(makeEvent('tool_end', { isSuccess: true }));
       await flush();
 
-      expect(store.refreshMessages).toHaveBeenCalledWith(
-        expect.objectContaining({ agentId: 'agent-1', topicId: 'topic-1' }),
-      );
+      expect(store.replaceMessages).toHaveBeenCalled();
     });
   });
 
@@ -213,7 +217,7 @@ describe('createGatewayEventHandler', () => {
       handler(makeEvent('step_complete', { phase: 'execution_complete', reason: 'done' }));
       await flush();
 
-      expect(store.refreshMessages).toHaveBeenCalled();
+      expect(store.replaceMessages).toHaveBeenCalled();
     });
 
     it('should not refresh on other phases', async () => {
@@ -223,12 +227,12 @@ describe('createGatewayEventHandler', () => {
       handler(makeEvent('step_complete', { phase: 'human_approval' }));
       await flush();
 
-      expect(store.refreshMessages).not.toHaveBeenCalled();
+      expect(store.replaceMessages).not.toHaveBeenCalled();
     });
   });
 
   describe('agent_runtime_end', () => {
-    it('should toggle loading off and refresh messages', async () => {
+    it('should toggle loading off, complete operation, and refresh messages', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
@@ -236,7 +240,8 @@ describe('createGatewayEventHandler', () => {
       await flush();
 
       expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-initial');
-      expect(store.refreshMessages).toHaveBeenCalled();
+      expect(store.completeOperation).toHaveBeenCalledWith('op-1');
+      expect(store.replaceMessages).toHaveBeenCalled();
     });
   });
 
@@ -281,10 +286,12 @@ describe('createGatewayEventHandler', () => {
       const store = createMockStore();
       const callOrder: string[] = [];
 
-      store.refreshMessages.mockImplementation(async () => {
+      const { messageService } = await import('@/services/message');
+      (messageService.getMessages as any).mockImplementation(async () => {
         callOrder.push('refresh_start');
         await new Promise((r) => setTimeout(r, 10));
         callOrder.push('refresh_end');
+        return [];
       });
       store.internal_dispatchMessage.mockImplementation(() => {
         callOrder.push('dispatch');
@@ -330,20 +337,20 @@ describe('createGatewayEventHandler', () => {
 
       handler(makeEvent('stream_end'));
       await flush();
-      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(false, 'msg-1');
+      // Loading stays active between steps — only tool streaming is cleared
       expect(store.internal_toggleToolCallingStreaming).toHaveBeenCalledWith('msg-1', undefined);
 
       // Tool execution
       handler(makeEvent('tool_start', { parentMessageId: 'msg-1', toolCalling: tools[0] }));
       handler(makeEvent('tool_end', { isSuccess: true }));
       await flush();
-      expect(store.refreshMessages).toHaveBeenCalled();
+      expect(store.replaceMessages).toHaveBeenCalled();
 
       // Step 2: Next LLM call with new assistant message
       vi.clearAllMocks();
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-2' } }));
       await flush();
-      expect(store.refreshMessages).toHaveBeenCalled();
+      expect(store.replaceMessages).toHaveBeenCalled();
       expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-2');
 
       handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'Here are the results.' }));

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -12,6 +12,7 @@ vi.mock('@/services/message', () => ({
 
 function createMockStore() {
   return {
+    associateMessageWithOperation: vi.fn(),
     completeOperation: vi.fn(),
     internal_dispatchMessage: vi.fn(),
     internal_toggleMessageLoading: vi.fn(),
@@ -47,15 +48,14 @@ const flush = async () => {
 
 describe('createGatewayEventHandler', () => {
   describe('stream_start', () => {
-    it('should show loading on old message immediately, then switch to new after fetch', async () => {
+    it('should associate new message with operation and show loading', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-step2' } }));
       await flush();
 
-      // Should have been called twice: first on old msg (optimistic), then on new msg (after fetch)
-      expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-initial');
+      expect(store.associateMessageWithOperation).toHaveBeenCalledWith('msg-step2', 'op-1');
       expect(store.internal_toggleMessageLoading).toHaveBeenCalledWith(true, 'msg-step2');
       expect(store.replaceMessages).toHaveBeenCalled();
     });

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -606,16 +606,24 @@ export class ConversationLifecycleActionImpl {
             prompt: message,
           });
 
+          // Create a dedicated operation for gateway execution with correct context
+          const { operationId: gatewayOpId } = this.#get().startOperation({
+            context: execContext,
+            parentOperationId: operationId,
+            type: 'execServerAgentRuntime',
+          });
+
           const eventHandler = createGatewayEventHandler(this.#get, {
             assistantMessageId: data.assistantMessageId,
             context: execContext,
-            operationId: result.operationId,
+            operationId: gatewayOpId,
           });
 
           this.#get().connectToGateway({
             gatewayUrl: agentGatewayUrl,
             onEvent: eventHandler,
             onSessionComplete: () => {
+              this.#get().completeOperation(gatewayOpId);
               if (data.topicId) this.#get().internal_updateTopicLoading(data.topicId, false);
             },
             operationId: result.operationId,

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -17,7 +17,6 @@ import { TRPCClientError } from '@trpc/client';
 import { t } from 'i18next';
 
 import { markUserValidAction } from '@/business/client/markUserValidAction';
-import { aiAgentService } from '@/services/aiAgent';
 import { aiChatService } from '@/services/aiChat';
 import { chatService } from '@/services/chat';
 import { resolveSelectedSkillsWithContent } from '@/services/chat/mecha/skillPreload';
@@ -36,7 +35,6 @@ import { getFileStoreState } from '@/store/file/store';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { type StoreSetter } from '@/store/types';
-import { useUserStore } from '@/store/user';
 import { useUserMemoryStore } from '@/store/userMemory';
 
 import { dbMessageSelectors, displayMessageSelectors, topicSelectors } from '../../../selectors';
@@ -50,8 +48,6 @@ import {
   parseSelectedToolsFromEditorData,
   processCommands,
 } from './commandBus';
-import { createGatewayEventHandler } from './gatewayEventHandler';
-
 /**
  * Extended params for sendMessage with context
  */
@@ -587,111 +583,77 @@ export class ConversationLifecycleActionImpl {
     }
 
     // ── AI execution ──
+
+    // Gateway mode: server-side execution via WebSocket (opt-in via Labs toggle)
+    // If gateway started, skip client-side agent loop entirely
+    if (
+      this.#get().startGatewayExecution({
+        assistantMessageId: data.assistantMessageId,
+        context: execContext,
+        message,
+        parentOperationId: operationId,
+        topicId: data.topicId,
+        userMessageId: data.userMessageId,
+      })
+    ) {
+      return {
+        assistantMessageId: data.assistantMessageId,
+        createdThreadId: data.createdThreadId,
+        userMessageId: data.userMessageId,
+      };
+    }
+
+    // Client mode: run agent loop locally
     {
-      // Check if server-side Gateway mode is available AND user has enabled it in Labs
-      const agentGatewayUrl =
-        window.global_serverConfigStore?.getState()?.serverConfig?.agentGatewayUrl;
-      const enableGatewayMode = useUserStore.getState().preference.lab?.enableGatewayMode;
+      const displayMessages = displayMessageSelectors.getDisplayMessagesByKey(
+        messageMapKey(execContext),
+      )(this.#get());
 
-      if (agentGatewayUrl && enableGatewayMode) {
-        // ── Gateway mode: trigger server-side execution, receive events via WebSocket ──
-        try {
-          const result = await aiAgentService.execAgentTask({
-            agentId: execContext.agentId,
-            appContext: {
-              groupId: execContext.groupId,
-              scope: execContext.scope,
-              threadId: execContext.threadId,
-              topicId: execContext.topicId,
-            },
-            existingMessageIds: [data.userMessageId, data.assistantMessageId],
-            prompt: message,
-          });
+      try {
+        // When agents are @mentioned, inject a slim callAgent-only manifest
+        // so the AI can delegate directly without activating the full agent-management tool
+        const injectedManifests = hasMentionedAgents ? [createCallAgentManifest()] : undefined;
 
-          // Create a dedicated operation for gateway execution with correct context
-          const { operationId: gatewayOpId } = this.#get().startOperation({
-            context: execContext,
-            parentOperationId: operationId,
-            type: 'execServerAgentRuntime',
-          });
+        const hasInitialContext = hasMentionedAgents || !!injectedManifests;
 
-          // Associate the initial assistant message with the gateway operation
-          // so the UI shows loading/generating state via the operation system
-          this.#get().associateMessageWithOperation(data.assistantMessageId, gatewayOpId);
+        // Note: selectedSkills and selectedTools are NOT passed here — they are
+        // persisted into the user message content above so they survive across
+        // turns without re-injection.
+        const agentRuntimeInitialContext = hasInitialContext
+          ? {
+              initialContext: {
+                // Only inject mentionedAgents in non-group context to avoid
+                // group @member mentions (including ALL_MEMBERS) leaking into agent-management
+                ...(hasMentionedAgents ? { mentionedAgents } : undefined),
+                ...(injectedManifests ? { injectedManifests } : undefined),
+              },
+              phase: 'init' as const,
+            }
+          : undefined;
 
-          const eventHandler = createGatewayEventHandler(this.#get, {
-            assistantMessageId: data.assistantMessageId,
-            context: execContext,
-            operationId: gatewayOpId,
-          });
+        await internal_execAgentRuntime({
+          context: execContext,
+          initialContext: agentRuntimeInitialContext,
+          messages: displayMessages,
+          parentMessageId: data.assistantMessageId,
+          parentMessageType: 'assistant',
+          parentOperationId: operationId,
+          inPortalThread: !!data.createdThreadId,
+          skipCreateFirstMessage: true,
+        });
 
-          this.#get().connectToGateway({
-            gatewayUrl: agentGatewayUrl,
-            onEvent: eventHandler,
-            onSessionComplete: () => {
-              this.#get().completeOperation(gatewayOpId);
-              if (data.topicId) this.#get().internal_updateTopicLoading(data.topicId, false);
-            },
-            operationId: result.operationId,
-            token: result.token || '',
-          });
-        } catch (e) {
-          console.error('[Gateway] Failed to start server-side agent:', e);
-          // Fall through to topic loading cleanup
-          if (data.topicId) this.#get().internal_updateTopicLoading(data.topicId, false);
+        const userFiles = dbMessageSelectors
+          .dbUserFiles(this.#get())
+          .map((f) => f?.id)
+          .filter(Boolean) as string[];
+
+        if (userFiles.length > 0) {
+          await getAgentStoreState().addFilesToAgent(userFiles, false);
         }
-      } else {
-        // ── Client mode: run agent loop locally ──
-        const displayMessages = displayMessageSelectors.getDisplayMessagesByKey(
-          messageMapKey(execContext),
-        )(this.#get());
-
-        try {
-          // When agents are @mentioned, inject a slim callAgent-only manifest
-          // so the AI can delegate directly without activating the full agent-management tool
-          const injectedManifests = hasMentionedAgents ? [createCallAgentManifest()] : undefined;
-
-          const hasInitialContext = hasMentionedAgents || !!injectedManifests;
-
-          // Note: selectedSkills and selectedTools are NOT passed here — they are
-          // persisted into the user message content above so they survive across
-          // turns without re-injection.
-          const agentRuntimeInitialContext = hasInitialContext
-            ? {
-                initialContext: {
-                  // Only inject mentionedAgents in non-group context to avoid
-                  // group @member mentions (including ALL_MEMBERS) leaking into agent-management
-                  ...(hasMentionedAgents ? { mentionedAgents } : undefined),
-                  ...(injectedManifests ? { injectedManifests } : undefined),
-                },
-                phase: 'init' as const,
-              }
-            : undefined;
-
-          await internal_execAgentRuntime({
-            context: execContext,
-            initialContext: agentRuntimeInitialContext,
-            messages: displayMessages,
-            parentMessageId: data.assistantMessageId,
-            parentMessageType: 'assistant',
-            parentOperationId: operationId,
-            inPortalThread: !!data.createdThreadId,
-            skipCreateFirstMessage: true,
-          });
-
-          const userFiles = dbMessageSelectors
-            .dbUserFiles(this.#get())
-            .map((f) => f?.id)
-            .filter(Boolean) as string[];
-
-          if (userFiles.length > 0) {
-            await getAgentStoreState().addFilesToAgent(userFiles, false);
-          }
-        } catch (e) {
-          console.error(e);
-        } finally {
-          if (data.topicId) this.#get().internal_updateTopicLoading(data.topicId, false);
-        }
+      } catch (e) {
+        console.error(e);
+      } finally {
+        if (data.topicId) this.#get().internal_updateTopicLoading(data.topicId, false);
       }
     }
 

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -36,6 +36,7 @@ import { getFileStoreState } from '@/store/file/store';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { type StoreSetter } from '@/store/types';
+import { useUserStore } from '@/store/user';
 import { useUserMemoryStore } from '@/store/userMemory';
 
 import { dbMessageSelectors, displayMessageSelectors, topicSelectors } from '../../../selectors';
@@ -587,11 +588,12 @@ export class ConversationLifecycleActionImpl {
 
     // ── AI execution ──
     {
-      // Check if server-side Gateway mode is available
+      // Check if server-side Gateway mode is available AND user has enabled it in Labs
       const agentGatewayUrl =
         window.global_serverConfigStore?.getState()?.serverConfig?.agentGatewayUrl;
+      const enableGatewayMode = useUserStore.getState().preference.lab?.enableGatewayMode;
 
-      if (agentGatewayUrl) {
+      if (agentGatewayUrl && enableGatewayMode) {
         // ── Gateway mode: trigger server-side execution, receive events via WebSocket ──
         try {
           const result = await aiAgentService.execAgentTask({
@@ -631,7 +633,7 @@ export class ConversationLifecycleActionImpl {
               if (data.topicId) this.#get().internal_updateTopicLoading(data.topicId, false);
             },
             operationId: result.operationId,
-            token: result.token,
+            token: result.token || '',
           });
         } catch (e) {
           console.error('[Gateway] Failed to start server-side agent:', e);

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -613,6 +613,10 @@ export class ConversationLifecycleActionImpl {
             type: 'execServerAgentRuntime',
           });
 
+          // Associate the initial assistant message with the gateway operation
+          // so the UI shows loading/generating state via the operation system
+          this.#get().associateMessageWithOperation(data.assistantMessageId, gatewayOpId);
+
           const eventHandler = createGatewayEventHandler(this.#get, {
             assistantMessageId: data.assistantMessageId,
             context: execContext,

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -619,7 +619,7 @@ export class ConversationLifecycleActionImpl {
               if (data.topicId) this.#get().internal_updateTopicLoading(data.topicId, false);
             },
             operationId: result.operationId,
-            token: '', // TODO: inject auth token in Phase 4
+            token: result.token,
           });
         } catch (e) {
           console.error('[Gateway] Failed to start server-side agent:', e);

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -585,17 +585,21 @@ export class ConversationLifecycleActionImpl {
     // ── AI execution ──
 
     // Gateway mode: server-side execution via WebSocket (opt-in via Labs toggle)
-    // If gateway started, skip client-side agent loop entirely
-    if (
-      this.#get().startGatewayExecution({
-        assistantMessageId: data.assistantMessageId,
-        context: execContext,
-        message,
-        parentOperationId: operationId,
-        topicId: data.topicId,
-        userMessageId: data.userMessageId,
-      })
-    ) {
+    if (this.#get().isGatewayModeEnabled()) {
+      try {
+        await this.#get().executeGatewayAgent({
+          assistantMessageId: data.assistantMessageId,
+          context: execContext,
+          message,
+          parentOperationId: operationId,
+          topicId: data.topicId,
+          userMessageId: data.userMessageId,
+        });
+      } catch (e) {
+        console.error('[Gateway] Failed to start server-side agent:', e);
+        if (data.topicId) this.#get().internal_updateTopicLoading(data.topicId, false);
+      }
+
       return {
         assistantMessageId: data.assistantMessageId,
         createdThreadId: data.createdThreadId,

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -17,6 +17,7 @@ import { TRPCClientError } from '@trpc/client';
 import { t } from 'i18next';
 
 import { markUserValidAction } from '@/business/client/markUserValidAction';
+import { aiAgentService } from '@/services/aiAgent';
 import { aiChatService } from '@/services/aiChat';
 import { chatService } from '@/services/chat';
 import { resolveSelectedSkillsWithContent } from '@/services/chat/mecha/skillPreload';
@@ -48,6 +49,7 @@ import {
   parseSelectedToolsFromEditorData,
   processCommands,
 } from './commandBus';
+import { createGatewayEventHandler } from './gatewayEventHandler';
 
 /**
  * Extended params for sendMessage with context
@@ -585,55 +587,97 @@ export class ConversationLifecycleActionImpl {
 
     // ── AI execution ──
     {
-      const displayMessages = displayMessageSelectors.getDisplayMessagesByKey(
-        messageMapKey(execContext),
-      )(this.#get());
+      // Check if server-side Gateway mode is available
+      const agentGatewayUrl =
+        window.global_serverConfigStore?.getState()?.serverConfig?.agentGatewayUrl;
 
-      try {
-        // When agents are @mentioned, inject a slim callAgent-only manifest
-        // so the AI can delegate directly without activating the full agent-management tool
-        const injectedManifests = hasMentionedAgents ? [createCallAgentManifest()] : undefined;
+      if (agentGatewayUrl) {
+        // ── Gateway mode: trigger server-side execution, receive events via WebSocket ──
+        try {
+          const result = await aiAgentService.execAgentTask({
+            agentId: execContext.agentId,
+            appContext: {
+              groupId: execContext.groupId,
+              scope: execContext.scope,
+              threadId: execContext.threadId,
+              topicId: execContext.topicId,
+            },
+            existingMessageIds: [data.userMessageId, data.assistantMessageId],
+            prompt: message,
+          });
 
-        const hasInitialContext = hasMentionedAgents || !!injectedManifests;
+          const eventHandler = createGatewayEventHandler(this.#get, {
+            assistantMessageId: data.assistantMessageId,
+            context: execContext,
+            operationId: result.operationId,
+          });
 
-        // Note: selectedSkills and selectedTools are NOT passed here — they are
-        // persisted into the user message content above so they survive across
-        // turns without re-injection.
-        const agentRuntimeInitialContext = hasInitialContext
-          ? {
-              initialContext: {
-                // Only inject mentionedAgents in non-group context to avoid
-                // group @member mentions (including ALL_MEMBERS) leaking into agent-management
-                ...(hasMentionedAgents ? { mentionedAgents } : undefined),
-                ...(injectedManifests ? { injectedManifests } : undefined),
-              },
-              phase: 'init' as const,
-            }
-          : undefined;
-
-        await internal_execAgentRuntime({
-          context: execContext,
-          initialContext: agentRuntimeInitialContext,
-          messages: displayMessages,
-          parentMessageId: data.assistantMessageId,
-          parentMessageType: 'assistant',
-          parentOperationId: operationId,
-          inPortalThread: !!data.createdThreadId,
-          skipCreateFirstMessage: true,
-        });
-
-        const userFiles = dbMessageSelectors
-          .dbUserFiles(this.#get())
-          .map((f) => f?.id)
-          .filter(Boolean) as string[];
-
-        if (userFiles.length > 0) {
-          await getAgentStoreState().addFilesToAgent(userFiles, false);
+          this.#get().connectToGateway({
+            gatewayUrl: agentGatewayUrl,
+            onEvent: eventHandler,
+            onSessionComplete: () => {
+              if (data.topicId) this.#get().internal_updateTopicLoading(data.topicId, false);
+            },
+            operationId: result.operationId,
+            token: '', // TODO: inject auth token in Phase 4
+          });
+        } catch (e) {
+          console.error('[Gateway] Failed to start server-side agent:', e);
+          // Fall through to topic loading cleanup
+          if (data.topicId) this.#get().internal_updateTopicLoading(data.topicId, false);
         }
-      } catch (e) {
-        console.error(e);
-      } finally {
-        if (data.topicId) this.#get().internal_updateTopicLoading(data.topicId, false);
+      } else {
+        // ── Client mode: run agent loop locally ──
+        const displayMessages = displayMessageSelectors.getDisplayMessagesByKey(
+          messageMapKey(execContext),
+        )(this.#get());
+
+        try {
+          // When agents are @mentioned, inject a slim callAgent-only manifest
+          // so the AI can delegate directly without activating the full agent-management tool
+          const injectedManifests = hasMentionedAgents ? [createCallAgentManifest()] : undefined;
+
+          const hasInitialContext = hasMentionedAgents || !!injectedManifests;
+
+          // Note: selectedSkills and selectedTools are NOT passed here — they are
+          // persisted into the user message content above so they survive across
+          // turns without re-injection.
+          const agentRuntimeInitialContext = hasInitialContext
+            ? {
+                initialContext: {
+                  // Only inject mentionedAgents in non-group context to avoid
+                  // group @member mentions (including ALL_MEMBERS) leaking into agent-management
+                  ...(hasMentionedAgents ? { mentionedAgents } : undefined),
+                  ...(injectedManifests ? { injectedManifests } : undefined),
+                },
+                phase: 'init' as const,
+              }
+            : undefined;
+
+          await internal_execAgentRuntime({
+            context: execContext,
+            initialContext: agentRuntimeInitialContext,
+            messages: displayMessages,
+            parentMessageId: data.assistantMessageId,
+            parentMessageType: 'assistant',
+            parentOperationId: operationId,
+            inPortalThread: !!data.createdThreadId,
+            skipCreateFirstMessage: true,
+          });
+
+          const userFiles = dbMessageSelectors
+            .dbUserFiles(this.#get())
+            .map((f) => f?.id)
+            .filter(Boolean) as string[];
+
+          if (userFiles.length > 0) {
+            await getAgentStoreState().addFilesToAgent(userFiles, false);
+          }
+        } catch (e) {
+          console.error(e);
+        } finally {
+          if (data.topicId) this.#get().internal_updateTopicLoading(data.topicId, false);
+        }
       }
     }
 

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -1,0 +1,164 @@
+import type {
+  AgentStreamClientOptions,
+  AgentStreamEvent,
+  ConnectionStatus,
+} from '@/libs/agent-stream';
+import { AgentStreamClient } from '@/libs/agent-stream/client';
+import type { ChatStore } from '@/store/chat/store';
+import type { StoreSetter } from '@/store/types';
+
+type Setter = StoreSetter<ChatStore>;
+
+// ─── Types ───
+
+export interface GatewayConnection {
+  client: Pick<AgentStreamClient, 'connect' | 'disconnect' | 'on' | 'sendInterrupt'>;
+  status: ConnectionStatus;
+}
+
+export interface ConnectGatewayParams {
+  /**
+   * Gateway WebSocket URL (e.g. https://agent-gateway.lobehub.com)
+   */
+  gatewayUrl: string;
+  /**
+   * Callback for each agent event received
+   */
+  onEvent?: (event: AgentStreamEvent) => void;
+  /**
+   * Called when the session completes (agent_runtime_end or session_complete)
+   */
+  onSessionComplete?: () => void;
+  /**
+   * The operation ID returned by execAgent
+   */
+  operationId: string;
+  /**
+   * Auth token for the Gateway
+   */
+  token: string;
+}
+
+// ─── Action Implementation ───
+
+export class GatewayActionImpl {
+  readonly #get: () => ChatStore;
+  readonly #set: Setter;
+
+  /** Overridable factory for testing */
+  createClient: (options: AgentStreamClientOptions) => GatewayConnection['client'] = (options) =>
+    new AgentStreamClient(options);
+
+  constructor(set: Setter, get: () => ChatStore, _api?: unknown) {
+    void _api;
+    this.#set = set;
+    this.#get = get;
+  }
+
+  /**
+   * Connect to the Agent Gateway for a specific operation.
+   * Creates an AgentStreamClient, manages its lifecycle, and wires up event callbacks.
+   */
+  connectToGateway = (params: ConnectGatewayParams): void => {
+    const { operationId, gatewayUrl, token, onEvent, onSessionComplete } = params;
+
+    // Disconnect existing connection for this operation if any
+    this.disconnectFromGateway(operationId);
+
+    const client = this.createClient({ gatewayUrl, operationId, token });
+
+    // Track connection in store
+    this.#set(
+      (state) => ({
+        gatewayConnections: {
+          ...state.gatewayConnections,
+          [operationId]: { client, status: 'connecting' },
+        },
+      }),
+      false,
+      'connectToGateway',
+    );
+
+    // Wire up status changes
+    client.on('status_changed', (status) => {
+      this.#set(
+        (state) => {
+          const conn = state.gatewayConnections[operationId];
+          if (!conn) return state;
+          return {
+            gatewayConnections: { ...state.gatewayConnections, [operationId]: { ...conn, status } },
+          };
+        },
+        false,
+        'gateway/statusChanged',
+      );
+    });
+
+    // Forward agent events to caller
+    if (onEvent) {
+      client.on('agent_event', onEvent);
+    }
+
+    // Handle session completion
+    client.on('session_complete', () => {
+      this.internal_cleanupGatewayConnection(operationId);
+      onSessionComplete?.();
+    });
+
+    // Handle disconnection (terminal events auto-disconnect the client)
+    client.on('disconnected', () => {
+      this.internal_cleanupGatewayConnection(operationId);
+    });
+
+    // Handle auth failures
+    client.on('auth_failed', (reason) => {
+      console.error(`[Gateway] Auth failed for operation ${operationId}: ${reason}`);
+      this.internal_cleanupGatewayConnection(operationId);
+    });
+
+    client.connect();
+  };
+
+  /**
+   * Disconnect from the Gateway for a specific operation.
+   */
+  disconnectFromGateway = (operationId: string): void => {
+    const conn = this.#get().gatewayConnections[operationId];
+    if (!conn) return;
+
+    conn.client.disconnect();
+    this.internal_cleanupGatewayConnection(operationId);
+  };
+
+  /**
+   * Send an interrupt command to stop the agent for a specific operation.
+   */
+  interruptGatewayAgent = (operationId: string): void => {
+    const conn = this.#get().gatewayConnections[operationId];
+    if (!conn) return;
+
+    conn.client.sendInterrupt();
+  };
+
+  /**
+   * Get the connection status for a specific operation.
+   */
+  getGatewayConnectionStatus = (operationId: string): ConnectionStatus | undefined => {
+    return this.#get().gatewayConnections[operationId]?.status;
+  };
+
+  // ─── Internal ───
+
+  private internal_cleanupGatewayConnection = (operationId: string): void => {
+    this.#set(
+      (state) => {
+        const { [operationId]: _, ...rest } = state.gatewayConnections;
+        return { gatewayConnections: rest };
+      },
+      false,
+      'gateway/cleanup',
+    );
+  };
+}
+
+export type GatewayAction = Pick<GatewayActionImpl, keyof GatewayActionImpl>;

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -1,11 +1,17 @@
+import type { ConversationContext } from '@lobechat/types';
+
 import type {
   AgentStreamClientOptions,
   AgentStreamEvent,
   ConnectionStatus,
 } from '@/libs/agent-stream';
 import { AgentStreamClient } from '@/libs/agent-stream/client';
+import { aiAgentService } from '@/services/aiAgent';
 import type { ChatStore } from '@/store/chat/store';
 import type { StoreSetter } from '@/store/types';
+import { useUserStore } from '@/store/user';
+
+import { createGatewayEventHandler } from './gatewayEventHandler';
 
 type Setter = StoreSetter<ChatStore>;
 
@@ -147,7 +153,107 @@ export class GatewayActionImpl {
     return this.#get().gatewayConnections[operationId]?.status;
   };
 
+  /**
+   * Try to start server-side agent execution via Gateway WebSocket.
+   * Returns true if gateway mode is active and execution was started,
+   * false if gateway is not available (caller should fall back to client mode).
+   */
+  startGatewayExecution = (params: {
+    assistantMessageId: string;
+    context: ConversationContext;
+    message: string;
+    parentOperationId: string;
+    topicId?: string;
+    userMessageId: string;
+  }): boolean => {
+    const { assistantMessageId, context, message, parentOperationId, topicId, userMessageId } =
+      params;
+
+    // Check if server-side Gateway mode is available AND user has enabled it in Labs
+    const agentGatewayUrl =
+      window.global_serverConfigStore?.getState()?.serverConfig?.agentGatewayUrl;
+    const enableGatewayMode = useUserStore.getState().preference.lab?.enableGatewayMode;
+
+    if (!agentGatewayUrl || !enableGatewayMode) return false;
+
+    // Fire-and-forget: start the gateway execution asynchronously
+    this.#executeViaGateway({
+      agentGatewayUrl,
+      assistantMessageId,
+      context,
+      message,
+      parentOperationId,
+      topicId,
+      userMessageId,
+    }).catch((e) => {
+      console.error('[Gateway] Failed to start server-side agent:', e);
+      if (topicId) this.#get().internal_updateTopicLoading(topicId, false);
+    });
+
+    return true;
+  };
+
   // ─── Internal ───
+
+  #executeViaGateway = async (params: {
+    agentGatewayUrl: string;
+    assistantMessageId: string;
+    context: ConversationContext;
+    message: string;
+    parentOperationId: string;
+    topicId?: string;
+    userMessageId: string;
+  }): Promise<void> => {
+    const {
+      agentGatewayUrl,
+      assistantMessageId,
+      context,
+      message,
+      parentOperationId,
+      topicId,
+      userMessageId,
+    } = params;
+
+    const result = await aiAgentService.execAgentTask({
+      agentId: context.agentId,
+      appContext: {
+        groupId: context.groupId,
+        scope: context.scope,
+        threadId: context.threadId,
+        topicId: context.topicId,
+      },
+      existingMessageIds: [userMessageId, assistantMessageId],
+      prompt: message,
+    });
+
+    // Create a dedicated operation for gateway execution with correct context
+    const { operationId: gatewayOpId } = this.#get().startOperation({
+      context,
+      parentOperationId,
+      type: 'execServerAgentRuntime',
+    });
+
+    // Associate the initial assistant message with the gateway operation
+    // so the UI shows loading/generating state via the operation system
+    this.#get().associateMessageWithOperation(assistantMessageId, gatewayOpId);
+
+    const eventHandler = createGatewayEventHandler(this.#get, {
+      assistantMessageId,
+      context,
+      operationId: gatewayOpId,
+    });
+
+    this.#get().connectToGateway({
+      gatewayUrl: agentGatewayUrl,
+      onEvent: eventHandler,
+      onSessionComplete: () => {
+        this.#get().completeOperation(gatewayOpId);
+        if (topicId) this.#get().internal_updateTopicLoading(topicId, false);
+      },
+      operationId: result.operationId,
+      token: result.token || '',
+    });
+  };
 
   private internal_cleanupGatewayConnection = (operationId: string): void => {
     this.#set(

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -154,49 +154,22 @@ export class GatewayActionImpl {
   };
 
   /**
-   * Try to start server-side agent execution via Gateway WebSocket.
-   * Returns true if gateway mode is active and execution was started,
-   * false if gateway is not available (caller should fall back to client mode).
+   * Check if Gateway mode is available and enabled.
+   * Returns true if both server config and user lab toggle are set.
    */
-  startGatewayExecution = (params: {
-    assistantMessageId: string;
-    context: ConversationContext;
-    message: string;
-    parentOperationId: string;
-    topicId?: string;
-    userMessageId: string;
-  }): boolean => {
-    const { assistantMessageId, context, message, parentOperationId, topicId, userMessageId } =
-      params;
-
-    // Check if server-side Gateway mode is available AND user has enabled it in Labs
+  isGatewayModeEnabled = (): boolean => {
     const agentGatewayUrl =
       window.global_serverConfigStore?.getState()?.serverConfig?.agentGatewayUrl;
     const enableGatewayMode = useUserStore.getState().preference.lab?.enableGatewayMode;
 
-    if (!agentGatewayUrl || !enableGatewayMode) return false;
-
-    // Fire-and-forget: start the gateway execution asynchronously
-    this.#executeViaGateway({
-      agentGatewayUrl,
-      assistantMessageId,
-      context,
-      message,
-      parentOperationId,
-      topicId,
-      userMessageId,
-    }).catch((e) => {
-      console.error('[Gateway] Failed to start server-side agent:', e);
-      if (topicId) this.#get().internal_updateTopicLoading(topicId, false);
-    });
-
-    return true;
+    return !!agentGatewayUrl && !!enableGatewayMode;
   };
 
-  // ─── Internal ───
-
-  #executeViaGateway = async (params: {
-    agentGatewayUrl: string;
+  /**
+   * Execute agent task via Gateway WebSocket.
+   * Call isGatewayModeEnabled() first to check availability.
+   */
+  executeGatewayAgent = async (params: {
     assistantMessageId: string;
     context: ConversationContext;
     message: string;
@@ -204,15 +177,11 @@ export class GatewayActionImpl {
     topicId?: string;
     userMessageId: string;
   }): Promise<void> => {
-    const {
-      agentGatewayUrl,
-      assistantMessageId,
-      context,
-      message,
-      parentOperationId,
-      topicId,
-      userMessageId,
-    } = params;
+    const { assistantMessageId, context, message, parentOperationId, topicId, userMessageId } =
+      params;
+
+    const agentGatewayUrl =
+      window.global_serverConfigStore!.getState().serverConfig.agentGatewayUrl!;
 
     const result = await aiAgentService.execAgentTask({
       agentId: context.agentId,

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -1,0 +1,97 @@
+import type { ConversationContext } from '@lobechat/types';
+
+import type { AgentStreamEvent, StreamChunkData } from '@/libs/agent-stream';
+import type { ChatStore } from '@/store/chat/store';
+
+/**
+ * Creates a handler function that processes Agent Gateway events
+ * and maps them to the chat store's message update actions.
+ *
+ * This replaces the client-side agent loop when running in server mode.
+ */
+export const createGatewayEventHandler = (
+  get: () => ChatStore,
+  params: {
+    assistantMessageId: string;
+    context: ConversationContext;
+    operationId: string;
+  },
+) => {
+  const { assistantMessageId, context } = params;
+
+  // Accumulated content from stream chunks
+  let accumulatedContent = '';
+  let accumulatedReasoning = '';
+
+  return (event: AgentStreamEvent) => {
+    switch (event.type) {
+      case 'stream_chunk': {
+        const data = event.data as StreamChunkData | undefined;
+        if (!data) break;
+
+        if (data.chunkType === 'text' && data.content) {
+          accumulatedContent += data.content;
+          get().internal_dispatchMessage({
+            id: assistantMessageId,
+            type: 'updateMessage',
+            value: { content: accumulatedContent },
+          });
+        }
+
+        if (data.chunkType === 'reasoning' && data.reasoning) {
+          accumulatedReasoning += data.reasoning;
+          get().internal_dispatchMessage({
+            id: assistantMessageId,
+            type: 'updateMessage',
+            value: { reasoning: { content: accumulatedReasoning } },
+          });
+        }
+
+        if (data.chunkType === 'tools_calling' && data.toolsCalling) {
+          get().internal_dispatchMessage({
+            id: assistantMessageId,
+            type: 'updateMessage',
+            value: { tools: data.toolsCalling },
+          });
+        }
+        break;
+      }
+
+      case 'stream_start': {
+        // Reset accumulated content for new stream
+        accumulatedContent = '';
+        accumulatedReasoning = '';
+        get().internal_toggleMessageLoading(true, assistantMessageId);
+        break;
+      }
+
+      case 'stream_end': {
+        get().internal_toggleMessageLoading(false, assistantMessageId);
+        break;
+      }
+
+      case 'agent_runtime_end': {
+        // Refresh messages from server to get the final persisted state
+        get().internal_toggleMessageLoading(false, assistantMessageId);
+        get().refreshMessages(context).catch(console.error);
+        break;
+      }
+
+      case 'error': {
+        const errorMsg = event.data?.message || event.data?.error || 'Unknown error';
+        get().internal_dispatchMessage({
+          id: assistantMessageId,
+          type: 'updateMessage',
+          value: {
+            error: { body: { message: errorMsg }, type: 'AgentRuntimeError' },
+          },
+        });
+        get().internal_toggleMessageLoading(false, assistantMessageId);
+        break;
+      }
+
+      // step_start, step_complete, tool_start, tool_end — no UI action needed for now
+      // These can be extended in the future for step progress indicators
+    }
+  };
+};

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -74,6 +74,8 @@ export const createGatewayEventHandler = (
           // Switch to the new assistant message created by the server for this step
           if (newAssistantMessageId) {
             currentAssistantMessageId = newAssistantMessageId;
+            // Associate the new message with the operation so UI shows generating state
+            get().associateMessageWithOperation(currentAssistantMessageId, operationId);
           }
 
           // Reset accumulators for the new stream

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -67,10 +67,6 @@ export const createGatewayEventHandler = (
 
           const newAssistantMessageId = data?.assistantMessage?.id;
 
-          // Optimistically show loading on the current message BEFORE fetching,
-          // so the UI doesn't appear frozen while waiting for DB response
-          get().internal_toggleMessageLoading(true, currentAssistantMessageId);
-
           // Switch to the new assistant message created by the server for this step
           if (newAssistantMessageId) {
             currentAssistantMessageId = newAssistantMessageId;
@@ -84,9 +80,6 @@ export const createGatewayEventHandler = (
 
           // Fetch from DB so the new message exists in dbMessagesMap before chunks arrive
           await fetchAndReplaceMessages(get, context).catch(console.error);
-
-          // Re-apply loading to the (possibly new) message after fetch replaces the map
-          get().internal_toggleMessageLoading(true, currentAssistantMessageId);
         });
         break;
       }
@@ -159,8 +152,6 @@ export const createGatewayEventHandler = (
       case 'tool_end': {
         enqueue(async () => {
           await fetchAndReplaceMessages(get, context).catch(console.error);
-          // Re-apply loading after refresh so UI stays active between tool_end and next stream_start
-          get().internal_toggleMessageLoading(true, currentAssistantMessageId);
         });
         break;
       }
@@ -179,7 +170,6 @@ export const createGatewayEventHandler = (
 
       case 'agent_runtime_end': {
         enqueue(async () => {
-          get().internal_toggleMessageLoading(false, currentAssistantMessageId);
           get().internal_toggleToolCallingStreaming(currentAssistantMessageId, undefined);
           get().completeOperation(operationId);
           await fetchAndReplaceMessages(get, context).catch(console.error);
@@ -200,7 +190,6 @@ export const createGatewayEventHandler = (
             },
             dispatchContext,
           );
-          get().internal_toggleMessageLoading(false, currentAssistantMessageId);
         });
         break;
       }

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -16,6 +16,10 @@ import type { ChatStore } from '@/store/chat/store';
  * using a hybrid approach:
  * - Current LLM step: real-time streaming via stream_chunk
  * - Step transitions: refreshMessages() from DB at stream_start / tool_end / step_complete
+ *
+ * The handler queues incoming events and processes them sequentially,
+ * ensuring that stream_chunk waits for stream_start's refreshMessages to resolve
+ * before dispatching updates.
  */
 export const createGatewayEventHandler = (
   get: () => ChatStore,
@@ -34,70 +38,83 @@ export const createGatewayEventHandler = (
   let accumulatedContent = '';
   let accumulatedReasoning = '';
 
+  // Sequential processing queue — ensures stream_chunk waits for stream_start's refresh
+  let processingChain: Promise<void> = Promise.resolve();
+
+  const enqueue = (fn: () => Promise<void> | void): void => {
+    processingChain = processingChain.then(fn, fn);
+  };
+
   return (event: AgentStreamEvent) => {
     switch (event.type) {
       case 'stream_start': {
-        const data = event.data as StreamStartData | undefined;
+        enqueue(async () => {
+          const data = event.data as StreamStartData | undefined;
 
-        // Switch to the new assistant message created by the server for this step
-        if (data?.assistantMessage?.id) {
-          currentAssistantMessageId = data.assistantMessage.id;
-        }
+          // Switch to the new assistant message created by the server for this step
+          if (data?.assistantMessage?.id) {
+            currentAssistantMessageId = data.assistantMessage.id;
+          }
 
-        // Reset accumulators for the new stream
-        accumulatedContent = '';
-        accumulatedReasoning = '';
+          // Reset accumulators for the new stream
+          accumulatedContent = '';
+          accumulatedReasoning = '';
 
-        // Refresh from DB to pick up the new assistant message
-        get().refreshMessages(context).catch(console.error);
+          // Await refresh so the new message exists in dbMessagesMap before chunks arrive
+          await get().refreshMessages(context).catch(console.error);
 
-        get().internal_toggleMessageLoading(true, currentAssistantMessageId);
+          get().internal_toggleMessageLoading(true, currentAssistantMessageId);
+        });
         break;
       }
 
       case 'stream_chunk': {
-        const data = event.data as StreamChunkData | undefined;
-        if (!data) break;
+        enqueue(() => {
+          const data = event.data as StreamChunkData | undefined;
+          if (!data) return;
 
-        if (data.chunkType === 'text' && data.content) {
-          accumulatedContent += data.content;
-          get().internal_dispatchMessage({
-            id: currentAssistantMessageId,
-            type: 'updateMessage',
-            value: { content: accumulatedContent },
-          });
-        }
+          if (data.chunkType === 'text' && data.content) {
+            accumulatedContent += data.content;
+            get().internal_dispatchMessage({
+              id: currentAssistantMessageId,
+              type: 'updateMessage',
+              value: { content: accumulatedContent },
+            });
+          }
 
-        if (data.chunkType === 'reasoning' && data.reasoning) {
-          accumulatedReasoning += data.reasoning;
-          get().internal_dispatchMessage({
-            id: currentAssistantMessageId,
-            type: 'updateMessage',
-            value: { reasoning: { content: accumulatedReasoning } },
-          });
-        }
+          if (data.chunkType === 'reasoning' && data.reasoning) {
+            accumulatedReasoning += data.reasoning;
+            get().internal_dispatchMessage({
+              id: currentAssistantMessageId,
+              type: 'updateMessage',
+              value: { reasoning: { content: accumulatedReasoning } },
+            });
+          }
 
-        if (data.chunkType === 'tools_calling' && data.toolsCalling) {
-          get().internal_dispatchMessage({
-            id: currentAssistantMessageId,
-            type: 'updateMessage',
-            value: { tools: data.toolsCalling },
-          });
+          if (data.chunkType === 'tools_calling' && data.toolsCalling) {
+            get().internal_dispatchMessage({
+              id: currentAssistantMessageId,
+              type: 'updateMessage',
+              value: { tools: data.toolsCalling },
+            });
 
-          // Drive tool calling animation
-          get().internal_toggleToolCallingStreaming(
-            currentAssistantMessageId,
-            data.toolsCalling.map(() => true),
-          );
-        }
+            // Drive tool calling animation
+            get().internal_toggleToolCallingStreaming(
+              currentAssistantMessageId,
+              data.toolsCalling.map(() => true),
+            );
+          }
+        });
         break;
       }
 
       case 'stream_end': {
-        get().internal_toggleMessageLoading(false, currentAssistantMessageId);
+        enqueue(() => {
+          get().internal_toggleMessageLoading(false, currentAssistantMessageId);
 
-        // Clear tool calling streaming animation
-        get().internal_toggleToolCallingStreaming(currentAssistantMessageId, undefined);
+          // Clear tool calling streaming animation
+          get().internal_toggleToolCallingStreaming(currentAssistantMessageId, undefined);
+        });
         break;
       }
 
@@ -108,8 +125,9 @@ export const createGatewayEventHandler = (
       }
 
       case 'tool_end': {
-        // Refresh from DB to pick up tool execution results
-        get().refreshMessages(context).catch(console.error);
+        enqueue(async () => {
+          await get().refreshMessages(context).catch(console.error);
+        });
         break;
       }
 
@@ -118,28 +136,33 @@ export const createGatewayEventHandler = (
 
         // Refresh on execution_complete to ensure final step state is consistent
         if (data?.phase === 'execution_complete') {
-          get().refreshMessages(context).catch(console.error);
+          enqueue(async () => {
+            await get().refreshMessages(context).catch(console.error);
+          });
         }
         break;
       }
 
       case 'agent_runtime_end': {
-        // Final refresh to get the complete persisted state
-        get().internal_toggleMessageLoading(false, currentAssistantMessageId);
-        get().refreshMessages(context).catch(console.error);
+        enqueue(async () => {
+          get().internal_toggleMessageLoading(false, currentAssistantMessageId);
+          await get().refreshMessages(context).catch(console.error);
+        });
         break;
       }
 
       case 'error': {
-        const errorMsg = event.data?.message || event.data?.error || 'Unknown error';
-        get().internal_dispatchMessage({
-          id: currentAssistantMessageId,
-          type: 'updateMessage',
-          value: {
-            error: { body: { message: errorMsg }, type: 'AgentRuntimeError' },
-          },
+        enqueue(() => {
+          const errorMsg = event.data?.message || event.data?.error || 'Unknown error';
+          get().internal_dispatchMessage({
+            id: currentAssistantMessageId,
+            type: 'updateMessage',
+            value: {
+              error: { body: { message: errorMsg }, type: 'AgentRuntimeError' },
+            },
+          });
+          get().internal_toggleMessageLoading(false, currentAssistantMessageId);
         });
-        get().internal_toggleMessageLoading(false, currentAssistantMessageId);
         break;
       }
     }

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -142,14 +142,16 @@ export const createGatewayEventHandler = (
       }
 
       case 'tool_start': {
-        // No client-side action needed — server creates tool messages in DB.
-        // They will appear when tool_end triggers fetchAndReplaceMessages.
+        // Server creates tool messages in DB.
+        // Loading is already active from stream_start (not cleared by stream_end).
         break;
       }
 
       case 'tool_end': {
         enqueue(async () => {
           await fetchAndReplaceMessages(get, context).catch(console.error);
+          // Re-apply loading after refresh so UI stays active between tool_end and next stream_start
+          get().internal_toggleMessageLoading(true, currentAssistantMessageId);
         });
         break;
       }

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -1,13 +1,21 @@
 import type { ConversationContext } from '@lobechat/types';
 
-import type { AgentStreamEvent, StreamChunkData } from '@/libs/agent-stream';
+import type {
+  AgentStreamEvent,
+  StepCompleteData,
+  StreamChunkData,
+  StreamStartData,
+} from '@/libs/agent-stream';
 import type { ChatStore } from '@/store/chat/store';
 
 /**
  * Creates a handler function that processes Agent Gateway events
  * and maps them to the chat store's message update actions.
  *
- * This replaces the client-side agent loop when running in server mode.
+ * Supports multi-step agent execution (LLM → tool calls → next LLM → ...)
+ * using a hybrid approach:
+ * - Current LLM step: real-time streaming via stream_chunk
+ * - Step transitions: refreshMessages() from DB at stream_start / tool_end / step_complete
  */
 export const createGatewayEventHandler = (
   get: () => ChatStore,
@@ -17,14 +25,36 @@ export const createGatewayEventHandler = (
     operationId: string;
   },
 ) => {
-  const { assistantMessageId, context } = params;
+  const { context } = params;
 
-  // Accumulated content from stream chunks
+  // Mutable — switches to new assistant message ID on each stream_start
+  let currentAssistantMessageId = params.assistantMessageId;
+
+  // Accumulated content from stream chunks (reset on each stream_start)
   let accumulatedContent = '';
   let accumulatedReasoning = '';
 
   return (event: AgentStreamEvent) => {
     switch (event.type) {
+      case 'stream_start': {
+        const data = event.data as StreamStartData | undefined;
+
+        // Switch to the new assistant message created by the server for this step
+        if (data?.assistantMessage?.id) {
+          currentAssistantMessageId = data.assistantMessage.id;
+        }
+
+        // Reset accumulators for the new stream
+        accumulatedContent = '';
+        accumulatedReasoning = '';
+
+        // Refresh from DB to pick up the new assistant message
+        get().refreshMessages(context).catch(console.error);
+
+        get().internal_toggleMessageLoading(true, currentAssistantMessageId);
+        break;
+      }
+
       case 'stream_chunk': {
         const data = event.data as StreamChunkData | undefined;
         if (!data) break;
@@ -32,7 +62,7 @@ export const createGatewayEventHandler = (
         if (data.chunkType === 'text' && data.content) {
           accumulatedContent += data.content;
           get().internal_dispatchMessage({
-            id: assistantMessageId,
+            id: currentAssistantMessageId,
             type: 'updateMessage',
             value: { content: accumulatedContent },
           });
@@ -41,7 +71,7 @@ export const createGatewayEventHandler = (
         if (data.chunkType === 'reasoning' && data.reasoning) {
           accumulatedReasoning += data.reasoning;
           get().internal_dispatchMessage({
-            id: assistantMessageId,
+            id: currentAssistantMessageId,
             type: 'updateMessage',
             value: { reasoning: { content: accumulatedReasoning } },
           });
@@ -49,30 +79,53 @@ export const createGatewayEventHandler = (
 
         if (data.chunkType === 'tools_calling' && data.toolsCalling) {
           get().internal_dispatchMessage({
-            id: assistantMessageId,
+            id: currentAssistantMessageId,
             type: 'updateMessage',
             value: { tools: data.toolsCalling },
           });
+
+          // Drive tool calling animation
+          get().internal_toggleToolCallingStreaming(
+            currentAssistantMessageId,
+            data.toolsCalling.map(() => true),
+          );
         }
         break;
       }
 
-      case 'stream_start': {
-        // Reset accumulated content for new stream
-        accumulatedContent = '';
-        accumulatedReasoning = '';
-        get().internal_toggleMessageLoading(true, assistantMessageId);
+      case 'stream_end': {
+        get().internal_toggleMessageLoading(false, currentAssistantMessageId);
+
+        // Clear tool calling streaming animation
+        get().internal_toggleToolCallingStreaming(currentAssistantMessageId, undefined);
         break;
       }
 
-      case 'stream_end': {
-        get().internal_toggleMessageLoading(false, assistantMessageId);
+      case 'tool_start': {
+        // No client-side action needed — server creates tool messages in DB.
+        // They will appear when tool_end triggers refreshMessages.
+        break;
+      }
+
+      case 'tool_end': {
+        // Refresh from DB to pick up tool execution results
+        get().refreshMessages(context).catch(console.error);
+        break;
+      }
+
+      case 'step_complete': {
+        const data = event.data as StepCompleteData | undefined;
+
+        // Refresh on execution_complete to ensure final step state is consistent
+        if (data?.phase === 'execution_complete') {
+          get().refreshMessages(context).catch(console.error);
+        }
         break;
       }
 
       case 'agent_runtime_end': {
-        // Refresh messages from server to get the final persisted state
-        get().internal_toggleMessageLoading(false, assistantMessageId);
+        // Final refresh to get the complete persisted state
+        get().internal_toggleMessageLoading(false, currentAssistantMessageId);
         get().refreshMessages(context).catch(console.error);
         break;
       }
@@ -80,18 +133,15 @@ export const createGatewayEventHandler = (
       case 'error': {
         const errorMsg = event.data?.message || event.data?.error || 'Unknown error';
         get().internal_dispatchMessage({
-          id: assistantMessageId,
+          id: currentAssistantMessageId,
           type: 'updateMessage',
           value: {
             error: { body: { message: errorMsg }, type: 'AgentRuntimeError' },
           },
         });
-        get().internal_toggleMessageLoading(false, assistantMessageId);
+        get().internal_toggleMessageLoading(false, currentAssistantMessageId);
         break;
       }
-
-      // step_start, step_complete, tool_start, tool_end — no UI action needed for now
-      // These can be extended in the future for step progress indicators
     }
   };
 };

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -65,9 +65,15 @@ export const createGatewayEventHandler = (
         enqueue(async () => {
           const data = event.data as StreamStartData | undefined;
 
+          const newAssistantMessageId = data?.assistantMessage?.id;
+
+          // Optimistically show loading on the current message BEFORE fetching,
+          // so the UI doesn't appear frozen while waiting for DB response
+          get().internal_toggleMessageLoading(true, currentAssistantMessageId);
+
           // Switch to the new assistant message created by the server for this step
-          if (data?.assistantMessage?.id) {
-            currentAssistantMessageId = data.assistantMessage.id;
+          if (newAssistantMessageId) {
+            currentAssistantMessageId = newAssistantMessageId;
           }
 
           // Reset accumulators for the new stream
@@ -77,6 +83,7 @@ export const createGatewayEventHandler = (
           // Fetch from DB so the new message exists in dbMessagesMap before chunks arrive
           await fetchAndReplaceMessages(get, context).catch(console.error);
 
+          // Re-apply loading to the (possibly new) message after fetch replaces the map
           get().internal_toggleMessageLoading(true, currentAssistantMessageId);
         });
         break;

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -29,7 +29,10 @@ export const createGatewayEventHandler = (
     operationId: string;
   },
 ) => {
-  const { context } = params;
+  const { context, operationId } = params;
+
+  // Dispatch context — ensures internal_dispatchMessage resolves the correct messageMapKey
+  const dispatchContext = { operationId };
 
   // Mutable — switches to new assistant message ID on each stream_start
   let currentAssistantMessageId = params.assistantMessageId;
@@ -75,28 +78,37 @@ export const createGatewayEventHandler = (
 
           if (data.chunkType === 'text' && data.content) {
             accumulatedContent += data.content;
-            get().internal_dispatchMessage({
-              id: currentAssistantMessageId,
-              type: 'updateMessage',
-              value: { content: accumulatedContent },
-            });
+            get().internal_dispatchMessage(
+              {
+                id: currentAssistantMessageId,
+                type: 'updateMessage',
+                value: { content: accumulatedContent },
+              },
+              dispatchContext,
+            );
           }
 
           if (data.chunkType === 'reasoning' && data.reasoning) {
             accumulatedReasoning += data.reasoning;
-            get().internal_dispatchMessage({
-              id: currentAssistantMessageId,
-              type: 'updateMessage',
-              value: { reasoning: { content: accumulatedReasoning } },
-            });
+            get().internal_dispatchMessage(
+              {
+                id: currentAssistantMessageId,
+                type: 'updateMessage',
+                value: { reasoning: { content: accumulatedReasoning } },
+              },
+              dispatchContext,
+            );
           }
 
           if (data.chunkType === 'tools_calling' && data.toolsCalling) {
-            get().internal_dispatchMessage({
-              id: currentAssistantMessageId,
-              type: 'updateMessage',
-              value: { tools: data.toolsCalling },
-            });
+            get().internal_dispatchMessage(
+              {
+                id: currentAssistantMessageId,
+                type: 'updateMessage',
+                value: { tools: data.toolsCalling },
+              },
+              dispatchContext,
+            );
 
             // Drive tool calling animation
             get().internal_toggleToolCallingStreaming(
@@ -154,13 +166,16 @@ export const createGatewayEventHandler = (
       case 'error': {
         enqueue(() => {
           const errorMsg = event.data?.message || event.data?.error || 'Unknown error';
-          get().internal_dispatchMessage({
-            id: currentAssistantMessageId,
-            type: 'updateMessage',
-            value: {
-              error: { body: { message: errorMsg }, type: 'AgentRuntimeError' },
+          get().internal_dispatchMessage(
+            {
+              id: currentAssistantMessageId,
+              type: 'updateMessage',
+              value: {
+                error: { body: { message: errorMsg }, type: 'AgentRuntimeError' },
+              },
             },
-          });
+            dispatchContext,
+          );
           get().internal_toggleMessageLoading(false, currentAssistantMessageId);
         });
         break;

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -6,7 +6,18 @@ import type {
   StreamChunkData,
   StreamStartData,
 } from '@/libs/agent-stream';
+import { messageService } from '@/services/message';
 import type { ChatStore } from '@/store/chat/store';
+
+/**
+ * Fetch messages from DB and replace them in the chat store's dbMessagesMap.
+ * This updates the ConversationArea component via React subscription:
+ *   dbMessagesMap → ConversationArea (messages prop) → ConversationStore → UI
+ */
+const fetchAndReplaceMessages = async (get: () => ChatStore, context: ConversationContext) => {
+  const messages = await messageService.getMessages(context);
+  get().replaceMessages(messages, { context });
+};
 
 /**
  * Creates a handler function that processes Agent Gateway events
@@ -15,10 +26,10 @@ import type { ChatStore } from '@/store/chat/store';
  * Supports multi-step agent execution (LLM → tool calls → next LLM → ...)
  * using a hybrid approach:
  * - Current LLM step: real-time streaming via stream_chunk
- * - Step transitions: refreshMessages() from DB at stream_start / tool_end / step_complete
+ * - Step transitions: fetchAndReplaceMessages from DB at stream_start / tool_end / step_complete
  *
  * The handler queues incoming events and processes them sequentially,
- * ensuring that stream_chunk waits for stream_start's refreshMessages to resolve
+ * ensuring that stream_chunk waits for stream_start's DB fetch to resolve
  * before dispatching updates.
  */
 export const createGatewayEventHandler = (
@@ -41,7 +52,7 @@ export const createGatewayEventHandler = (
   let accumulatedContent = '';
   let accumulatedReasoning = '';
 
-  // Sequential processing queue — ensures stream_chunk waits for stream_start's refresh
+  // Sequential processing queue — ensures stream_chunk waits for stream_start's fetch
   let processingChain: Promise<void> = Promise.resolve();
 
   const enqueue = (fn: () => Promise<void> | void): void => {
@@ -63,8 +74,8 @@ export const createGatewayEventHandler = (
           accumulatedContent = '';
           accumulatedReasoning = '';
 
-          // Await refresh so the new message exists in dbMessagesMap before chunks arrive
-          await get().refreshMessages(context).catch(console.error);
+          // Fetch from DB so the new message exists in dbMessagesMap before chunks arrive
+          await fetchAndReplaceMessages(get, context).catch(console.error);
 
           get().internal_toggleMessageLoading(true, currentAssistantMessageId);
         });
@@ -122,9 +133,9 @@ export const createGatewayEventHandler = (
 
       case 'stream_end': {
         enqueue(() => {
-          get().internal_toggleMessageLoading(false, currentAssistantMessageId);
-
-          // Clear tool calling streaming animation
+          // Only clear tool calling streaming — keep message loading active
+          // until agent_runtime_end so users don't think the session ended
+          // during tool execution gaps between steps
           get().internal_toggleToolCallingStreaming(currentAssistantMessageId, undefined);
         });
         break;
@@ -132,13 +143,13 @@ export const createGatewayEventHandler = (
 
       case 'tool_start': {
         // No client-side action needed — server creates tool messages in DB.
-        // They will appear when tool_end triggers refreshMessages.
+        // They will appear when tool_end triggers fetchAndReplaceMessages.
         break;
       }
 
       case 'tool_end': {
         enqueue(async () => {
-          await get().refreshMessages(context).catch(console.error);
+          await fetchAndReplaceMessages(get, context).catch(console.error);
         });
         break;
       }
@@ -149,7 +160,7 @@ export const createGatewayEventHandler = (
         // Refresh on execution_complete to ensure final step state is consistent
         if (data?.phase === 'execution_complete') {
           enqueue(async () => {
-            await get().refreshMessages(context).catch(console.error);
+            await fetchAndReplaceMessages(get, context).catch(console.error);
           });
         }
         break;
@@ -158,7 +169,9 @@ export const createGatewayEventHandler = (
       case 'agent_runtime_end': {
         enqueue(async () => {
           get().internal_toggleMessageLoading(false, currentAssistantMessageId);
-          await get().refreshMessages(context).catch(console.error);
+          get().internal_toggleToolCallingStreaming(currentAssistantMessageId, undefined);
+          get().completeOperation(operationId);
+          await fetchAndReplaceMessages(get, context).catch(console.error);
         });
         break;
       }

--- a/src/store/chat/slices/aiChat/actions/index.ts
+++ b/src/store/chat/slices/aiChat/actions/index.ts
@@ -7,6 +7,8 @@ import { type ConversationControlAction } from './conversationControl';
 import { ConversationControlActionImpl } from './conversationControl';
 import { type ConversationLifecycleAction } from './conversationLifecycle';
 import { ConversationLifecycleActionImpl } from './conversationLifecycle';
+import { type GatewayAction } from './gateway';
+import { GatewayActionImpl } from './gateway';
 import { type ChatMemoryAction } from './memory';
 import { ChatMemoryActionImpl } from './memory';
 import { type StreamingExecutorAction } from './streamingExecutor';
@@ -17,6 +19,7 @@ import { StreamingStatesActionImpl } from './streamingStates';
 export type ChatAIChatAction = ChatMemoryAction &
   ConversationLifecycleAction &
   ConversationControlAction &
+  GatewayAction &
   StreamingExecutorAction &
   StreamingStatesAction;
 
@@ -34,6 +37,7 @@ export const chatAiChat: StateCreator<
     new ChatMemoryActionImpl(...params),
     new ConversationLifecycleActionImpl(...params),
     new ConversationControlActionImpl(...params),
+    new GatewayActionImpl(...params),
     new StreamingExecutorActionImpl(...params),
     new StreamingStatesActionImpl(...params),
   ]);

--- a/src/store/chat/slices/aiChat/initialState.ts
+++ b/src/store/chat/slices/aiChat/initialState.ts
@@ -1,6 +1,11 @@
 import { type ChatInputEditor } from '@/features/ChatInput';
+import type { GatewayConnection } from '@/store/chat/slices/aiChat/actions/gateway';
 
 export interface ChatAIChatState {
+  /**
+   * Active Agent Gateway WebSocket connections, keyed by operationId
+   */
+  gatewayConnections: Record<string, GatewayConnection>;
   inputFiles: File[];
   inputMessage: string;
   mainInputEditor: ChatInputEditor | null;
@@ -13,6 +18,7 @@ export interface ChatAIChatState {
 }
 
 export const initialAiChatState: ChatAIChatState = {
+  gatewayConnections: {},
   inputFiles: [],
   inputMessage: '',
   mainInputEditor: null,

--- a/src/store/user/slices/preference/selectors/labPrefer.ts
+++ b/src/store/user/slices/preference/selectors/labPrefer.ts
@@ -3,6 +3,7 @@ import { DEFAULT_PREFERENCE } from '@lobechat/const';
 import { type UserState } from '@/store/user/initialState';
 
 export const labPreferSelectors = {
+  enableGatewayMode: (s: UserState): boolean => s.preference.lab?.enableGatewayMode ?? false,
   enableInputMarkdown: (s: UserState): boolean =>
     s.preference.lab?.enableInputMarkdown ?? DEFAULT_PREFERENCE.lab!.enableInputMarkdown!,
 };


### PR DESCRIPTION
## Summary

- Add `GatewayActionImpl` to aiChat slice for managing Agent Gateway WebSocket connections
- Track connections per operationId with status updates in store state
- Support connect, disconnect, interrupt, and event forwarding via callbacks
- Type `execAgentTask` return value with `ExecAgentResult` interface
- 13 unit tests covering all gateway action flows

Fixes LOBE-6826

## Test plan

- [x] `bunx vitest run src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts` — 13/13 passing
- [x] `bun run type-check` — no errors
- [ ] Integration with Phase 2 (sendMessage → execAgent → Gateway events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)