### PR TITLE
🔨 chore: extend execAgent with parentMessageId for Gateway regeneration/continue

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -229,7 +229,7 @@
   "operation.contextCompression": "Context too long, compressing history...",
   "operation.execAgentRuntime": "Preparing response",
   "operation.execClientTask": "Executing task",
-  "operation.execServerAgentRuntime": "Running… You can switch tasks or close the page—I'll keep going.",
+  "operation.execServerAgentRuntime": "Preparing response (switching tasks or closing the page won't stop)",
   "operation.sendMessage": "Sending message",
   "owner": "Group owner",
   "pageCopilot.title": "Page Agent",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -229,7 +229,7 @@
   "operation.contextCompression": "上下文过长，正在压缩历史记录……",
   "operation.execAgentRuntime": "准备响应中",
   "operation.execClientTask": "执行任务中",
-  "operation.execServerAgentRuntime": "运行中…你可以切换任务或关闭页面，我会继续执行。",
+  "operation.execServerAgentRuntime": "准备响应中（切换任务或关闭页面都会继续执行）",
   "operation.sendMessage": "消息发送中",
   "owner": "群主",
   "pageCopilot.title": "文稿助理",

--- a/src/server/routers/lambda/__tests__/aiAgent.test.ts
+++ b/src/server/routers/lambda/__tests__/aiAgent.test.ts
@@ -1,6 +1,13 @@
 // @vitest-environment node
 import { type LobeChatDatabase } from '@lobechat/database';
-import { agents, agentsToSessions, sessions, threads, topics } from '@lobechat/database/schemas';
+import {
+  agents,
+  agentsToSessions,
+  messages,
+  sessions,
+  threads,
+  topics,
+} from '@lobechat/database/schemas';
 import { getTestDB } from '@lobechat/database/test-utils';
 import { eq } from 'drizzle-orm';
 import type * as ModelBankModule from 'model-bank';
@@ -372,6 +379,58 @@ describe('AI Agent Router Integration Tests', () => {
           }),
         }),
       );
+    });
+
+    it('should skip user message creation when parentMessageId is provided (regeneration)', async () => {
+      const caller = aiAgentRouter.createCaller(createTestContext());
+
+      // Create a topic and a user message to regenerate from
+      const [topic] = await serverDB
+        .insert(topics)
+        .values({
+          title: 'Regen Topic',
+          agentId: testAgentId,
+          sessionId: testSessionId,
+          userId,
+        })
+        .returning();
+
+      const [userMsg] = await serverDB
+        .insert(messages)
+        .values({
+          role: 'user',
+          content: 'Original question',
+          userId,
+          agentId: testAgentId,
+          topicId: topic.id,
+        })
+        .returning();
+
+      const result = await caller.execAgent({
+        agentId: testAgentId,
+        prompt: 'Original question',
+        parentMessageId: userMsg.id,
+        appContext: { topicId: topic.id },
+      });
+
+      expect(result.success).toBe(true);
+
+      // Verify only the assistant message was created (no new user message)
+      const allMessages = await serverDB
+        .select()
+        .from(messages)
+        .where(eq(messages.topicId, topic.id));
+
+      const userMessages = allMessages.filter((m) => m.role === 'user');
+      const assistantMessages = allMessages.filter((m) => m.role === 'assistant');
+
+      // Should still have only 1 user message (the original, no new one created)
+      expect(userMessages).toHaveLength(1);
+      expect(userMessages[0].id).toBe(userMsg.id);
+
+      // Should have 1 assistant message with parentId pointing to the user message
+      expect(assistantMessages).toHaveLength(1);
+      expect(assistantMessages[0].parentId).toBe(userMsg.id);
     });
   });
 });

--- a/src/server/routers/lambda/__tests__/aiAgent.test.ts
+++ b/src/server/routers/lambda/__tests__/aiAgent.test.ts
@@ -395,7 +395,7 @@ describe('AI Agent Router Integration Tests', () => {
         })
         .returning();
 
