### PR TITLE
🐛 fix: support ENABLE_MOCK_DEV_USER in checkAuth and openapi auth middleware

### DIFF
--- a/packages/openapi/src/middleware/auth.ts
+++ b/packages/openapi/src/middleware/auth.ts
@@ -52,7 +52,7 @@ export const userAuthMiddleware = async (c: Context, next: Next) => {
   const isMockUser = process.env.ENABLE_MOCK_DEV_USER === '1';
   if (process.env.NODE_ENV === 'development' && (isDebugApi || isMockUser)) {
     log('Development debug mode, using mock user ID');
-    c.set('userId', process.env.MOCK_DEV_USER_ID);
+    c.set('userId', process.env.MOCK_DEV_USER_ID || 'DEV_USER');
     c.set('authType', 'debug');
     return next();
   }

--- a/packages/openapi/src/middleware/auth.ts
+++ b/packages/openapi/src/middleware/auth.ts
@@ -49,7 +49,8 @@ setInterval(cleanupApiKeyCache, 10 * 60 * 1000);
 export const userAuthMiddleware = async (c: Context, next: Next) => {
   // Development mode debug bypass
   const isDebugApi = c.req.header('lobe-auth-dev-backend-api') === '1';
-  if (process.env.NODE_ENV === 'development' && isDebugApi) {
+  const isMockUser = process.env.ENABLE_MOCK_DEV_USER === '1';
+  if (process.env.NODE_ENV === 'development' && (isDebugApi || isMockUser)) {
     log('Development debug mode, using mock user ID');
     c.set('userId', process.env.MOCK_DEV_USER_ID);
     c.set('authType', 'debug');

--- a/src/app/(backend)/middleware/auth/index.test.ts
+++ b/src/app/(backend)/middleware/auth/index.test.ts
@@ -4,9 +4,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createErrorResponse } from '@/utils/errorResponse';
 
-import { type RequestHandler } from './index';
-import { checkAuth } from './index';
+import { checkAuth, type RequestHandler } from './index';
 import { checkAuthMethod } from './utils';
+
+vi.mock('@lobechat/model-runtime', () => ({
+  AgentRuntimeError: {
+    createError: vi.fn((type: string) => ({ errorType: type })),
+  },
+}));
+
+vi.mock('@lobechat/types', () => ({
+  ChatErrorType: { Unauthorized: 'Unauthorized', InternalServerError: 'InternalServerError' },
+}));
 
 vi.mock('@/utils/errorResponse', () => ({
   createErrorResponse: vi.fn(),
@@ -24,6 +33,27 @@ vi.mock('@/auth', () => ({
   },
 }));
 
+vi.mock('@/database/core/db-adaptor', () => ({
+  getServerDB: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/libs/observability/traceparent', () => ({
+  extractTraceContext: vi.fn(),
+  injectActiveTraceHeaders: vi.fn(),
+}));
+
+vi.mock('@lobechat/observability-otel/api', () => ({
+  context: { with: vi.fn((_ctx: any, fn: () => any) => fn()) },
+}));
+
+vi.mock('@/libs/oidc-provider/jwt', () => ({
+  validateOIDCJWT: vi.fn(),
+}));
+
+vi.mock('@/envs/auth', () => ({
+  LOBE_CHAT_OIDC_AUTH_HEADER: 'Oidc-Auth',
+}));
+
 describe('checkAuth', () => {
   const mockHandler: RequestHandler = vi.fn();
   const mockRequest = new Request('https://example.com');
@@ -35,6 +65,7 @@ describe('checkAuth', () => {
 
   afterEach(() => {
     vi.resetAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('should return error response on checkAuthMethod error (no session)', async () => {
@@ -50,5 +81,68 @@ describe('checkAuth', () => {
       provider: 'mock',
     });
     expect(mockHandler).not.toHaveBeenCalled();
+  });
+
+  describe('mock dev user', () => {
+    it('should use MOCK_DEV_USER_ID when ENABLE_MOCK_DEV_USER is enabled', async () => {
+      vi.stubEnv('NODE_ENV', 'development');
+      vi.stubEnv('ENABLE_MOCK_DEV_USER', '1');
+      vi.stubEnv('MOCK_DEV_USER_ID', 'mock-user-123');
+
+      await checkAuth(mockHandler)(mockRequest, mockOptions);
+
+      expect(mockHandler).toHaveBeenCalledWith(
+        expect.any(Request),
+        expect.objectContaining({
+          jwtPayload: { userId: 'mock-user-123' },
+          userId: 'mock-user-123',
+        }),
+      );
+    });
+
+    it('should fall back to DEV_USER when MOCK_DEV_USER_ID is not set', async () => {
+      vi.stubEnv('NODE_ENV', 'development');
+      vi.stubEnv('ENABLE_MOCK_DEV_USER', '1');
+      delete process.env.MOCK_DEV_USER_ID;
+
+      await checkAuth(mockHandler)(mockRequest, mockOptions);
+
+      expect(mockHandler).toHaveBeenCalledWith(
+        expect.any(Request),
+        expect.objectContaining({
+          jwtPayload: { userId: 'DEV_USER' },
+          userId: 'DEV_USER',
+        }),
+      );
+    });
+
+    it('should use MOCK_DEV_USER_ID with debug header', async () => {
+      vi.stubEnv('NODE_ENV', 'development');
+      vi.stubEnv('MOCK_DEV_USER_ID', 'mock-user-456');
+
+      const debugRequest = new Request('https://example.com', {
+        headers: { 'lobe-auth-dev-backend-api': '1' },
+      });
+
+      await checkAuth(mockHandler)(debugRequest, mockOptions);
+
+      expect(mockHandler).toHaveBeenCalledWith(
+        expect.any(Request),
+        expect.objectContaining({
+          jwtPayload: { userId: 'mock-user-456' },
+          userId: 'mock-user-456',
+        }),
+      );
+    });
+
+    it('should not mock user in production', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      vi.stubEnv('ENABLE_MOCK_DEV_USER', '1');
+      vi.stubEnv('MOCK_DEV_USER_ID', 'mock-user-123');
+
+      await checkAuth(mockHandler)(mockRequest, mockOptions);
+
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/(backend)/middleware/auth/index.ts
+++ b/src/app/(backend)/middleware/auth/index.ts
@@ -35,12 +35,14 @@ export const checkAuth =
 
     // we have a special header to debug the api endpoint in development mode
     const isDebugApi = req.headers.get('lobe-auth-dev-backend-api') === '1';
-    if (process.env.NODE_ENV === 'development' && isDebugApi) {
+    const isMockUser = process.env.ENABLE_MOCK_DEV_USER === '1';
+    if (process.env.NODE_ENV === 'development' && (isDebugApi || isMockUser)) {
+      const mockUserId = process.env.MOCK_DEV_USER_ID || 'DEV_USER';
       return handler(clonedReq, {
         ...options,
-        jwtPayload: { userId: 'DEV_USER' },
+        jwtPayload: { userId: mockUserId },
         serverDB,
-        userId: 'DEV_USER',
+        userId: mockUserId,
       });
     }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Both `checkAuth` (webapi routes) and `userAuthMiddleware` (OpenAPI Hono routes) now respect `ENABLE_MOCK_DEV_USER` env var and read `MOCK_DEV_USER_ID` instead of hardcoding `'DEV_USER'`, aligning with the existing tRPC lambda context behavior.

Previously:
- `checkAuth` only triggered mock user via the `lobe-auth-dev-backend-api` debug header, and hardcoded `userId: 'DEV_USER'`
- `userAuthMiddleware` only triggered mock user via the debug header

Now both middlewares also check `ENABLE_MOCK_DEV_USER === '1'` and use `process.env.MOCK_DEV_USER_ID` (with `'DEV_USER'` fallback).

#### 🧪 How to Test

- [x] Added/updated tests

Unit tests added for `checkAuth` covering:
- `ENABLE_MOCK_DEV_USER=1` uses `MOCK_DEV_USER_ID`
- Fallback to `'DEV_USER'` when `MOCK_DEV_USER_ID` is not set
- Debug header still works with `MOCK_DEV_USER_ID`
- Production environment is not affected