### PR TITLE
✨ feat: support `regenerateUserMessage` in gateway mode

### DIFF
--- a/src/features/Conversation/store/slices/generation/action.test.ts
+++ b/src/features/Conversation/store/slices/generation/action.test.ts
@@ -20,6 +20,8 @@ const mockStartOperation = vi.fn(() => ({ operationId: 'test-op-id' }));
 const mockCompleteOperation = vi.fn();
 const mockFailOperation = vi.fn();
 const mockInternalExecAgentRuntime = vi.fn();
+const mockIsGatewayModeEnabled = vi.fn(() => false);
+const mockExecuteGatewayAgent = vi.fn();
 
 vi.mock('@/store/chat', () => ({
   useChatStore: {
@@ -45,6 +47,8 @@ vi.mock('@/store/chat', () => ({
       completeOperation: mockCompleteOperation,
       failOperation: mockFailOperation,
       internal_execAgentRuntime: mockInternalExecAgentRuntime,
+      isGatewayModeEnabled: mockIsGatewayModeEnabled,
+      executeGatewayAgent: mockExecuteGatewayAgent,
     })),
     setState: vi.fn(),
   },
@@ -169,6 +173,7 @@ describe('Generation Actions', () => {
         completeOperation: mockCompleteOperation,
         failOperation: mockFailOperation,
         internal_execAgentRuntime: mockInternalExecAgentRuntime,
+        isGatewayModeEnabled: mockIsGatewayModeEnabled,
       } as any);
 
       const context: ConversationContext = {
@@ -228,6 +233,7 @@ describe('Generation Actions', () => {
         completeOperation: mockCompleteOperation,
         failOperation: mockFailOperation,
         internal_execAgentRuntime: mockInternalExecAgentRuntime,
+        isGatewayModeEnabled: mockIsGatewayModeEnabled,
       } as any);
 
       const context: ConversationContext = {
@@ -264,6 +270,7 @@ describe('Generation Actions', () => {
         completeOperation: mockCompleteOperation,
         failOperation: mockFailOperation,
         internal_execAgentRuntime: mockInternalExecAgentRuntime,
+        isGatewayModeEnabled: mockIsGatewayModeEnabled,
       } as any);
 
       const context: ConversationContext = {
@@ -302,6 +309,7 @@ describe('Generation Actions', () => {
         completeOperation: mockCompleteOperation,
         failOperation: mockFailOperation,
         internal_execAgentRuntime: mockInternalExecAgentRuntime,
+        isGatewayModeEnabled: mockIsGatewayModeEnabled,
       } as any);
 
       const onBeforeContinue = vi.fn().mockResolvedValue(false);
@@ -392,6 +400,7 @@ describe('Generation Actions', () => {
         completeOperation: mockCompleteOperation,
         failOperation: mockFailOperation,
         internal_execAgentRuntime: mockInternalExecAgentRuntime,
+        isGatewayModeEnabled: mockIsGatewayModeEnabled,
       } as any);
 
       const context: ConversationContext = {
@@ -436,6 +445,7 @@ describe('Generation Actions', () => {
         completeOperation: mockCompleteOperation,
         failOperation: mockFailOperation,
         internal_execAgentRuntime: mockInternalExecAgentRuntime,
+        isGatewayModeEnabled: mockIsGatewayModeEnabled,
       } as any);
 
       const context: ConversationContext = {
@@ -509,6 +519,7 @@ describe('Generation Actions', () => {
           callOrder.push('internal_execAgentRuntime');
           return Promise.resolve();
         }),
+        isGatewayModeEnabled: mockIsGatewayModeEnabled,
       } as any);
 
       const context: ConversationContext = {
@@ -609,6 +620,7 @@ describe('Generation Actions', () => {
         startOperation: mockStartOperation,
         completeOperation: mockCompleteOperation,
         internal_execAgentRuntime: mockInternalExecAgentRuntime,
+        isGatewayModeEnabled: mockIsGatewayModeEnabled,
       } as any);
 
       const context: ConversationContext = {
@@ -662,6 +674,7 @@ describe('Generation Actions', () => {
         completeOperation: mockCompleteOperation,
         failOperation: mockFailOperation,
         internal_execAgentRuntime: mockInternalExecAgentRuntime,
+        isGatewayModeEnabled: mockIsGatewayModeEnabled,
       } as any);
 
       const context: ConversationContext = {
@@ -719,6 +732,7 @@ describe('Generation Actions', () => {
         completeOperation: mockCompleteOperation,
         failOperation: mockFailOperation,
         internal_execAgentRuntime: mockInternalExecAgentRuntime,
+        isGatewayModeEnabled: mockIsGatewayModeEnabled,
       } as any);
 
       const context: ConversationContext = {
@@ -767,6 +781,7 @@ describe('Generation Actions', () => {
         completeOperation: mockCompleteOperation,
         failOperation: mockFailOperation,
         internal_execAgentRuntime: mockInternalExecAgentRuntime,
+        isGatewayModeEnabled: mockIsGatewayModeEnabled,
       } as any);
 
       const context: ConversationContext = {
@@ -822,6 +837,134 @@ describe('Generation Actions', () => {
           },
         }),
       );
+    });
+
+    it('should use executeGatewayAgent when gateway mode is enabled', async () => {
+      const { useChatStore } = await import('@/store/chat');
+      vi.mocked(useChatStore.getState).mockReturnValue({
+        messagesMap: {},
+        operations: {},
+        operationsByMessage: {},
+
+        startOperation: mockStartOperation,
+        completeOperation: mockCompleteOperation,
+        failOperation: mockFailOperation,
+        isGatewayModeEnabled: vi.fn(() => true),
+        executeGatewayAgent: mockExecuteGatewayAgent,
+        internal_execAgentRuntime: mockInternalExecAgentRuntime,
+        switchMessageBranch: mockSwitchMessageBranch,
+      } as any);
+
+      const context: ConversationContext = {
+        agentId: 'session-1',
+        topicId: 'topic-1',
+        threadId: null,
+      };
+
+      const store = createStore({ context });
+
+      act(() => {
+        store.setState({
+          displayMessages: [{ id: 'msg-1', role: 'user', content: 'Hello world' }],
+        } as any);
+      });
+
+      await act(async () => {
+        await store.getState().regenerateUserMessage('msg-1');
+      });
+
+      // Should call executeGatewayAgent with parentMessageId and original content
+      expect(mockExecuteGatewayAgent).toHaveBeenCalledWith({
+        context,
+        message: 'Hello world',
+        parentMessageId: 'msg-1',
+      });
+
+      // Should NOT call client-mode internal_execAgentRuntime
+      expect(mockInternalExecAgentRuntime).not.toHaveBeenCalled();
+
+      // Should NOT call switchMessageBranch (server handles branching)
+      expect(mockSwitchMessageBranch).not.toHaveBeenCalled();
+
+      // Should complete the operation
+      expect(mockCompleteOperation).toHaveBeenCalledWith('test-op-id');
+    });
+
+    it('should call onRegenerateComplete hook after gateway regeneration', async () => {
+      const { useChatStore } = await import('@/store/chat');
+      vi.mocked(useChatStore.getState).mockReturnValue({
+        messagesMap: {},
+        operations: {},
+        operationsByMessage: {},
+
+        startOperation: mockStartOperation,
+        completeOperation: mockCompleteOperation,
+        failOperation: mockFailOperation,
+        isGatewayModeEnabled: vi.fn(() => true),
+        executeGatewayAgent: mockExecuteGatewayAgent,
+      } as any);
+
+      const onRegenerateComplete = vi.fn();
+      const context: ConversationContext = {
+        agentId: 'session-1',
+        topicId: 'topic-1',
+        threadId: null,
+      };
+
+      const store = createStore({ context, hooks: { onRegenerateComplete } });
+
+      act(() => {
+        store.setState({
+          displayMessages: [{ id: 'msg-1', role: 'user', content: 'Hello' }],
+        } as any);
+      });
+
+      await act(async () => {
+        await store.getState().regenerateUserMessage('msg-1');
+      });
+
+      expect(onRegenerateComplete).toHaveBeenCalledWith('msg-1');
+    });
+
+    it('should fall back to client mode when gateway is disabled', async () => {
+      const { useChatStore } = await import('@/store/chat');
+      vi.mocked(useChatStore.getState).mockReturnValue({
+        messagesMap: {},
+        operations: {},
+        operationsByMessage: {},
+
+        startOperation: mockStartOperation,
+        completeOperation: mockCompleteOperation,
+        failOperation: mockFailOperation,
+        isGatewayModeEnabled: vi.fn(() => false),
+        executeGatewayAgent: mockExecuteGatewayAgent,
+        internal_execAgentRuntime: mockInternalExecAgentRuntime,
+        switchMessageBranch: mockSwitchMessageBranch,
+      } as any);
+
+      const context: ConversationContext = {
+        agentId: 'session-1',
+        topicId: 'topic-1',
+        threadId: null,
+      };
+
+      const store = createStore({ context });
+
+      act(() => {
+        store.setState({
+          displayMessages: [{ id: 'msg-1', role: 'user', content: 'Hello' }],
+        } as any);
+      });
+
+      await act(async () => {
+        await store.getState().regenerateUserMessage('msg-1');
+      });
+
+      // Should NOT call executeGatewayAgent
+      expect(mockExecuteGatewayAgent).not.toHaveBeenCalled();
+
+      // Should call client-mode internal_execAgentRuntime
+      expect(mockInternalExecAgentRuntime).toHaveBeenCalled();
     });
 
     it('should not regenerate if message is already loading', async () => {

--- a/src/features/Conversation/store/slices/generation/action.test.ts
+++ b/src/features/Conversation/store/slices/generation/action.test.ts
@@ -873,20 +873,30 @@ describe('Generation Actions', () => {
         await store.getState().regenerateUserMessage('msg-1');
       });
 
-      // Should call executeGatewayAgent with parentMessageId and original content
-      expect(mockExecuteGatewayAgent).toHaveBeenCalledWith({
-        context,
-        message: 'Hello world',
-        parentMessageId: 'msg-1',
+      // Should switch message branch before gateway call
+      expect(mockSwitchMessageBranch).toHaveBeenCalledWith('msg-1', 0, {
+        operationId: 'test-op-id',
       });
+
+      // Should call executeGatewayAgent with parentMessageId, original content, and onComplete
+      expect(mockExecuteGatewayAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context,
+          message: 'Hello world',
+          parentMessageId: 'msg-1',
+          onComplete: expect.any(Function),
+        }),
+      );
 
       // Should NOT call client-mode internal_execAgentRuntime
       expect(mockInternalExecAgentRuntime).not.toHaveBeenCalled();
 
-      // Should NOT call switchMessageBranch (server handles branching)
-      expect(mockSwitchMessageBranch).not.toHaveBeenCalled();
+      // regenerate operation stays running until onComplete is called
+      expect(mockCompleteOperation).not.toHaveBeenCalled();
 
-      // Should complete the operation
+      // Simulate gateway session complete
+      const onComplete = mockExecuteGatewayAgent.mock.calls[0][0].onComplete;
+      onComplete();
       expect(mockCompleteOperation).toHaveBeenCalledWith('test-op-id');
     });
 
@@ -902,6 +912,7 @@ describe('Generation Actions', () => {
         failOperation: mockFailOperation,
         isGatewayModeEnabled: vi.fn(() => true),
         executeGatewayAgent: mockExecuteGatewayAgent,
+        switchMessageBranch: mockSwitchMessageBranch,
       } as any);
 
       const onRegenerateComplete = vi.fn();
@@ -923,6 +934,12 @@ describe('Generation Actions', () => {
         await store.getState().regenerateUserMessage('msg-1');
       });
 
+      // Hook is called via onComplete callback, not directly
+      expect(onRegenerateComplete).not.toHaveBeenCalled();
+
+      // Simulate gateway session complete
+      const onComplete = mockExecuteGatewayAgent.mock.calls[0][0].onComplete;
+      onComplete();
       expect(onRegenerateComplete).toHaveBeenCalledWith('msg-1');
     });
 

--- a/src/features/Conversation/store/slices/generation/action.ts
+++ b/src/features/Conversation/store/slices/generation/action.ts
@@ -342,6 +342,23 @@ export const generationSlice: StateCreator<
     });
 
     try {
+      // ── Gateway mode: trigger server-side regeneration ──
+      if (chatStore.isGatewayModeEnabled()) {
+        await chatStore.executeGatewayAgent({
+          context,
+          message: item.content,
+          parentMessageId: messageId,
+        });
+
+        chatStore.completeOperation(operationId);
+
+        if (hooks.onRegenerateComplete) {
+          hooks.onRegenerateComplete(messageId);
+        }
+        return;
+      }
+
+      // ── Client mode: run agent locally ──
       // Calculate next branch index by counting children of this user message
       // We need to count how many assistant messages have this user message as parent
       const { dbMessages } = get();

--- a/src/features/Conversation/store/slices/generation/action.ts
+++ b/src/features/Conversation/store/slices/generation/action.ts
@@ -342,23 +342,6 @@ export const generationSlice: StateCreator<
     });
 
     try {
-      // ── Gateway mode: trigger server-side regeneration ──
-      if (chatStore.isGatewayModeEnabled()) {
-        await chatStore.executeGatewayAgent({
-          context,
-          message: item.content,
-          parentMessageId: messageId,
-        });
-
-        chatStore.completeOperation(operationId);
-
-        if (hooks.onRegenerateComplete) {
-          hooks.onRegenerateComplete(messageId);
-        }
-        return;
-      }
-
-      // ── Client mode: run agent locally ──
       // Calculate next branch index by counting children of this user message
       // We need to count how many assistant messages have this user message as parent
       const { dbMessages } = get();
@@ -366,10 +349,32 @@ export const generationSlice: StateCreator<
       // New branch index = current children count (since index is 0-based)
       const nextBranchIndex = childrenCount;
 
-      // Switch to a new branch (pass operationId for correct context in optimistic update)
+      // Switch to the new branch so the UI shows the incoming response immediately
       await chatStore.switchMessageBranch(messageId, nextBranchIndex, {
         operationId,
       });
+
+      // ── Gateway mode: trigger server-side regeneration ──
+      if (chatStore.isGatewayModeEnabled()) {
+        // Keep the regenerate operation running until the gateway session completes,
+        // so isMessageRegenerating stays true and duplicate clicks are blocked.
+        await chatStore.executeGatewayAgent({
+          context,
+          message: item.content,
+          onComplete: () => {
+            chatStore.completeOperation(operationId);
+            if (hooks.onRegenerateComplete) {
+              hooks.onRegenerateComplete(messageId);
+            }
+          },
+          parentMessageId: messageId,
+        });
+
+        return;
+      }
+
+      // ── Client mode: run agent locally ──
+      // (switchMessageBranch already called above)
 
       // Execute agent runtime with full context from ConversationStore
       await chatStore.internal_execAgentRuntime({

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -188,10 +188,12 @@ export class GatewayActionImpl {
   executeGatewayAgent = async (params: {
     context: ConversationContext;
     message: string;
+    /** Called when the gateway session completes (agent finished running) */
+    onComplete?: () => void;
     /** Parent message ID for regeneration/continue (skip user message creation, branch from this message) */
     parentMessageId?: string;
   }): Promise<ExecAgentResult> => {
-    const { context, message, parentMessageId } = params;
+    const { context, message, onComplete, parentMessageId } = params;
 
     const agentGatewayUrl =
       window.global_serverConfigStore!.getState().serverConfig.agentGatewayUrl!;
@@ -262,6 +264,7 @@ export class GatewayActionImpl {
             .updateTopicMetadata(result.topicId, { runningOperation: null })
             .catch(() => {});
         }
+        onComplete?.();
       },
       operationId: result.operationId,
       token: result.token || '',


### PR DESCRIPTION
## Summary

- When gateway mode is enabled, `regenerateUserMessage` now calls `executeGatewayAgent` with `parentMessageId` instead of running `internal_execAgentRuntime` locally
- The server handles branching and agent execution in gateway mode

Fixes LOBE-6828

## Test plan

- [x] Unit tests added for gateway mode branch in `regenerateUserMessage`
- [ ] Manual test: enable gateway mode, regenerate a message, verify it goes through gateway instead of client mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)