### PR TITLE
🌐 chore: update execServerAgentRuntime i18n copy

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -229,7 +229,7 @@
   "operation.contextCompression": "Context too long, compressing history...",
   "operation.execAgentRuntime": "Preparing response",
   "operation.execClientTask": "Executing task",
-  "operation.execServerAgentRuntime": "Running… You can switch tasks or close the page—I'll keep going.",
+  "operation.execServerAgentRuntime": "Preparing response (switching tasks or closing the page won't stop)",
   "operation.sendMessage": "Sending message",
   "owner": "Group owner",
   "pageCopilot.title": "Page Agent",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -229,7 +229,7 @@
   "operation.contextCompression": "上下文过长，正在压缩历史记录……",
   "operation.execAgentRuntime": "准备响应中",
   "operation.execClientTask": "执行任务中",
-  "operation.execServerAgentRuntime": "运行中…你可以切换任务或关闭页面，我会继续执行。",
+  "operation.execServerAgentRuntime": "准备响应中（切换任务或关闭页面都会继续执行）",
   "operation.sendMessage": "消息发送中",
   "owner": "群主",
   "pageCopilot.title": "文稿助理",


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🌐 i18n

#### 🔀 Description of Change

Update the `execServerAgentRuntime` operation i18n copy to be more user-friendly:

- **EN**: `"Preparing response (switching tasks or closing the page won't stop)"`
- **ZH**: `"准备响应中（切换任务或关闭页面都会继续执行）"`

#### 🧪 How to Test

- [x] No tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)