### PR TITLE
🐛 fix(database): prevent IDOR in addFilesToKnowledgeBase

### DIFF
--- a/packages/database/src/models/__tests__/knowledgeBase.test.ts
+++ b/packages/database/src/models/__tests__/knowledgeBase.test.ts
@@ -293,6 +293,110 @@ describe('KnowledgeBaseModel', () => {
       expect(addedFiles).toHaveLength(0);
     });
 
+    it("should NOT allow adding files to another user's knowledge base (IDOR)", async () => {
+      // Setup: victim creates a knowledge base
+      const victimModel = new KnowledgeBaseModel(serverDB, 'user2');
+      const { id: victimKbId } = await victimModel.create({ name: 'Victim KB' });
+
+      // Setup: attacker uploads their own file
+      await serverDB.insert(globalFiles).values([
+        {
+          hashId: 'hash_attacker',
+          url: 'https://example.com/malicious.pdf',
+          size: 1000,
+          fileType: 'application/pdf',
+          creator: userId,
+        },
+      ]);
+      await serverDB.insert(files).values([
+        {
+          id: 'file_attacker',
+          name: 'malicious.pdf',
+          url: 'https://example.com/malicious.pdf',
+          fileHash: 'hash_attacker',
+          size: 1000,
+          fileType: 'application/pdf',
+          userId, // attacker's file
+        },
+      ]);
+
+      // Attack: attacker tries to add their file to victim's knowledge base
+      const result = await knowledgeBaseModel.addFilesToKnowledgeBase(victimKbId, [
+        'file_attacker',
+      ]);
+
+      // The operation should be rejected - no files should be inserted
+      expect(result).toHaveLength(0);
+
+      // Verify no files were added to victim's knowledge base
+      const kbFiles = await serverDB.query.knowledgeBaseFiles.findMany({
+        where: eq(knowledgeBaseFiles.knowledgeBaseId, victimKbId),
+      });
+      expect(kbFiles).toHaveLength(0);
+    });
+
+    it("should NOT allow adding documents to another user's knowledge base (IDOR)", async () => {
+      // Setup: victim creates a knowledge base
+      const victimModel = new KnowledgeBaseModel(serverDB, 'user2');
+      const { id: victimKbId } = await victimModel.create({ name: 'Victim KB' });
+
+      // Setup: attacker has a document with a mirror file
+      await serverDB.insert(globalFiles).values([
+        {
+          hashId: 'hash_attacker_doc',
+          url: 'https://example.com/malicious_doc.pdf',
+          size: 1000,
+          fileType: 'application/pdf',
+          creator: userId,
+        },
+      ]);
+      await serverDB.insert(files).values([
+        {
+          id: 'file_attacker_doc',
+          name: 'malicious_doc.pdf',
+          url: 'https://example.com/malicious_doc.pdf',
+          fileHash: 'hash_attacker_doc',
+          size: 1000,
+          fileType: 'application/pdf',
+          userId,
+        },
+      ]);
+      await serverDB.insert(documents).values([
+        {
+          id: 'docs_attacker',
+          title: 'Malicious Document',
+          content: 'Injected content',
+          fileType: 'application/pdf',
+          totalCharCount: 100,
+          totalLineCount: 10,
+          sourceType: 'file',
+          source: 'malicious.pdf',
+          fileId: 'file_attacker_doc',
+          userId,
+        },
+      ]);
+
+      // Attack: attacker tries to add their document to victim's knowledge base
+      const result = await knowledgeBaseModel.addFilesToKnowledgeBase(victimKbId, [
+        'docs_attacker',
+      ]);
+
+      // The operation should be rejected
+      expect(result).toHaveLength(0);
+
+      // Verify no files were added to victim's knowledge base
+      const kbFiles = await serverDB.query.knowledgeBaseFiles.findMany({
+        where: eq(knowledgeBaseFiles.knowledgeBaseId, victimKbId),
+      });
+      expect(kbFiles).toHaveLength(0);
+
+      // Verify the document's knowledgeBaseId was NOT updated to victim's KB
+      const doc = await serverDB.query.documents.findFirst({
+        where: eq(documents.id, 'docs_attacker'),
+      });
+      expect(doc?.knowledgeBaseId).toBeNull();
+    });
+
     it('should handle mixed document IDs and file IDs', async () => {
       await serverDB.insert(globalFiles).values([
         {

--- a/packages/database/src/models/knowledgeBase.ts
+++ b/packages/database/src/models/knowledgeBase.ts
@@ -26,6 +26,12 @@ export class KnowledgeBaseModel {
   };
 
   addFilesToKnowledgeBase = async (id: string, fileIds: string[]) => {
+    // Verify the target knowledge base belongs to the current user
+    const kb = await this.db.query.knowledgeBases.findFirst({
+      where: and(eq(knowledgeBases.id, id), eq(knowledgeBases.userId, this.userId)),
+    });
+    if (!kb) return [];
+
     // Separate document IDs from file IDs
     const documentIds = fileIds.filter((id) => id.startsWith('docs_'));
     const directFileIds = fileIds.filter((id) => !id.startsWith('docs_'));


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to GHSA-f9hf-w38v-9g4p

#### 🔀 Description of Change

Fix an Insecure Direct Object Reference (IDOR) vulnerability in `addFilesToKnowledgeBase`. The method previously verified file ownership but did not check whether the target knowledge base belonged to the authenticated user, allowing an attacker to inject files into any other user's knowledge base.

**Fix**: Added an ownership check at the start of `addFilesToKnowledgeBase` that verifies the target `knowledgeBaseId` belongs to `this.userId` before proceeding. Returns an empty array if the knowledge base is not owned by the current user.

#### 🧪 How to Test

- [x] Added/updated tests

Two regression tests added:
1. Attacker cannot add files to another user's knowledge base
2. Attacker cannot add documents (docs_ prefix) to another user's knowledge base

#### 📝 Additional Information

- **CWE-639**: Authorization Bypass Through User-Controlled Key
- **CVSS**: 6.5 (Medium) — `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N`
- Impact: Data pollution via RAG and indirect prompt injection