### PR TITLE
✨ feat(chat-input): improve mention menu skill and tool icons

### DIFF
--- a/src/features/ChatInput/InputEditor/MentionItemIcon.tsx
+++ b/src/features/ChatInput/InputEditor/MentionItemIcon.tsx
@@ -1,8 +1,6 @@
 import { Avatar, Icon } from '@lobehub/ui';
-import { McpIcon } from '@lobehub/ui/icons';
+import { McpIcon, SkillsIcon } from '@lobehub/ui/icons';
 import { memo } from 'react';
-
-import SkillAvatar from '@/components/SkillAvatar';
 
 interface MentionItemIconProps {
   avatar?: string;
@@ -21,7 +19,7 @@ const MentionItemIcon = memo<MentionItemIconProps>(({ avatar, category, label, s
   }
 
   if (category === 'skill' && !normalizedAvatar) {
-    return <SkillAvatar size={size} />;
+    return <Icon icon={SkillsIcon} size={Math.round(size * 0.8)} />;
   }
 
   return (

--- a/src/features/ChatInput/InputEditor/MentionItemIcon.tsx
+++ b/src/features/ChatInput/InputEditor/MentionItemIcon.tsx
@@ -1,0 +1,40 @@
+import { Avatar, Icon } from '@lobehub/ui';
+import { McpIcon } from '@lobehub/ui/icons';
+import { memo } from 'react';
+
+import SkillAvatar from '@/components/SkillAvatar';
+
+interface MentionItemIconProps {
+  avatar?: string;
+  category: 'skill' | 'tool';
+  label: string;
+  size?: number;
+}
+
+const isAvatarPlaceholder = (avatar?: string) => Boolean(avatar && avatar.endsWith('_AVATAR'));
+
+const MentionItemIcon = memo<MentionItemIconProps>(({ avatar, category, label, size = 24 }) => {
+  const normalizedAvatar = isAvatarPlaceholder(avatar) ? undefined : avatar;
+
+  if (category === 'tool' && !normalizedAvatar) {
+    return <Icon icon={McpIcon} size={Math.round(size * 0.8)} />;
+  }
+
+  if (category === 'skill' && !normalizedAvatar) {
+    return <SkillAvatar size={size} />;
+  }
+
+  return (
+    <Avatar
+      avatar={normalizedAvatar}
+      shape={'square'}
+      size={size}
+      style={{ flex: 'none', overflow: 'hidden' }}
+      title={label}
+    />
+  );
+});
+
+MentionItemIcon.displayName = 'MentionItemIcon';
+
+export default MentionItemIcon;

--- a/src/features/ChatInput/InputEditor/MentionMenu/style.ts
+++ b/src/features/ChatInput/InputEditor/MentionMenu/style.ts
@@ -85,6 +85,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     background: ${cssVar.colorFillSecondary};
   `,
   itemIcon: css`
+    overflow: hidden;
     display: flex;
     flex-shrink: 0;
     align-items: center;
@@ -92,6 +93,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
     width: 24px;
     height: 24px;
+    border-radius: 6px;
   `,
   itemLabel: css`
     overflow: hidden;

--- a/src/features/ChatInput/InputEditor/useMentionCategories.tsx
+++ b/src/features/ChatInput/InputEditor/useMentionCategories.tsx
@@ -1,7 +1,7 @@
 import { Avatar, Icon } from '@lobehub/ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
 import { Bot, MessageSquareText, Users, Wrench } from 'lucide-react';
-import { createElement, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
@@ -13,32 +13,12 @@ import { homeAgentListSelectors } from '@/store/home/selectors';
 import { useAgentId } from '../hooks/useAgentId';
 import { useChatInputStore } from '../store';
 import { useInstalledSkillsAndTools } from './ActionTag/useInstalledSkillsAndTools';
+import MentionItemIcon from './MentionItemIcon';
 import type { MentionCategory } from './MentionMenu/types';
 
 const MAX_AGENT_ITEMS = 20;
 const MAX_TOPIC_LABEL = 50;
 type MenuOptionWithMetadata = { key: string; metadata?: Record<string, unknown> };
-
-/** Render a skill/tool avatar as a ReactNode icon. */
-const shouldRenderIconAsImage = (str: string) =>
-  str.startsWith('http://') ||
-  str.startsWith('https://') ||
-  str.startsWith('blob:') ||
-  /^data:image\//i.test(str);
-
-const renderAvatar = (avatar: string | undefined): React.ReactNode => {
-  if (!avatar) return <Icon icon={SkillsIcon} size={16} />;
-  if (shouldRenderIconAsImage(avatar)) {
-    return createElement('img', {
-      alt: '',
-      height: 16,
-      src: avatar,
-      style: { flexShrink: 0, objectFit: 'contain' as const },
-      width: 16,
-    });
-  }
-  return createElement('span', { style: { fontSize: 16, lineHeight: 1 } }, avatar);
-};
 
 export const useMentionCategories = (): MentionCategory[] => {
   const currentAgentId = useAgentId();
@@ -149,7 +129,7 @@ export const useMentionCategories = (): MentionCategory[] => {
         id: 'skill',
         icon: <Icon icon={SkillsIcon} size={16} />,
         items: skillItems.map((item) => ({
-          icon: renderAvatar(item.icon),
+          icon: <MentionItemIcon avatar={item.icon} category={'skill'} label={item.label} />,
           key: `skill-${item.type}`,
           label: item.label,
           metadata: {
@@ -170,7 +150,7 @@ export const useMentionCategories = (): MentionCategory[] => {
         id: 'tool',
         icon: <Icon icon={Wrench} size={16} />,
         items: toolItems.map((item) => ({
-          icon: renderAvatar(item.icon),
+          icon: <MentionItemIcon avatar={item.icon} category={'tool'} label={item.label} />,
           key: `tool-${item.type}`,
           label: item.label,
           metadata: {


### PR DESCRIPTION
## Summary

Extracts mention list icons for skills and tools into a dedicated `MentionItemIcon` component: uses `SkillAvatar` / MCP icon for empty avatars, treats `*_AVATAR` placeholders as missing, and uses square `Avatar` for real image URLs. Mention menu icon cell gets `overflow: hidden` and rounded corners for cleaner thumbnails.

## Test plan

- [ ] Open chat input `@` mention menu
- [ ] Verify skill and tool rows show consistent icons (including fallback icons when no avatar)
- [ ] Verify image URLs still render as square avatars

Made with [Cursor](https://cursor.com)