### PR TITLE
🔨 chore: Gateway reconnect after page reload

### DIFF
--- a/locales/en-US/auth.json
+++ b/locales/en-US/auth.json
@@ -196,7 +196,7 @@
   "profile.usernameTooLong": "Username cannot exceed 64 characters",
   "profile.usernameUpdateFailed": "Failed to update username, please try again later",
   "signin.subtitle": "Sign up or log in to your {{appName}} account",
-  "signin.title": "Agent teammates \nthat grow with you",
+  "signin.title": "Agent teammates that grow with you",
   "signout": "Log Out",
   "signup": "Sign Up",
   "stats.aiheatmaps": "Activity Index",

--- a/locales/en-US/auth.json
+++ b/locales/en-US/auth.json
@@ -196,7 +196,7 @@
   "profile.usernameTooLong": "Username cannot exceed 64 characters",
   "profile.usernameUpdateFailed": "Failed to update username, please try again later",
   "signin.subtitle": "Sign up or log in to your {{appName}} account",
-  "signin.title": "Agent teammates that grow with you",
+  "signin.title": "Agent teammates \nthat grow with you",
   "signout": "Log Out",
   "signup": "Sign Up",
   "stats.aiheatmaps": "Activity Index",

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -57,6 +57,8 @@ export interface ChatTopicMetadata {
   runningOperation?: {
     assistantMessageId: string;
     operationId: string;
+    scope?: string;
+    threadId?: string | null;
   } | null;
   userMemoryExtractRunState?: TopicUserMemoryExtractRunState;
   userMemoryExtractStatus?: 'pending' | 'completed' | 'failed';

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -49,6 +49,15 @@ export interface ChatTopicMetadata {
   cronJobId?: string;
   model?: string;
   provider?: string;
+  /**
+   * Currently running Gateway operation on this topic.
+   * Set when agent execution starts, cleared when it completes/fails.
+   * Used to reconnect WebSocket after page reload.
+   */
+  runningOperation?: {
+    assistantMessageId: string;
+    operationId: string;
+  } | null;
   userMemoryExtractRunState?: TopicUserMemoryExtractRunState;
   userMemoryExtractStatus?: 'pending' | 'completed' | 'failed';
   /**

--- a/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
@@ -18,6 +18,7 @@ import MessageFromUrl from './MainChatInput/MessageFromUrl';
 import ThreadHydration from './ThreadHydration';
 import { useActionsBarConfig } from './useActionsBarConfig';
 import { useAgentContext } from './useAgentContext';
+import { useGatewayReconnect } from './useGatewayReconnect';
 
 const log = debug('lobe-render:agent:ConversationArea');
 
@@ -45,6 +46,9 @@ const Conversation = memo(() => {
 
   // Get actionsBar config with branching support from ChatStore
   const actionsBarConfig = useActionsBarConfig();
+
+  // Auto-reconnect to running Gateway operation on topic load
+  useGatewayReconnect(context.topicId);
 
   return (
     <ConversationProvider

--- a/src/routes/(main)/agent/features/Conversation/useGatewayReconnect.ts
+++ b/src/routes/(main)/agent/features/Conversation/useGatewayReconnect.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import useSWR from 'swr';
 
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
@@ -7,39 +7,39 @@ import { topicSelectors } from '@/store/chat/selectors';
  * Hook that detects a running Gateway operation on the current topic
  * and automatically reconnects the WebSocket after page reload.
  *
- * Subscribes to the topic's runningOperation metadata so it triggers
- * even when topic data arrives asynchronously from SWR.
+ * Uses SWR to manage the reconnect lifecycle — it only fires when
+ * runningOperation exists and deduplicates by operationId.
  */
 export const useGatewayReconnect = (topicId?: string | null) => {
-  const reconnectedRef = useRef<Set<string>>(new Set());
-
-  const reconnectToGatewayOperation = useChatStore((s) => s.reconnectToGatewayOperation);
   const isGatewayModeEnabled = useChatStore((s) => s.isGatewayModeEnabled);
 
-  // Subscribe to the topic's runningOperation so the effect re-fires
-  // when topic metadata arrives from SWR (initially empty on page load)
+  // Subscribe to topic's runningOperation — re-evaluates when topic data arrives from SWR
   const runningOperation = useChatStore((s) =>
     topicId ? topicSelectors.getTopicById(topicId)(s)?.metadata?.runningOperation : undefined,
   );
 
-  useEffect(() => {
-    if (!topicId || !runningOperation || !isGatewayModeEnabled()) return;
+  // SWR key is the operationId — null key means no fetch
+  // This naturally deduplicates: same operationId = same key = no re-fetch
+  useSWR(
+    runningOperation && isGatewayModeEnabled()
+      ? ['reconnectGateway', runningOperation.operationId]
+      : null,
+    async () => {
+      if (!runningOperation || !topicId) return;
 
-    // Skip if already reconnected to this operation
-    if (reconnectedRef.current.has(runningOperation.operationId)) return;
-
-    // Mark as reconnected to avoid duplicate connections
-    reconnectedRef.current.add(runningOperation.operationId);
-
-    reconnectToGatewayOperation({
-      assistantMessageId: runningOperation.assistantMessageId,
-      operationId: runningOperation.operationId,
-      scope: runningOperation.scope,
-      threadId: runningOperation.threadId,
-      topicId,
-    }).catch((e) => {
-      console.error('[GatewayReconnect] Failed to reconnect:', e);
-      reconnectedRef.current.delete(runningOperation.operationId);
-    });
-  }, [topicId, runningOperation, isGatewayModeEnabled, reconnectToGatewayOperation]);
+      await useChatStore.getState().reconnectToGatewayOperation({
+        assistantMessageId: runningOperation.assistantMessageId,
+        operationId: runningOperation.operationId,
+        scope: runningOperation.scope,
+        threadId: runningOperation.threadId,
+        topicId,
+      });
+    },
+    {
+      // Don't revalidate on focus/reconnect — one attempt is enough
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    },
+  );
 };

--- a/src/routes/(main)/agent/features/Conversation/useGatewayReconnect.ts
+++ b/src/routes/(main)/agent/features/Conversation/useGatewayReconnect.ts
@@ -6,6 +6,9 @@ import { topicSelectors } from '@/store/chat/selectors';
 /**
  * Hook that detects a running Gateway operation on the current topic
  * and automatically reconnects the WebSocket after page reload.
+ *
+ * Subscribes to the topic's runningOperation metadata so it triggers
+ * even when topic data arrives asynchronously from SWR.
  */
 export const useGatewayReconnect = (topicId?: string | null) => {
   const reconnectedRef = useRef<Set<string>>(new Set());
@@ -13,28 +16,30 @@ export const useGatewayReconnect = (topicId?: string | null) => {
   const reconnectToGatewayOperation = useChatStore((s) => s.reconnectToGatewayOperation);
   const isGatewayModeEnabled = useChatStore((s) => s.isGatewayModeEnabled);
 
+  // Subscribe to the topic's runningOperation so the effect re-fires
+  // when topic metadata arrives from SWR (initially empty on page load)
+  const runningOperation = useChatStore((s) =>
+    topicId ? topicSelectors.getTopicById(topicId)(s)?.metadata?.runningOperation : undefined,
+  );
+
   useEffect(() => {
-    if (!topicId || !isGatewayModeEnabled()) return;
+    if (!topicId || !runningOperation || !isGatewayModeEnabled()) return;
 
-    // Skip if already reconnected to this topic's operation
-    if (reconnectedRef.current.has(topicId)) return;
-
-    const topic = topicSelectors.getTopicById(topicId)(useChatStore.getState());
-    const runningOp = topic?.metadata?.runningOperation;
-
-    if (!runningOp) return;
+    // Skip if already reconnected to this operation
+    if (reconnectedRef.current.has(runningOperation.operationId)) return;
 
     // Mark as reconnected to avoid duplicate connections
-    reconnectedRef.current.add(topicId);
+    reconnectedRef.current.add(runningOperation.operationId);
 
     reconnectToGatewayOperation({
-      assistantMessageId: runningOp.assistantMessageId,
-      operationId: runningOp.operationId,
+      assistantMessageId: runningOperation.assistantMessageId,
+      operationId: runningOperation.operationId,
+      scope: runningOperation.scope,
+      threadId: runningOperation.threadId,
       topicId,
     }).catch((e) => {
       console.error('[GatewayReconnect] Failed to reconnect:', e);
-      // Remove from reconnected set so it can be retried
-      reconnectedRef.current.delete(topicId);
+      reconnectedRef.current.delete(runningOperation.operationId);
     });
-  }, [topicId, isGatewayModeEnabled, reconnectToGatewayOperation]);
+  }, [topicId, runningOperation, isGatewayModeEnabled, reconnectToGatewayOperation]);
 };

--- a/src/routes/(main)/agent/features/Conversation/useGatewayReconnect.ts
+++ b/src/routes/(main)/agent/features/Conversation/useGatewayReconnect.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react';
+
+import { useChatStore } from '@/store/chat';
+import { topicSelectors } from '@/store/chat/selectors';
+
+/**
+ * Hook that detects a running Gateway operation on the current topic
+ * and automatically reconnects the WebSocket after page reload.
+ */
+export const useGatewayReconnect = (topicId?: string | null) => {
+  const reconnectedRef = useRef<Set<string>>(new Set());
+
+  const reconnectToGatewayOperation = useChatStore((s) => s.reconnectToGatewayOperation);
+  const isGatewayModeEnabled = useChatStore((s) => s.isGatewayModeEnabled);
+
+  useEffect(() => {
+    if (!topicId || !isGatewayModeEnabled()) return;
+
+    // Skip if already reconnected to this topic's operation
+    if (reconnectedRef.current.has(topicId)) return;
+
+    const topic = topicSelectors.getTopicById(topicId)(useChatStore.getState());
+    const runningOp = topic?.metadata?.runningOperation;
+
+    if (!runningOp) return;
+
+    // Mark as reconnected to avoid duplicate connections
+    reconnectedRef.current.add(topicId);
+
+    reconnectToGatewayOperation({
+      assistantMessageId: runningOp.assistantMessageId,
+      operationId: runningOp.operationId,
+      topicId,
+    }).catch((e) => {
+      console.error('[GatewayReconnect] Failed to reconnect:', e);
+      // Remove from reconnected set so it can be retried
+      reconnectedRef.current.delete(topicId);
+    });
+  }, [topicId, isGatewayModeEnabled, reconnectToGatewayOperation]);
+};

--- a/src/server/routers/lambda/aiAgent.ts
+++ b/src/server/routers/lambda/aiAgent.ts
@@ -1225,4 +1225,18 @@ export const aiAgentRouter = router({
         });
       }
     }),
