### PR TITLE
🐛 fix: cascade cancel running topics on task status change

### DIFF
--- a/packages/database/src/models/taskTopic.ts
+++ b/packages/database/src/models/taskTopic.ts
@@ -44,6 +44,26 @@ export class TaskTopicModel {
       );
   }
 
+  /**
+   * Atomically cancel a topic only if it is still in `running` status.
+   * Returns true if a row was actually updated.
+   */
+  async cancelIfRunning(taskId: string, topicId: string): Promise<boolean> {
+    const result = await this.db
+      .update(taskTopics)
+      .set({ status: 'canceled' })
+      .where(
+        and(
+          eq(taskTopics.taskId, taskId),
+          eq(taskTopics.topicId, topicId),
+          eq(taskTopics.status, 'running'),
+          eq(taskTopics.userId, this.userId),
+        ),
+      )
+      .returning();
+    return result.length > 0;
+  }
+
   async updateOperationId(taskId: string, topicId: string, operationId?: string): Promise<void> {
     await this.db
       .update(taskTopics)

--- a/src/server/routers/lambda/__tests__/integration/task.integration.test.ts
+++ b/src/server/routers/lambda/__tests__/integration/task.integration.test.ts
@@ -356,6 +356,49 @@ describe('Task Router Integration', () => {
     });
   });
 
+  describe('updateStatus cascade cancels running topics', () => {
+    it('should cancel running topics when task transitions out of running', async () => {
+      const task = await caller.create({
+        assigneeAgentId: testAgentId,
+        instruction: 'Test cascade',
+      });
+
+      // Start running — creates a running topic
+      await caller.run({ id: task.data.id });
+
+      // Transition task from running → paused via updateStatus
+      const result = await caller.updateStatus({
+        id: task.data.id,
+        status: 'paused',
+      });
+      expect(result.data.status).toBe('paused');
+
+      // The running topic should have been interrupted
+      expect(mockInterruptTask).toHaveBeenCalledWith({ operationId: 'op_test' });
+
+      // Running again should succeed (no CONFLICT) because the topic was canceled
+      mockExecAgent.mockResolvedValueOnce({
+        operationId: 'op_test_2',
+        success: true,
+        topicId: testTopicId,
+      });
+
+      // Need to set back to a runnable status first
+      await caller.updateStatus({ id: task.data.id, status: 'backlog' });
+      await expect(caller.run({ id: task.data.id })).resolves.toBeDefined();
+    });
+
+    it('should not interrupt topics when task is not currently running', async () => {
+      const task = await caller.create({
+        instruction: 'Test no cascade',
+      });
+
+      // Task is in backlog, transition to paused — no topics to cancel
+      await caller.updateStatus({ id: task.data.id, status: 'paused' });
+      expect(mockInterruptTask).not.toHaveBeenCalled();
+    });
+  });
+
   describe('heartbeat timeout detection', () => {
     it('should auto-detect timeout on detail and pause task', async () => {
       const task = await caller.create({

--- a/src/server/routers/lambda/__tests__/integration/task.integration.test.ts
+++ b/src/server/routers/lambda/__tests__/integration/task.integration.test.ts
@@ -397,6 +397,26 @@ describe('Task Router Integration', () => {
       await caller.updateStatus({ id: task.data.id, status: 'paused' });
       expect(mockInterruptTask).not.toHaveBeenCalled();
     });
+
+    it('should skip cancellation when interrupt fails', async () => {
+      const task = await caller.create({
+        assigneeAgentId: testAgentId,
+        instruction: 'Test interrupt failure',
+      });
+
+      await caller.run({ id: task.data.id });
+
+      // Make interruptTask fail
+      mockInterruptTask.mockRejectedValueOnce(new Error('network error'));
+
+      // Transition task from running → paused
+      await caller.updateStatus({ id: task.data.id, status: 'paused' });
+
+      // The topic should still be running because interrupt failed
+      // so re-running should hit CONFLICT
+      await caller.updateStatus({ id: task.data.id, status: 'backlog' });
+      await expect(caller.run({ id: task.data.id })).rejects.toThrow(/already has a running topic/);
+    });
   });
 
   describe('heartbeat timeout detection', () => {

--- a/src/server/routers/lambda/task.ts
+++ b/src/server/routers/lambda/task.ts
@@ -1233,6 +1233,22 @@ export const taskRouter = router({
         const model = ctx.taskModel;
         const resolved = await resolveOrThrow(model, id);
 
+        // Cascade: when leaving `running`, cancel all running topics
+        if (resolved.status === 'running' && status !== 'running') {
+          const topics = await ctx.taskTopicModel.findByTaskId(resolved.id);
+          const aiAgentService = new AiAgentService(ctx.serverDB, ctx.userId);
+
+          for (const t of topics) {
+            if (t.status !== 'running') continue;
+            if (t.operationId) {
+              await aiAgentService.interruptTask({ operationId: t.operationId }).catch((err) => {
+                console.error('[task:updateStatus] failed to interrupt topic %s:', t.topicId, err);
+              });
+            }
+            await ctx.taskTopicModel.updateStatus(resolved.id, t.topicId, 'canceled');
+          }
+        }
+
         const extra: Record<string, unknown> = {};
         if (status === 'running') extra.startedAt = new Date();
         if (status === 'completed' || status === 'failed' || status === 'canceled')

--- a/src/server/routers/lambda/task.ts
+++ b/src/server/routers/lambda/task.ts
@@ -1239,7 +1239,7 @@ export const taskRouter = router({
           const aiAgentService = new AiAgentService(ctx.serverDB, ctx.userId);
 
           for (const t of topics) {
-            if (t.status !== 'running') continue;
+            if (t.status !== 'running' || !t.topicId) continue;
 
             // Interrupt the remote operation first; if it fails, skip cancellation
             // to avoid desynchronizing DB state from a still-running operation.

--- a/src/server/routers/lambda/task.ts
+++ b/src/server/routers/lambda/task.ts
@@ -1240,12 +1240,21 @@ export const taskRouter = router({
 
           for (const t of topics) {
             if (t.status !== 'running') continue;
+
+            // Interrupt the remote operation first; if it fails, skip cancellation
+            // to avoid desynchronizing DB state from a still-running operation.
             if (t.operationId) {
-              await aiAgentService.interruptTask({ operationId: t.operationId }).catch((err) => {
+              try {
+                await aiAgentService.interruptTask({ operationId: t.operationId });
+              } catch (err) {
                 console.error('[task:updateStatus] failed to interrupt topic %s:', t.topicId, err);
-              });
+                continue;
+              }
             }
-            await ctx.taskTopicModel.updateStatus(resolved.id, t.topicId, 'canceled');
+
+            // Conditionally cancel only if the topic is still running,
+            // avoiding overwrite of a concurrent completed/timeout transition.
+            await ctx.taskTopicModel.cancelIfRunning(resolved.id, t.topicId);
           }
         }
 


### PR DESCRIPTION
## Summary

- When a task transitions out of `running` status, automatically cancel all associated running topics and interrupt their operations
- Prevents 409 CONFLICT errors when users re-run a task after manually changing its status
- Adds integration tests for the cascade behavior

Fixes LOBE-6719

## Test plan

- [x] Existing integration tests pass (15/15)
- [x] New test: cascade cancels running topics when task transitions out of running
- [x] New test: no interruption when task is not currently running

🤖 Generated with [Claude Code](https://claude.com/claude-code)