-      const [userMsg] = await serverDB
+      const [userMsg] = (await serverDB
         .insert(messages)
         .values({
           role: 'user',
@@ -404,7 +404,7 @@ describe('AI Agent Router Integration Tests', () => {
           agentId: testAgentId,
           topicId: topic.id,
         })
-        .returning();
+        .returning()) as any[];
 
       const result = await caller.execAgent({
         agentId: testAgentId,

--- a/src/server/routers/lambda/aiAgent.ts
+++ b/src/server/routers/lambda/aiAgent.ts
@@ -95,6 +95,8 @@ const ExecAgentSchema = z
     deviceId: z.string().optional(),
     /** Optional existing message IDs to include in context */
     existingMessageIds: z.array(z.string()).optional().default([]),
+    /** Parent message ID for regeneration/continue (skip user message creation, branch from this message) */
+    parentMessageId: z.string().optional(),
     /** The user input/prompt */
     prompt: z.string(),
     /** The agent slug to run (either agentId or slug is required) */
@@ -528,6 +530,7 @@ export const aiAgentRouter = router({
       autoStart = true,
       deviceId,
       existingMessageIds = [],
+      parentMessageId,
     } = input;
 
     log('execAgent: identifier=%s, prompt=%s', agentId || slug, prompt.slice(0, 50));
@@ -539,7 +542,10 @@ export const aiAgentRouter = router({
         autoStart,
         deviceId,
         existingMessageIds,
+        parentMessageId,
         prompt,
+        // When parentMessageId is provided, this is a regeneration/continue — skip user message creation
+        resume: !!parentMessageId,
         slug,
       });
     } catch (error: any) {

--- a/src/server/routers/lambda/aiAgent.ts
+++ b/src/server/routers/lambda/aiAgent.ts
@@ -592,6 +592,7 @@ export const aiAgentRouter = router({
         autoStart = true,
         deviceId,
         existingMessageIds = [],
+        parentMessageId,
       } = task;
 
       try {
@@ -601,7 +602,10 @@ export const aiAgentRouter = router({
           autoStart,
           deviceId,
           existingMessageIds,
+          parentMessageId,
           prompt,
+          // When parentMessageId is provided, this is a regeneration/continue — skip user message creation
+          resume: !!parentMessageId,
           slug,
         });
 

--- a/src/services/aiAgent.ts
+++ b/src/services/aiAgent.ts
@@ -16,6 +16,8 @@ export interface ExecAgentTaskParams {
   autoStart?: boolean;
   deviceId?: string;
   existingMessageIds?: string[];
+  /** Parent message ID for regeneration/continue (skip user message creation, branch from this message) */
+  parentMessageId?: string;
   prompt: string;
   slug?: string;
 }

--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -307,8 +307,15 @@ describe('GatewayActionImpl', () => {
       const { action } = createExecuteTestAction();
 
       vi.mocked(aiAgentService.execAgentTask).mockResolvedValue({
+        agentId: 'agent-1',
         assistantMessageId: 'ast-1',
+        autoStarted: true,
+        createdAt: new Date().toISOString(),
+        message: 'ok',
         operationId: 'server-op-1',
+        status: 'created',
+        success: true,
+        timestamp: new Date().toISOString(),
         token: 'test-token',
         topicId: 'topic-1',
         userMessageId: 'usr-1',
@@ -332,8 +339,15 @@ describe('GatewayActionImpl', () => {
       const { action } = createExecuteTestAction();
 
       vi.mocked(aiAgentService.execAgentTask).mockResolvedValue({
+        agentId: 'agent-1',
         assistantMessageId: 'ast-1',
+        autoStarted: true,
+        createdAt: new Date().toISOString(),
+        message: 'ok',
         operationId: 'server-op-1',
+        status: 'created',
+        success: true,
+        timestamp: new Date().toISOString(),
         token: 'test-token',
         topicId: 'topic-1',
         userMessageId: 'usr-1',
@@ -356,8 +370,15 @@ describe('GatewayActionImpl', () => {
       const { action } = createExecuteTestAction();
 
       vi.mocked(aiAgentService.execAgentTask).mockResolvedValue({
+        agentId: 'agent-1',
         assistantMessageId: 'ast-1',
+        autoStarted: true,
+        createdAt: new Date().toISOString(),
+        message: 'ok',
         operationId: 'server-op-1',
+        status: 'created',
+        success: true,
+        timestamp: new Date().toISOString(),
         token: 'test-token',
         topicId: 'topic-1',
         userMessageId: 'usr-1',

--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -1,9 +1,34 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentStreamEvent } from '@/libs/agent-stream';
+import { aiAgentService } from '@/services/aiAgent';
 
 import type { GatewayConnection } from '../gateway';
 import { GatewayActionImpl } from '../gateway';
+
+vi.mock('@/services/aiAgent', () => ({
+  aiAgentService: {
+    execAgentTask: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/message', () => ({
+  messageService: {
+    getMessages: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('@/services/topic', () => ({
+  topicService: {
+    updateTopicMetadata: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: {
+    getState: vi.fn(() => ({ preference: { lab: {} } })),
+  },
+}));
 
 // ─── Mock Client Factory ───
 
@@ -234,6 +259,122 @@ describe('GatewayActionImpl', () => {
     it('should return undefined for unknown operationId', () => {
       const { action } = createTestAction();
       expect(action.getGatewayConnectionStatus('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('executeGatewayAgent', () => {
+    function createExecuteTestAction() {
+      const mockClient = createMockClient();
+      const state: Record<string, any> = { gatewayConnections: {} };
+      const set = vi.fn((updater: any) => {
+        if (typeof updater === 'function') {
+          Object.assign(state, updater(state));
+        } else {
+          Object.assign(state, updater);
+        }
+      });
+
+      const get = vi.fn(() => ({
+        ...state,
+        startOperation: vi.fn(() => ({ operationId: 'gw-op-1' })),
+        associateMessageWithOperation: vi.fn(),
+        connectToGateway: vi.fn(),
+        internal_updateTopicLoading: vi.fn(),
+        replaceMessages: vi.fn(),
+        switchTopic: vi.fn(),
+      })) as any;
+
+      // Set up window.global_serverConfigStore
+      (globalThis as any).window = {
+        global_serverConfigStore: {
+          getState: () => ({
+            serverConfig: { agentGatewayUrl: 'https://gateway.test.com' },
+          }),
+        },
+      };
+
+      const action = new GatewayActionImpl(set as any, get, undefined);
+      action.createClient = vi.fn(() => mockClient);
+
+      return { action, get, mockClient, set, state };
+    }
+
+    afterEach(() => {
+      delete (globalThis as any).window;
+    });
+
+    it('should forward parentMessageId to execAgentTask for regeneration', async () => {
+      const { action } = createExecuteTestAction();
+
+      vi.mocked(aiAgentService.execAgentTask).mockResolvedValue({
+        assistantMessageId: 'ast-1',
+        operationId: 'server-op-1',
+        token: 'test-token',
+        topicId: 'topic-1',
+        userMessageId: 'usr-1',
+      });
+
+      await action.executeGatewayAgent({
+        context: { agentId: 'agent-1', topicId: 'topic-1', threadId: null, scope: 'main' },
+        message: 'Original question',
+        parentMessageId: 'user-msg-123',
+      });
+
+      expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentMessageId: 'user-msg-123',
+          prompt: 'Original question',
+        }),
+      );
+    });
+
+    it('should not include parentMessageId when not provided (normal send)', async () => {
+      const { action } = createExecuteTestAction();
+
+      vi.mocked(aiAgentService.execAgentTask).mockResolvedValue({
+        assistantMessageId: 'ast-1',
+        operationId: 'server-op-1',
+        token: 'test-token',
+        topicId: 'topic-1',
+        userMessageId: 'usr-1',
+      });
+
+      await action.executeGatewayAgent({
+        context: { agentId: 'agent-1', topicId: 'topic-1', threadId: null, scope: 'main' },
+        message: 'Hello',
+      });
+
+      expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentMessageId: undefined,
+          prompt: 'Hello',
+        }),
+      );
+    });
+
+    it('should forward empty prompt for continue generation', async () => {
+      const { action } = createExecuteTestAction();
+
+      vi.mocked(aiAgentService.execAgentTask).mockResolvedValue({
+        assistantMessageId: 'ast-1',
+        operationId: 'server-op-1',
+        token: 'test-token',
+        topicId: 'topic-1',
+        userMessageId: 'usr-1',
+      });
+
+      await action.executeGatewayAgent({
+        context: { agentId: 'agent-1', topicId: 'topic-1', threadId: null, scope: 'main' },
+        message: '',
+        parentMessageId: 'assistant-msg-456',
+      });
+
+      expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentMessageId: 'assistant-msg-456',
+          prompt: '',
+        }),
+      );
     });
   });
 });

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -188,8 +188,10 @@ export class GatewayActionImpl {
   executeGatewayAgent = async (params: {
     context: ConversationContext;
     message: string;
+    /** Parent message ID for regeneration/continue (skip user message creation, branch from this message) */
+    parentMessageId?: string;
   }): Promise<ExecAgentResult> => {
-    const { context, message } = params;
+    const { context, message, parentMessageId } = params;
 
     const agentGatewayUrl =
       window.global_serverConfigStore!.getState().serverConfig.agentGatewayUrl!;
@@ -204,6 +206,7 @@ export class GatewayActionImpl {
         threadId: context.threadId,
         topicId: context.topicId,
       },
+      parentMessageId,
       prompt: message,
     });
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Fixes LOBE-6933

#### 🔀 Description of Change

Extend the `execAgent` API to support `parentMessageId`, enabling regeneration and continue-generation flows through the Gateway WebSocket path.

**What this enables:**
- **Regeneration**: Pass `parentMessageId` = user message ID → server skips creating user message, creates new assistant message branched from that user message
- **Continue generation**: Pass `parentMessageId` = assistant message ID → server skips creating user message, continues from that assistant message

**Changes:**
- `ExecAgentSchema` (server router): Added `parentMessageId` field; when provided, sets `resume: true` to skip user message creation
- `ExecAgentTaskParams` (client service): Added `parentMessageId` field
- `executeGatewayAgent` (gateway action): Accepts and forwards `parentMessageId` to `execAgentTask`

This is the infrastructure layer (LOBE-6933) for LOBE-6828 (Phase 3: regeneration/continue Gateway conversion). The action-layer gateway branches (LOBE-6934, LOBE-6935) will follow as separate PRs.

#### 🧪 How to Test

- [x] Added/updated tests

**Tests added:**
- Server router integration test: verifies `parentMessageId` skips user message creation and sets correct `parentId` on assistant message
- Gateway unit tests: verifies `parentMessageId` forwarding for regeneration, normal send, and continue generation scenarios

📝 Generated with [Claude Code](https://claude.com/claude-code)