### PR TITLE
🐛 fix: add typeof guard before .trim() calls in context engine

### DIFF
--- a/packages/context-engine/src/base/BaseProcessor.ts
+++ b/packages/context-engine/src/base/BaseProcessor.ts
@@ -79,7 +79,7 @@ export abstract class BaseProcessor implements ContextProcessor {
    * Check if message is empty
    */
   protected isEmptyMessage(message: string | undefined | null): boolean {
-    return !message || message.trim().length === 0;
+    return !message || typeof message !== 'string' || message.trim().length === 0;
   }
 
   protected markAsExecuted(context: PipelineContext): PipelineContext {

--- a/packages/context-engine/src/base/BaseSystemRoleProvider.ts
+++ b/packages/context-engine/src/base/BaseSystemRoleProvider.ts
@@ -34,7 +34,7 @@ export abstract class BaseSystemRoleProvider extends BaseProcessor {
   protected async doProcess(context: PipelineContext): Promise<PipelineContext> {
     const content = await this.buildSystemRoleContent(context);
 
-    if (!content || content.trim() === '') {
+    if (!content || typeof content !== 'string' || content.trim() === '') {
       log('[%s] No content to inject, skipping', this.name);
       return this.markAsExecuted(context);
     }

--- a/packages/context-engine/src/base/__tests__/BaseProcessor.test.ts
+++ b/packages/context-engine/src/base/__tests__/BaseProcessor.test.ts
@@ -51,6 +51,11 @@ class MessageCheckingProcessor extends BaseProcessor {
 
     return this.markAsExecuted(cloned);
   }
+
+  /** Expose isEmptyMessage for direct testing with arbitrary values */
+  public testIsEmptyMessage(value: any): boolean {
+    return this.isEmptyMessage(value);
+  }
 }
 
 describe('BaseProcessor', () => {
@@ -279,6 +284,26 @@ describe('BaseProcessor', () => {
       await processor.process(context);
 
       expect(processor.lastEmptyCheck).toBe(false);
+    });
+
+    it('should return true for non-string truthy values (object)', () => {
+      const processor = new MessageCheckingProcessor();
+      expect(processor.testIsEmptyMessage({ key: 'value' } as any)).toBe(true);
+    });
+
+    it('should return true for non-string truthy values (array)', () => {
+      const processor = new MessageCheckingProcessor();
+      expect(processor.testIsEmptyMessage(['hello'] as any)).toBe(true);
+    });
+
+    it('should return true for non-string truthy values (number)', () => {
+      const processor = new MessageCheckingProcessor();
+      expect(processor.testIsEmptyMessage(42 as any)).toBe(true);
+    });
+
+    it('should return true for boolean true', () => {
+      const processor = new MessageCheckingProcessor();
+      expect(processor.testIsEmptyMessage(true as any)).toBe(true);
     });
   });
 

--- a/packages/context-engine/src/base/__tests__/BaseSystemRoleProvider.test.ts
+++ b/packages/context-engine/src/base/__tests__/BaseSystemRoleProvider.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PipelineContext } from '../../types';
+import { BaseSystemRoleProvider } from '../BaseSystemRoleProvider';
+
+const createContext = (messages: any[] = []): PipelineContext => ({
+  initialState: { messages: [] },
+  isAborted: false,
+  messages: messages.map((m, i) => ({
+    createdAt: Date.now(),
+    id: `msg-${i}`,
+    updatedAt: Date.now(),
+    ...m,
+  })),
+  metadata: {},
+});
+
+class StringProvider extends BaseSystemRoleProvider {
+  readonly name = 'StringProvider';
+  constructor(private returnValue: any) {
+    super();
+  }
+  protected buildSystemRoleContent(): any {
+    return this.returnValue;
+  }
+}
+
+describe('BaseSystemRoleProvider', () => {
+  it('should inject string content into system message', async () => {
+    const provider = new StringProvider('Hello system');
+    const result = await provider.process(createContext([{ content: 'Hi', role: 'user' }]));
+
+    expect(result.messages[0].role).toBe('system');
+    expect(result.messages[0].content).toBe('Hello system');
+  });
+
+  it('should skip when content is null', async () => {
+    const provider = new StringProvider(null);
+    const result = await provider.process(createContext([{ content: 'Hi', role: 'user' }]));
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+  });
+
+  it('should skip when content is empty string', async () => {
+    const provider = new StringProvider('');
+    const result = await provider.process(createContext([{ content: 'Hi', role: 'user' }]));
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+  });
+
+  it('should skip when content is whitespace-only string', async () => {
+    const provider = new StringProvider('   \n  ');
+    const result = await provider.process(createContext([{ content: 'Hi', role: 'user' }]));
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+  });
+
+  it('should not throw when buildSystemRoleContent returns an object', async () => {
+    const provider = new StringProvider({ some: 'object' });
+    const result = await provider.process(createContext([{ content: 'Hi', role: 'user' }]));
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+  });
+
+  it('should not throw when buildSystemRoleContent returns an array', async () => {
+    const provider = new StringProvider(['a', 'b']);
+    const result = await provider.process(createContext([{ content: 'Hi', role: 'user' }]));
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+  });
+
+  it('should not throw when buildSystemRoleContent returns a number', async () => {
+    const provider = new StringProvider(42);
+    const result = await provider.process(createContext([{ content: 'Hi', role: 'user' }]));
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+  });
+
+  it('should not throw when buildSystemRoleContent returns true', async () => {
+    const provider = new StringProvider(true);
+    const result = await provider.process(createContext([{ content: 'Hi', role: 'user' }]));
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+  });
+});

--- a/packages/context-engine/src/providers/SystemRoleInjector.ts
+++ b/packages/context-engine/src/providers/SystemRoleInjector.ts
@@ -36,7 +36,7 @@ export class SystemRoleInjector extends BaseSystemRoleProvider {
 
   protected buildSystemRoleContent(_context: PipelineContext): string | null {
     const systemRole = this.config.systemRole;
-    if (!systemRole || systemRole.trim() === '') {
+    if (!systemRole || typeof systemRole !== 'string' || systemRole.trim() === '') {
       log('No system role configured, skipping injection');
       return null;
     }

--- a/packages/context-engine/src/providers/__tests__/SystemRoleInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/SystemRoleInjector.test.ts
@@ -219,6 +219,67 @@ describe('SystemRoleInjector', () => {
     expect(result.metadata.systemRoleInjected).toBeUndefined();
   });
 
+  it('should skip injection when systemRole is a non-string truthy value (object)', async () => {
+    const provider = new SystemRoleInjector({
+      systemRole: { nested: 'object' } as any,
+    });
+
+    const context = {
+      initialState: { messages: [], model: 'gpt-4', provider: 'openai', systemRole: '', tools: [] },
+      messages: [
+        { id: '1', role: 'user', content: 'Hello', createdAt: Date.now(), updatedAt: Date.now() },
+      ],
+      metadata: { model: 'gpt-4', maxTokens: 4096 },
+      isAborted: false,
+    };
+
+    const result = await provider.process(context);
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+    expect(result.metadata.systemRoleInjected).toBeUndefined();
+  });
+
+  it('should skip injection when systemRole is an array', async () => {
+    const provider = new SystemRoleInjector({
+      systemRole: ['system', 'role'] as any,
+    });
+
+    const context = {
+      initialState: { messages: [], model: 'gpt-4', provider: 'openai', systemRole: '', tools: [] },
+      messages: [
+        { id: '1', role: 'user', content: 'Hello', createdAt: Date.now(), updatedAt: Date.now() },
+      ],
+      metadata: { model: 'gpt-4', maxTokens: 4096 },
+      isAborted: false,
+    };
+
+    const result = await provider.process(context);
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+  });
+
+  it('should skip injection when systemRole is a number', async () => {
+    const provider = new SystemRoleInjector({
+      systemRole: 42 as any,
+    });
+
+    const context = {
+      initialState: { messages: [], model: 'gpt-4', provider: 'openai', systemRole: '', tools: [] },
+      messages: [
+        { id: '1', role: 'user', content: 'Hello', createdAt: Date.now(), updatedAt: Date.now() },
+      ],
+      metadata: { model: 'gpt-4', maxTokens: 4096 },
+      isAborted: false,
+    };
+
+    const result = await provider.process(context);
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+  });
+
   it('should handle empty message array', async () => {
     const provider = new SystemRoleInjector({
       systemRole: 'You are a helpful assistant.',


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Production `e.trim is not a function` TypeError during agent `call_llm` step.

#### 🔀 Description of Change

Add `typeof !== 'string'` guard before `.trim()` calls in three locations within the context engine:

- `BaseSystemRoleProvider.doProcess()` — `content.trim()`
- `SystemRoleInjector.buildSystemRoleContent()` — `systemRole.trim()`
- `BaseProcessor.isEmptyMessage()` — `message.trim()`

These locations use `!value` to check for falsy values before calling `.trim()`, but truthy non-string values (object, array, number) pass that check and crash. This happens in production when `agentConfig.systemRole` or a `buildSystemRoleContent()` return value becomes a non-string after Redis serialization round-trips between agent steps.

#### 🧪 How to Test

- [x] Added/updated tests

New test cases cover object, array, number, and boolean inputs for all three locations.

📝 Generated with [Claude Code](https://claude.com/claude-code)