+
+  /**
+   * Refresh Gateway JWT token for an existing operation.
+   * Used when reconnecting after page reload (original token expired).
+   */
+  refreshGatewayToken: aiAgentProcedure.query(async ({ ctx }) => {
+    // Sign a fresh JWT for Gateway WebSocket authentication.
+    // The token is scoped to the authenticated user (ctx.userId),
+    // and the Gateway validates payload.sub matches the stored userId.
+    const { signUserJWT } = await import('@/libs/trpc/utils/internalJwt');
+    const token = await signUserJWT(ctx.userId);
+
+    return { token };
+  }),
 });

--- a/src/server/routers/lambda/aiAgent.ts
+++ b/src/server/routers/lambda/aiAgent.ts
@@ -1230,13 +1230,22 @@ export const aiAgentRouter = router({
    * Refresh Gateway JWT token for an existing operation.
    * Used when reconnecting after page reload (original token expired).
    */
-  refreshGatewayToken: aiAgentProcedure.query(async ({ ctx }) => {
-    // Sign a fresh JWT for Gateway WebSocket authentication.
-    // The token is scoped to the authenticated user (ctx.userId),
-    // and the Gateway validates payload.sub matches the stored userId.
-    const { signUserJWT } = await import('@/libs/trpc/utils/internalJwt');
-    const token = await signUserJWT(ctx.userId);
+  refreshGatewayToken: aiAgentProcedure
+    .input(z.object({ topicId: z.string() }))
+    .query(async ({ input, ctx }) => {
+      // Verify the topic belongs to this user and has a running operation
+      const topic = await ctx.topicModel.findById(input.topicId);
 
-    return { token };
-  }),
+      if (!topic?.metadata?.runningOperation) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'No running operation found on this topic',
+        });
+      }
+
+      const { signUserJWT } = await import('@/libs/trpc/utils/internalJwt');
+      const token = await signUserJWT(ctx.userId);
+
+      return { token };
+    }),
 });

