### PR TITLE
i18n: add gatewayMode translations for labs

### DIFF
--- a/locales/en-US/labs.json
+++ b/locales/en-US/labs.json
@@ -1,6 +1,8 @@
 {
   "features.assistantMessageGroup.desc": "Group agent messages and their tool call results together for display",
   "features.assistantMessageGroup.title": "Agent Message Grouping",
+  "features.gatewayMode.desc": "Execute agent tasks on the server via Gateway WebSocket instead of running locally. Enables faster execution and reduces client resource usage.",
+  "features.gatewayMode.title": "Server-Side Agent Execution (Gateway)",
   "features.groupChat.desc": "Enable multi-agent group chat coordination.",
   "features.groupChat.title": "Group Chat (Multi-Agent)",
   "features.inputMarkdown.desc": "Render Markdown in the input area in real time (bold text, code blocks, tables, etc.).",

--- a/locales/zh-CN/labs.json
+++ b/locales/zh-CN/labs.json
@@ -1,7 +1,7 @@
 {
   "features.assistantMessageGroup.desc": "将代理消息及其工具调用结果组合在一起显示",
   "features.assistantMessageGroup.title": "代理消息分组",
-  "features.gatewayMode.desc": "通过 Gateway WebSocket 在服务端执行代理任务，而非在本地运行。可实现更快的执行速度并减少客户端资源占用。",
+  "features.gatewayMode.desc": "通过 Gateway 在服务端执行 Agent 任务。可实现关闭浏览器后仍然执行 agent。",
   "features.gatewayMode.title": "服务端代理执行（Gateway）",
   "features.groupChat.desc": "启用多代理协同群聊功能。",
   "features.groupChat.title": "群聊（多代理）",

--- a/locales/zh-CN/labs.json
+++ b/locales/zh-CN/labs.json
@@ -1,6 +1,8 @@
 {
   "features.assistantMessageGroup.desc": "将代理消息及其工具调用结果组合在一起显示",
   "features.assistantMessageGroup.title": "代理消息分组",
+  "features.gatewayMode.desc": "通过 Gateway WebSocket 在服务端执行代理任务，而非在本地运行。可实现更快的执行速度并减少客户端资源占用。",
+  "features.gatewayMode.title": "服务端代理执行（Gateway）",
   "features.groupChat.desc": "启用多代理协同群聊功能。",
   "features.groupChat.title": "群聊（多代理）",
   "features.inputMarkdown.desc": "在输入区域实时渲染 Markdown（粗体、代码块、表格等）",


### PR DESCRIPTION
## Summary
- Add `features.gatewayMode.title` and `features.gatewayMode.desc` translations to zh-CN and en-US

🤖 Generated with [Claude Code](https://claude.com/claude-code)