### PR TITLE
🔨 chore: generate JWT token for Gateway WebSocket auth in execAgent

### DIFF
--- a/packages/types/src/agentExecution/index.ts
+++ b/packages/types/src/agentExecution/index.ts
@@ -70,6 +70,8 @@ export interface ExecAgentResult {
   success: boolean;
   /** ISO timestamp */
   timestamp: string;
+  /** Short-lived JWT token for Gateway WebSocket authentication */
+  token?: string;
   /** The topic ID (created or reused) */
   topicId: string;
   /** The user message ID created for this operation */

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -41,6 +41,7 @@ import { TopicModel } from '@/database/models/topic';
 import { UserModel } from '@/database/models/user';
 import { UserPersonaModel } from '@/database/models/userMemory/persona';
 import { shouldEnableBuiltinSkill } from '@/helpers/skillFilters';
+import { signUserJWT } from '@/libs/trpc/utils/internalJwt';
 import {
   createServerAgentToolsEngine,
   type EvalContext,
@@ -1075,6 +1076,14 @@ export class AiAgentService {
 
       log('execAgent: created operation %s (autoStarted: %s)', operationId, result.autoStarted);
 
+      // Generate a short-lived JWT for Gateway WebSocket authentication
+      let gatewayToken: string | undefined;
+      try {
+        gatewayToken = await signUserJWT(this.userId);
+      } catch {
+        log('execAgent: failed to sign gateway JWT, gateway auth will be unavailable');
+      }
+
       return {
         agentId: resolvedAgentId,
         assistantMessageId: assistantMessageRecord.id,
@@ -1086,6 +1095,7 @@ export class AiAgentService {
         status: 'created',
         success: true,
         timestamp: new Date().toISOString(),
+        token: gatewayToken,
         topicId,
         userMessageId: userMessageRecord?.id ?? parentMessageId ?? '',
       };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Fixes LOBE-6874

#### 🔀 Description of Change

Generate a short-lived RS256 JWT token (`signUserJWT(userId)`) when creating an agent operation via `execAgent`, and return it in `ExecAgentResult.token`. This allows the client to authenticate with the Agent Gateway WebSocket connection.

**Changes:**
- `packages/types/src/agentExecution/index.ts` — Added optional `token` field to `ExecAgentResult`
- `src/server/services/aiAgent/index.ts` — Call `signUserJWT(this.userId)` in `execAgent` and include the token in the response. Wrapped in try-catch so JWT signing failure doesn't block operation creation.

#### 🧪 How to Test

- [x] No tests needed

Token generation relies on `JWKS_KEY` env var being set. When not set, `signUserJWT` throws and the token field is simply omitted (graceful degradation).

#### 📝 Additional Information

This is a prerequisite for the Gateway multi-step streaming display (LOBE-6874). The client will pass this token to `connectToGateway()` for WebSocket authentication with the Agent Gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)