### PR TITLE
chore: bump lucide-react to v1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -343,7 +343,7 @@
     "langfuse": "^3.38.6",
     "langfuse-core": "^3.38.6",
     "lexical": "0.42.0",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.8.0",
     "mammoth": "^1.11.0",
     "marked": "^17.0.1",
     "mdast-util-to-markdown": "^2.1.2",

--- a/src/features/CommandMenu/MainMenu.tsx
+++ b/src/features/CommandMenu/MainMenu.tsx
@@ -1,6 +1,5 @@
 import { SOCIAL_URL } from '@lobechat/business-const';
-import { Github } from '@lobehub/icons';
-import { DiscordIcon } from '@lobehub/ui/icons';
+import { DiscordIcon, GithubIcon } from '@lobehub/ui/icons';
 import { Command } from 'cmdk';
 import {
   Bot,
@@ -145,7 +144,7 @@ const MainMenu = memo(() => {
           {t('cmdk.contactUs')}
         </CommandItem>
         <CommandItem
-          icon={<Github />}
+          icon={<GithubIcon />}
           keywords={t('cmdk.keywords.submitIssue').split(' ')}
           value="submit-issue"
           onSelect={() => handleExternalLink(FEEDBACK)}

--- a/src/features/CommandMenu/MainMenu.tsx
+++ b/src/features/CommandMenu/MainMenu.tsx
@@ -1,11 +1,11 @@
 import { SOCIAL_URL } from '@lobechat/business-const';
+import { Github } from '@lobehub/icons';
 import { DiscordIcon } from '@lobehub/ui/icons';
 import { Command } from 'cmdk';
 import {
   Bot,
   FeatherIcon,
   FilePen,
-  Github,
   LibraryBig,
   MessageSquarePlusIcon,
   Monitor,

--- a/src/features/SkillStore/SkillList/AddSkillButton.tsx
+++ b/src/features/SkillStore/SkillList/AddSkillButton.tsx
@@ -1,5 +1,5 @@
-import { Github } from '@lobehub/icons';
 import { Button, DropdownMenu, Flexbox, Icon, Text } from '@lobehub/ui';
+import { GithubIcon } from '@lobehub/ui/icons';
 import { ChevronDown, FileArchive, Grid2x2Plus, Link, PenLine } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -63,7 +63,7 @@ const AddSkillButton = () => {
             onClick: () => setUrlModal(true),
           },
           {
-            icon: <Icon icon={Github} />,
+            icon: <Icon icon={GithubIcon} />,
             key: 'importGithub',
             label: (
               <MenuLabel desc={t('tab.importFromGithub.desc')} title={t('tab.importFromGithub')} />

--- a/src/features/SkillStore/SkillList/AddSkillButton.tsx
+++ b/src/features/SkillStore/SkillList/AddSkillButton.tsx
@@ -1,5 +1,6 @@
+import { Github } from '@lobehub/icons';
 import { Button, DropdownMenu, Flexbox, Icon, Text } from '@lobehub/ui';
-import { ChevronDown, FileArchive, Github, Grid2x2Plus, Link, PenLine } from 'lucide-react';
+import { ChevronDown, FileArchive, Grid2x2Plus, Link, PenLine } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/SkillStore/SkillList/ImportFromGithubModal.tsx
+++ b/src/features/SkillStore/SkillList/ImportFromGithubModal.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { Github } from '@lobehub/icons';
 import { Alert, Flexbox, Icon, Input } from '@lobehub/ui';
 import { App, Button, Modal, Typography } from 'antd';
-import { ArrowLeftRight, Github, Sparkles } from 'lucide-react';
+import { ArrowLeftRight, Sparkles } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/SkillStore/SkillList/ImportFromGithubModal.tsx
+++ b/src/features/SkillStore/SkillList/ImportFromGithubModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Github } from '@lobehub/icons';
 import { Alert, Flexbox, Icon, Input } from '@lobehub/ui';
+import { GithubIcon } from '@lobehub/ui/icons';
 import { App, Button, Modal, Typography } from 'antd';
 import { ArrowLeftRight, Sparkles } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -50,7 +50,7 @@ const ImportFromGithubModal = memo<ImportFromGithubModalProps>(({ open, onOpenCh
     <Modal destroyOnClose footer={null} open={open} title={null} width={480} onCancel={handleClose}>
       <Flexbox align="center" gap={16} padding={'16px 0'}>
         <Flexbox horizontal align="center" gap={8}>
-          <Icon icon={Github} size={28} />
+          <Icon icon={GithubIcon} size={28} />
           <Icon
             icon={ArrowLeftRight}
             size={16}

--- a/src/routes/(main)/community/features/CreateButton/Inner.tsx
+++ b/src/routes/(main)/community/features/CreateButton/Inner.tsx
@@ -1,6 +1,7 @@
+import { Github } from '@lobehub/icons';
 import { Button, Icon, Tag, Typography } from '@lobehub/ui';
 import { Divider } from 'antd';
-import { Github, Settings, Share2 } from 'lucide-react';
+import { Settings, Share2 } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/routes/(main)/community/features/CreateButton/Inner.tsx
+++ b/src/routes/(main)/community/features/CreateButton/Inner.tsx
@@ -1,5 +1,5 @@
-import { Github } from '@lobehub/icons';
 import { Button, Icon, Tag, Typography } from '@lobehub/ui';
+import { GithubIcon } from '@lobehub/ui/icons';
 import { Divider } from 'antd';
 import { Settings, Share2 } from 'lucide-react';
 import { memo } from 'react';
@@ -42,7 +42,7 @@ const Inner = memo(() => {
       <p>{t('createGuide.func2.desc')}</p>
       <br />
       <Button
-        icon={Github}
+        icon={GithubIcon}
         type={'primary'}
         onClick={() => window.open(AGENTS_INDEX_GITHUB, '__blank')}
       >

--- a/src/routes/(main)/home/_layout/Footer/index.tsx
+++ b/src/routes/(main)/home/_layout/Footer/index.tsx
@@ -2,10 +2,9 @@
 
 import { SOCIAL_URL } from '@lobechat/business-const';
 import { useAnalytics } from '@lobehub/analytics/react';
-import { Github } from '@lobehub/icons';
 import { type MenuProps } from '@lobehub/ui';
 import { ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
-import { DiscordIcon } from '@lobehub/ui/icons';
+import { DiscordIcon, GithubIcon } from '@lobehub/ui/icons';
 import {
   Book,
   CircleHelp,
@@ -173,7 +172,7 @@ const Footer = memo(() => {
       ...(footer.layout === 'compact' && !footer.hideGitHub
         ? [
             {
-              icon: <Icon icon={Github} />,
+              icon: <Icon icon={GithubIcon} />,
               key: 'github',
               label: (
                 <a href={GITHUB} rel="noopener noreferrer" target="_blank">
@@ -226,7 +225,7 @@ const Footer = memo(() => {
             </DropdownMenu>
             {!footer.hideGitHub && (
               <a aria-label={'GitHub'} href={GITHUB} rel="noopener noreferrer" target={'_blank'}>
-                <ActionIcon icon={Github} size={16} title={'GitHub'} />
+                <ActionIcon icon={GithubIcon} size={16} title={'GitHub'} />
               </a>
             )}
             <Link to="/eval">

--- a/src/routes/(main)/home/_layout/Footer/index.tsx
+++ b/src/routes/(main)/home/_layout/Footer/index.tsx
@@ -2,6 +2,7 @@
 
 import { SOCIAL_URL } from '@lobechat/business-const';
 import { useAnalytics } from '@lobehub/analytics/react';
+import { Github } from '@lobehub/icons';
 import { type MenuProps } from '@lobehub/ui';
 import { ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
 import { DiscordIcon } from '@lobehub/ui/icons';
@@ -11,7 +12,6 @@ import {
   Feather,
   FileClockIcon,
   FlaskConical,
-  Github,
   Rocket,
   Settings,
   Settings2,


### PR DESCRIPTION
## Summary

- Bump `lucide-react` from `^0.577.0` to `^1.8.0`
- Fix breaking change: `Github` icon removed in v1.x (brand icons removed). Replaced with `Github` from `@lobehub/icons` in 5 affected files.

## Affected files

- `package.json` — version bump
- `src/features/CommandMenu/MainMenu.tsx` — replace Github import
- `src/features/SkillStore/SkillList/AddSkillButton.tsx` — replace Github import
- `src/features/SkillStore/SkillList/ImportFromGithubModal.tsx` — replace Github import
- `src/routes/(main)/community/features/CreateButton/Inner.tsx` — replace Github import
- `src/routes/(main)/home/_layout/Footer/index.tsx` — replace Github import

## Test plan

- [x] `tsc --noEmit` passes with 0 errors
- [ ] Verify Github icon renders correctly in UI
- [ ] Full build passes (`bun run build:spa && bun run build:next`)