### PR TITLE
🔨 chore: remove redundant update-status call from GatewayStreamNotifier

### DIFF
--- a/src/server/modules/AgentRuntime/GatewayStreamNotifier.ts
+++ b/src/server/modules/AgentRuntime/GatewayStreamNotifier.ts
@@ -96,14 +96,6 @@ export class GatewayStreamNotifier implements IStreamEventManager {
       type: 'agent_runtime_end',
     });
 
-    const status =
-      reason === 'error' ? 'error' : reason === 'interrupted' ? 'interrupted' : 'completed';
-    this.httpPost('/api/operations/update-status', {
-      operationId,
-      status,
-      summary: reasonDetail,
-    });
-
     return result;
   }
 

--- a/src/server/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
@@ -144,27 +144,15 @@ describe('GatewayStreamNotifier', () => {
       ]);
     });
 
-    it('calls gateway push-event and update-status endpoints', async () => {
+    it('calls gateway push-event endpoint only (no update-status)', async () => {
       await notifier.publishAgentRuntimeEnd('op-1', 2, {}, 'completed', 'All done');
 
       await new Promise((r) => setTimeout(r, 50));
 
       const urls = mockFetch.mock.calls.map((c: any[]) => c[0]);
       expect(urls).toContain(`${gatewayUrl}/api/operations/push-event`);
-      expect(urls).toContain(`${gatewayUrl}/api/operations/update-status`);
-    });
-
-    it('maps error reason to error status', async () => {
-      await notifier.publishAgentRuntimeEnd('op-1', 0, {}, 'error', 'Something broke');
-
-      await new Promise((r) => setTimeout(r, 50));
-
-      const statusCall = mockFetch.mock.calls.find(
-        (c: any[]) => c[0] === `${gatewayUrl}/api/operations/update-status`,
-      );
-      expect(statusCall).toBeDefined();
-      const body = JSON.parse(statusCall![1].body);
-      expect(body.status).toBe('error');
+      // Gateway handles session completion directly in pushEvent on agent_runtime_end
+      expect(urls).not.toContain(`${gatewayUrl}/api/operations/update-status`);
     });
   });
 


### PR DESCRIPTION
## Summary
- Remove the separate `update-status` HTTP call from `GatewayStreamNotifier.publishAgentRuntimeEnd`
- Gateway now handles session completion directly in `pushEvent` when it receives `agent_runtime_end` event
- Fixes gateway session stuck in "running" status when the `update-status` fire-and-forget request fails silently

## Root cause
`GatewayStreamNotifier` was sending two independent fire-and-forget HTTP requests on agent completion:
1. `push-event` with `agent_runtime_end` event
2. `update-status` with `completed` status

If request 2 failed (timeout, network issue), the gateway session would stay in "running" forever. Now the gateway detects `agent_runtime_end` in the push-event handler and completes the session atomically.

## Test plan
- [x] Gateway auto-completes session on `agent_runtime_end` push event
- [x] No separate `update-status` call needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)