### PR TITLE
💰 chore: adjust Seedance 2.0 pricing with 20% service fee

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/video.ts
+++ b/packages/model-bank/src/aiModels/lobehub/video.ts
@@ -76,11 +76,11 @@ export const lobehubVideoModels: AIVideoModelCard[] = [
     organization: 'ByteDance',
     parameters: seedance20Params,
     pricing: {
-      approximatePricePerVideo: 0.75,
+      approximatePricePerVideo: 0.82,
       units: [
         {
           name: 'videoGeneration',
-          rate: 6.9,
+          rate: 7.56,
           strategy: 'fixed',
           unit: 'millionTokens',
         },
@@ -98,11 +98,11 @@ export const lobehubVideoModels: AIVideoModelCard[] = [
     organization: 'ByteDance',
     parameters: seedance20Params,
     pricing: {
-      approximatePricePerVideo: 0.6,
+      approximatePricePerVideo: 0.66,
       units: [
         {
           name: 'videoGeneration',
-          rate: 5.55,
+          rate: 6.08,
           strategy: 'fixed',
           unit: 'millionTokens',
         },


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

Follow-up to https://github.com/lobehub/lobehub/pull/13663

#### 🔀 Description of Change

Adjust Seedance 2.0 & 2.0 Fast LobeHub-hosted pricing from cost price to CNY/7.3*1.2 (20% service fee):

| Model | rate (USD/M tokens) | approxPerVideo |
|-------|-----|-----|
| 2.0 | 6.9 → 7.56 | 0.75 → 0.82 |
| 2.0 fast | 5.55 → 6.08 | 0.60 → 0.66 |

#### 🧪 How to Test

- [x] No tests needed