### PR TITLE
🐛 fix: buffer and deduplicate events during gateway resume

### DIFF
--- a/src/libs/agent-stream/client.ts
+++ b/src/libs/agent-stream/client.ts
@@ -14,6 +14,7 @@ const INITIAL_RECONNECT_DELAY = 1000; // 1s
 const MAX_RECONNECT_DELAY = 30_000; // 30s
 const MAX_MISSED_HEARTBEATS = 3;
 const RESUME_FLUSH_DELAY = 500; // 500ms debounce after last resume event
+const RESUME_TIMEOUT = 3000; // 3s: if no events after resume request, session is already done
 
 // ─── Typed Event Emitter (browser-compatible, no node:events) ───
 
@@ -209,6 +210,17 @@ export class AgentStreamClient extends TypedEmitter {
           if (!this.lastEventId) {
             this.resumeMode = true;
             this.resumeBuffer = [];
+
+            // Safety timeout: if no events arrive after resume, the session has already
+            // completed and the DO has nothing to replay. Exit resume mode and signal completion.
+            this.resumeFlushTimer = setTimeout(() => {
+              if (this.resumeMode && this.resumeBuffer.length === 0) {
+                this.resumeMode = false;
+                this.sessionEnded = true;
+                this.emit('session_complete');
+                this.disconnect();
+              }
+            }, RESUME_TIMEOUT);
           }
 
           // Request all buffered events (covers events pushed before WS connected)

--- a/src/libs/agent-stream/client.ts
+++ b/src/libs/agent-stream/client.ts
@@ -13,6 +13,7 @@ const HEARTBEAT_INTERVAL = 30_000; // 30s
 const INITIAL_RECONNECT_DELAY = 1000; // 1s
 const MAX_RECONNECT_DELAY = 30_000; // 30s
 const MAX_MISSED_HEARTBEATS = 3;
+const RESUME_FLUSH_DELAY = 500; // 500ms debounce after last resume event
 
 // ─── Typed Event Emitter (browser-compatible, no node:events) ───
 
@@ -69,6 +70,12 @@ export class AgentStreamClient extends TypedEmitter {
   private intentionalDisconnect = false;
   private lastEventId = '';
   private sessionEnded = false;
+
+  // Resume buffering: when reconnecting with empty lastEventId, buffer events
+  // until resume replay completes, then deduplicate and emit in order.
+  private resumeBuffer: Array<{ event: AgentStreamEvent; id?: string }> = [];
+  private resumeMode = false;
+  private resumeFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
   private readonly gatewayUrl: string;
   private readonly operationId: string;
@@ -196,6 +203,14 @@ export class AgentStreamClient extends TypedEmitter {
         case 'auth_success': {
           this.setStatus('connected');
           this.startHeartbeat();
+
+          // Enter resume mode when reconnecting with no lastEventId (page reload).
+          // Buffer all events until resume replay completes, then deduplicate and emit.
+          if (!this.lastEventId) {
+            this.resumeMode = true;
+            this.resumeBuffer = [];
+          }
+
           // Request all buffered events (covers events pushed before WS connected)
           this.sendMessage({ lastEventId: this.lastEventId, type: 'resume' });
           this.emit('connected');
@@ -216,6 +231,20 @@ export class AgentStreamClient extends TypedEmitter {
         case 'agent_event': {
           const agentEvent: AgentStreamEvent = message.event;
           if (message.id) this.lastEventId = message.id;
+
+          if (this.resumeMode) {
+            // Buffer events during resume — will be deduplicated and emitted after replay
+            this.resumeBuffer.push({ event: agentEvent, id: message.id });
+            this.scheduleResumeFlush();
+
+            // Terminal events still end the session even in resume mode
+            if (agentEvent.type === 'agent_runtime_end' || agentEvent.type === 'error') {
+              this.sessionEnded = true;
+              this.flushResumeBuffer();
+              this.disconnect();
+            }
+            break;
+          }
 
           this.emit('agent_event', agentEvent);
 
@@ -322,6 +351,52 @@ export class AgentStreamClient extends TypedEmitter {
     this.emit('status_changed', status);
   }
 
+  // ─── Resume Buffering ───
+
+  /**
+   * Schedule a debounced flush of the resume buffer.
+   * Resume replay events arrive in rapid succession; once there's a 500ms gap,
+   * we consider the replay done and flush the deduplicated buffer.
+   */
+  private scheduleResumeFlush(): void {
+    if (this.resumeFlushTimer) clearTimeout(this.resumeFlushTimer);
+    this.resumeFlushTimer = setTimeout(() => {
+      this.flushResumeBuffer();
+    }, RESUME_FLUSH_DELAY);
+  }
+
+  /**
+   * Deduplicate buffered events by event ID and emit them in order.
+   */
+  private flushResumeBuffer(): void {
+    if (!this.resumeMode) return;
+    this.resumeMode = false;
+
+    if (this.resumeFlushTimer) {
+      clearTimeout(this.resumeFlushTimer);
+      this.resumeFlushTimer = null;
+    }
+
+    // Deduplicate by event ID, keeping the first occurrence (from resume replay)
+    const seen = new Set<string>();
+    const deduped: AgentStreamEvent[] = [];
+
+    for (const { event, id } of this.resumeBuffer) {
+      const key = id || `${event.type}_${event.stepIndex}_${event.timestamp}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        deduped.push(event);
+      }
+    }
+
+    this.resumeBuffer = [];
+
+    // Emit deduplicated events in order
+    for (const event of deduped) {
+      this.emit('agent_event', event);
+    }
+  }
+
   // ─── Helpers ───
 
   private sendMessage(data: ClientMessage): void {
@@ -349,5 +424,11 @@ export class AgentStreamClient extends TypedEmitter {
     this.stopHeartbeat();
     this.clearReconnectTimer();
     this.closeWebSocket();
+    if (this.resumeFlushTimer) {
+      clearTimeout(this.resumeFlushTimer);
+      this.resumeFlushTimer = null;
+    }
+    this.resumeMode = false;
+    this.resumeBuffer = [];
   }
 }

--- a/src/libs/agent-stream/client.ts
+++ b/src/libs/agent-stream/client.ts
@@ -270,6 +270,10 @@ export class AgentStreamClient extends TypedEmitter {
 
         case 'session_complete': {
           this.sessionEnded = true;
+          // Flush any buffered resume events before disconnecting
+          if (this.resumeMode) {
+            this.flushResumeBuffer();
+          }
           this.emit('session_complete');
           this.disconnect();
           break;

--- a/src/libs/agent-stream/client.ts
+++ b/src/libs/agent-stream/client.ts
@@ -81,6 +81,7 @@ export class AgentStreamClient extends TypedEmitter {
   private readonly gatewayUrl: string;
   private readonly operationId: string;
   private readonly autoReconnect: boolean;
+  private readonly resumeOnConnect: boolean;
   private token: string;
 
   constructor(options: AgentStreamClientOptions) {
@@ -89,6 +90,7 @@ export class AgentStreamClient extends TypedEmitter {
     this.operationId = options.operationId;
     this.token = options.token;
     this.autoReconnect = options.autoReconnect ?? true;
+    this.resumeOnConnect = options.resumeOnConnect ?? false;
   }
 
   // ─── Public API ───
@@ -205,9 +207,10 @@ export class AgentStreamClient extends TypedEmitter {
           this.setStatus('connected');
           this.startHeartbeat();
 
-          // Enter resume mode when reconnecting with no lastEventId (page reload).
+          // Enter resume mode only for explicit reconnect scenarios (page reload).
           // Buffer all events until resume replay completes, then deduplicate and emit.
-          if (!this.lastEventId) {
+          // This is NOT enabled for normal first-connect to avoid delaying live streaming.
+          if (this.resumeOnConnect && !this.lastEventId) {
             this.resumeMode = true;
             this.resumeBuffer = [];
 

--- a/src/libs/agent-stream/types.ts
+++ b/src/libs/agent-stream/types.ts
@@ -156,6 +156,13 @@ export interface AgentStreamClientOptions {
   gatewayUrl: string;
   /** Operation ID to subscribe to */
   operationId: string;
+  /**
+   * Enable resume buffering on first connect (default: false).
+   * When true, events are buffered and deduplicated after the resume replay
+   * completes, preventing out-of-order display during page-reload reconnect.
+   * Only set this for reconnection scenarios, not for new operations.
+   */
+  resumeOnConnect?: boolean;
   /** Auth token */
   token: string;
 }

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -1821,6 +1821,16 @@ export const createRuntimeExecutors = (
 
     log('[%s:%d] Finishing execution: (%s)', operationId, stepIndex, reason);
 
+    // Clear runningOperation from topic metadata so reconnect doesn't trigger after completion
+    if (ctx.topicId && ctx.userId) {
+      try {
+        const topicModel = new TopicModel(ctx.serverDB, ctx.userId);
+        await topicModel.updateMetadata(ctx.topicId, { runningOperation: null });
+      } catch (e) {
+        log('[%s] Failed to clear runningOperation metadata: %O', operationId, e);
+      }
+    }
+
     // Publish execution complete event
     await streamManager.publishStreamEvent(operationId, {
       data: {

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -203,12 +203,9 @@ export class GatewayActionImpl {
       prompt: message,
     });
 
-    // If server created a new topic, switch to it and clean up the _new key temp messages
+    // If server created a new topic, fetch messages first then switch topic
+    // (same pattern as client mode: replaceMessages before switchTopic to avoid skeleton flash)
     if (isCreateNewTopic && result.topicId) {
-      await this.#get().switchTopic(result.topicId, { clearNewKey: true });
-
-      // Eagerly fetch messages so the UI doesn't show a skeleton loading state
-      // while waiting for SWR to re-fetch after topic switch
       try {
         const newContext = { ...context, topicId: result.topicId };
         const messages = await messageService.getMessages(newContext);
@@ -216,6 +213,11 @@ export class GatewayActionImpl {
       } catch {
         /* non-critical */
       }
+
+      await this.#get().switchTopic(result.topicId, {
+        clearNewKey: true,
+        skipRefreshMessage: true,
+      });
     }
 
     // Use the server-created topicId for the execution context

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -7,6 +7,7 @@ import type {
 } from '@/libs/agent-stream';
 import { AgentStreamClient } from '@/libs/agent-stream/client';
 import { aiAgentService } from '@/services/aiAgent';
+import { messageService } from '@/services/message';
 import { topicService } from '@/services/topic';
 import type { ChatStore } from '@/store/chat/store';
 import type { StoreSetter } from '@/store/types';
@@ -205,6 +206,16 @@ export class GatewayActionImpl {
     // If server created a new topic, switch to it and clean up the _new key temp messages
     if (isCreateNewTopic && result.topicId) {
       await this.#get().switchTopic(result.topicId, { clearNewKey: true });
+
+      // Eagerly fetch messages so the UI doesn't show a skeleton loading state
+      // while waiting for SWR to re-fetch after topic switch
+      try {
+        const newContext = { ...context, topicId: result.topicId };
+        const messages = await messageService.getMessages(newContext);
+        this.#get().replaceMessages(messages, { context: newContext });
+      } catch {
+        /* non-critical */
+      }
     }
 
     // Use the server-created topicId for the execution context

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -42,6 +42,10 @@ export interface ConnectGatewayParams {
    */
   operationId: string;
   /**
+   * Enable resume buffering for reconnect scenarios (default: false)
+   */
+  resumeOnConnect?: boolean;
+  /**
    * Auth token for the Gateway
    */
   token: string;
@@ -68,12 +72,12 @@ export class GatewayActionImpl {
    * Creates an AgentStreamClient, manages its lifecycle, and wires up event callbacks.
    */
   connectToGateway = (params: ConnectGatewayParams): void => {
-    const { operationId, gatewayUrl, token, onEvent, onSessionComplete } = params;
+    const { operationId, gatewayUrl, token, onEvent, onSessionComplete, resumeOnConnect } = params;
 
     // Disconnect existing connection for this operation if any
     this.disconnectFromGateway(operationId);
 
-    const client = this.createClient({ gatewayUrl, operationId, token });
+    const client = this.createClient({ gatewayUrl, operationId, resumeOnConnect, token });
 
     // Track connection in store
     this.#set(
@@ -316,6 +320,7 @@ export class GatewayActionImpl {
         topicService.updateTopicMetadata(topicId, { runningOperation: null }).catch(() => {});
       },
       operationId,
+      resumeOnConnect: true,
       token,
     });
   };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Part of LOBE-6829

#### 🔀 Description of Change

When reconnecting with empty `lastEventId` (page reload), live broadcast events can arrive before resume replay completes, causing content to appear out of order — user sees current streaming content first, then the full replay from the beginning.

**Fix:** `AgentStreamClient` enters resume mode when `lastEventId` is empty. All `agent_event` messages are buffered. After a 500ms gap (resume replay is dense, live events are sparse), the buffer is deduplicated by event ID and emitted in correct order.

#### 🧪 How to Test

- [x] Tested locally

1. Enable Gateway mode, send a web search message
2. While agent is executing, close browser
3. Reopen and navigate to the topic
4. Content should appear in correct chronological order without jumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)