--- a/src/server/routers/lambda/topic.ts
+++ b/src/server/routers/lambda/topic.ts
@@ -563,6 +563,8 @@ export const topicRouter = router({
             .object({
               assistantMessageId: z.string(),
               operationId: z.string(),
+              scope: z.string().optional(),
+              threadId: z.string().nullable().optional(),
             })
             .nullable()
             .optional(),

--- a/src/server/routers/lambda/topic.ts
+++ b/src/server/routers/lambda/topic.ts
@@ -556,9 +556,16 @@ export const topicRouter = router({
       z.object({
         id: z.string(),
         metadata: z.object({
+          boundDeviceId: z.string().optional(),
           model: z.string().optional(),
           provider: z.string().optional(),
-          boundDeviceId: z.string().optional(),
+          runningOperation: z
+            .object({
+              assistantMessageId: z.string(),
+              operationId: z.string(),
+            })
+            .nullable()
+            .optional(),
           workingDirectory: z.string().optional(),
         }),
       }),

--- a/src/server/services/aiAgent/__tests__/execAgent.device.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.device.test.ts
@@ -366,7 +366,11 @@ describe('AiAgentService.execAgent - device auto-activation', () => {
 
       const createOpArgs = mockCreateOperation.mock.calls[0][0];
       expect(createOpArgs.activeDeviceId).toBe('device-001');
-      expect(topicMock.updateMetadata).not.toHaveBeenCalled();
+      // updateMetadata is called for runningOperation persistence, but not for device binding
+      expect(topicMock.updateMetadata).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ boundDeviceId: expect.anything() }),
+      );
     });
 
     it('should not reuse topic boundDeviceId when no explicit deviceId is provided', async () => {
@@ -492,7 +496,11 @@ describe('AiAgentService.execAgent - device auto-activation', () => {
         deviceId: 'device-002',
       });
 
-      expect(topicMock.updateMetadata).not.toHaveBeenCalled();
+      // updateMetadata is called for runningOperation persistence, but not for device binding
+      expect(topicMock.updateMetadata).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ boundDeviceId: expect.anything() }),
+      );
       const createOpArgs = mockCreateOperation.mock.calls[0][0];
       expect(createOpArgs.activeDeviceId).toBe('device-002');
     });

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -1081,6 +1081,8 @@ export class AiAgentService {
         runningOperation: {
           assistantMessageId: assistantMessageRecord.id,
           operationId,
+          scope: appContext?.scope ?? undefined,
+          threadId: appContext?.threadId ?? undefined,
         },
       });
 

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -1076,6 +1076,14 @@ export class AiAgentService {
 
       log('execAgent: created operation %s (autoStarted: %s)', operationId, result.autoStarted);
 
+      // Persist running operation to topic metadata for reconnect after page reload
+      await this.topicModel.updateMetadata(topicId, {
+        runningOperation: {
+          assistantMessageId: assistantMessageRecord.id,
+          operationId,
+        },
+      });
+
       // Generate a short-lived JWT for Gateway WebSocket authentication
       let gatewayToken: string | undefined;
       try {

--- a/src/services/aiAgent.ts
+++ b/src/services/aiAgent.ts
@@ -108,6 +108,13 @@ class AiAgentService {
    * - Group mode: pass groupId, Thread will be associated with the Group
    * - Single Agent mode: omit groupId, Thread will only be associated with the Agent
    */
+  /**
+   * Get a fresh JWT token for Gateway WebSocket reconnection.
+   */
+  async refreshGatewayToken(): Promise<{ token: string }> {
+    return await lambdaClient.aiAgent.refreshGatewayToken.query();
+  }
+
   async execSubAgentTask(params: ExecSubAgentTaskParams) {
     return await lambdaClient.aiAgent.execSubAgentTask.mutate(params);
   }

--- a/src/services/aiAgent.ts
+++ b/src/services/aiAgent.ts
@@ -111,8 +111,8 @@ class AiAgentService {
   /**
    * Get a fresh JWT token for Gateway WebSocket reconnection.
    */
-  async refreshGatewayToken(): Promise<{ token: string }> {
-    return await lambdaClient.aiAgent.refreshGatewayToken.query();
+  async refreshGatewayToken(topicId: string): Promise<{ token: string }> {
+    return await lambdaClient.aiAgent.refreshGatewayToken.query({ topicId });
   }
 
   async execSubAgentTask(params: ExecSubAgentTaskParams) {

--- a/src/services/topic/index.ts
+++ b/src/services/topic/index.ts
@@ -81,10 +81,11 @@ export class TopicService {
   updateTopicMetadata = (
     id: string,
     metadata: {
+      boundDeviceId?: string;
       model?: string;
       provider?: string;
+      runningOperation?: { assistantMessageId: string; operationId: string } | null;
       workingDirectory?: string;
-      boundDeviceId?: string;
     },
   ) => {
     return lambdaClient.topic.updateTopicMetadata.mutate({ id, metadata });

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -250,6 +250,56 @@ export class GatewayActionImpl {
     return result;
   };
 
+  /**
+   * Reconnect to an existing Gateway operation after page reload.
+   * Reads runningOperation from topic metadata, refreshes the JWT token,
+   * and establishes a new WebSocket connection with event replay.
+   */
+  reconnectToGatewayOperation = async (params: {
+    assistantMessageId: string;
+    operationId: string;
+    topicId: string;
+  }): Promise<void> => {
+    const { assistantMessageId, operationId, topicId } = params;
+
+    if (!this.isGatewayModeEnabled()) return;
+
+    const agentGatewayUrl =
+      window.global_serverConfigStore!.getState().serverConfig.agentGatewayUrl!;
+
+    // Get a fresh JWT token (original expired after 5 min)
+    const { token } = await aiAgentService.refreshGatewayToken();
+
+    const agentId = this.#get().activeAgentId;
+    const context = { agentId, topicId, scope: 'main' as const, threadId: null };
+
+    // Create a local operation for UI loading state
+    const { operationId: gatewayOpId } = this.#get().startOperation({
+      context,
+      type: 'execServerAgentRuntime',
+    });
+
+    this.#get().associateMessageWithOperation(assistantMessageId, gatewayOpId);
+
+    const eventHandler = createGatewayEventHandler(this.#get, {
+      assistantMessageId,
+      context,
+      operationId: gatewayOpId,
+    });
+
+    this.#get().connectToGateway({
+      gatewayUrl: agentGatewayUrl,
+      onEvent: eventHandler,
+      onSessionComplete: () => {
+        this.#get().completeOperation(gatewayOpId);
+        this.#get().internal_updateTopicLoading(topicId, false);
+        topicService.updateTopicMetadata(topicId, { runningOperation: null }).catch(() => {});
+      },
+      operationId,
+      token,
+    });
+  };
+
   private internal_cleanupGatewayConnection = (operationId: string): void => {
     this.#set(
       (state) => {

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -270,7 +270,7 @@ export class GatewayActionImpl {
       window.global_serverConfigStore!.getState().serverConfig.agentGatewayUrl!;
 
     // Get a fresh JWT token (original expired after 5 min)
-    const { token } = await aiAgentService.refreshGatewayToken();
+    const { token } = await aiAgentService.refreshGatewayToken(topicId);
 
     const agentId = this.#get().activeAgentId;
     const context = {

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -258,9 +258,11 @@ export class GatewayActionImpl {
   reconnectToGatewayOperation = async (params: {
     assistantMessageId: string;
     operationId: string;
+    scope?: string;
+    threadId?: string | null;
     topicId: string;
   }): Promise<void> => {
-    const { assistantMessageId, operationId, topicId } = params;
+    const { assistantMessageId, operationId, topicId, scope, threadId } = params;
 
     if (!this.isGatewayModeEnabled()) return;
 
@@ -271,7 +273,12 @@ export class GatewayActionImpl {
     const { token } = await aiAgentService.refreshGatewayToken();
 
     const agentId = this.#get().activeAgentId;
-    const context = { agentId, topicId, scope: 'main' as const, threadId: null };
+    const context = {
+      agentId,
+      scope: (scope ?? 'main') as ConversationContext['scope'],
+      threadId: threadId ?? null,
+      topicId,
+    };
 
     // Create a local operation for UI loading state
     const { operationId: gatewayOpId } = this.#get().startOperation({

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -7,6 +7,7 @@ import type {
 } from '@/libs/agent-stream';
 import { AgentStreamClient } from '@/libs/agent-stream/client';
 import { aiAgentService } from '@/services/aiAgent';
+import { topicService } from '@/services/topic';
 import type { ChatStore } from '@/store/chat/store';
 import type { StoreSetter } from '@/store/types';
 import { useUserStore } from '@/store/user';
@@ -233,7 +234,14 @@ export class GatewayActionImpl {
       onEvent: eventHandler,
       onSessionComplete: () => {
         this.#get().completeOperation(gatewayOpId);
-        if (result.topicId) this.#get().internal_updateTopicLoading(result.topicId, false);
+        if (result.topicId) {
+          this.#get().internal_updateTopicLoading(result.topicId, false);
+          // Clear running operation from topic metadata (best-effort from frontend;
+          // if browser was closed, reconnect logic will handle stale entries)
+          topicService
+            .updateTopicMetadata(result.topicId, { runningOperation: null })
+            .catch(() => {});
+        }
       },
       operationId: result.operationId,
       token: result.token || '',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

relative LOBE-6829, LOBE-6905, LOBE-6906, LOBE-6907

#### 🔀 Description of Change

**Gateway reconnect: resume agent execution after page reload/browser close.**

When a user closes the browser during Gateway agent execution, the agent continues running on the server. On reopening, the app automatically reconnects the WebSocket and resumes displaying the streaming output.

**How it works:**

1. **Persist** — `execAgent` writes `{ operationId, assistantMessageId }` to topic `metadata.runningOperation` when starting
2. **Detect** — `useGatewayReconnect` hook checks topic metadata when entering a topic
3. **Reconnect** — Calls `refreshGatewayToken` for a fresh JWT, then `reconnectToGatewayOperation` to establish WebSocket with `resume(lastEventId='')` which replays all buffered events (Gateway buffers up to 1000 events, 10 min TTL)
4. **Cleanup** — `onSessionComplete` clears `metadata.runningOperation`

**Changes:**
- `ChatTopicMetadata` — new `runningOperation` field
- `execAgent` — persists runningOperation to topic metadata
- `refreshGatewayToken` — new tRPC query endpoint (signs fresh JWT)
- `reconnectToGatewayOperation` — new GatewayActionImpl method
- `useGatewayReconnect` — hook wired into ConversationArea
- `updateTopicMetadata` — extended schema to support runningOperation

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

1. Enable Gateway mode in Labs
2. Send a web search message (takes ~60s)
3. Close the browser tab during execution
4. Reopen and navigate to the same topic
5. Should see the agent resume/complete with final results

🤖 Generated with [Claude Code](https://claude.com/claude-code)