### PR TITLE
🔨 chore: resolve author info for task activity list

### DIFF
--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -59,8 +59,16 @@ export interface TaskDetailWorkspaceNode {
   title?: string;
 }
 
+export interface TaskDetailActivityAuthor {
+  avatar?: string | null;
+  id: string;
+  name?: string | null;
+  type: 'agent' | 'user';
+}
+
 export interface TaskDetailActivity {
   agentId?: string | null;
+  author?: TaskDetailActivityAuthor;
   briefType?: string;
   content?: string;
   id?: string;

--- a/src/server/services/task/index.test.ts
+++ b/src/server/services/task/index.test.ts
@@ -21,7 +21,13 @@ vi.mock('@/database/models/brief', () => ({
 }));
 
 describe('TaskService', () => {
-  const db = {} as LobeChatDatabase;
+  const mockSelectChain = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockResolvedValue([]),
+  };
+  const db = {
+    select: vi.fn().mockReturnValue(mockSelectChain),
+  } as unknown as LobeChatDatabase;
   const userId = 'user-1';
 
   const mockTaskModel = {
@@ -506,6 +512,93 @@ describe('TaskService', () => {
       expect(result?.activities?.[0].type).toBe('brief');
       expect(result?.activities?.[1].type).toBe('comment');
       expect(result?.activities?.[2].type).toBe('topic');
+    });
+
+    it('should resolve author info for activities', async () => {
+      const task = {
+        assigneeAgentId: 'agt_assignee',
+        assigneeUserId: null,
+        createdAt: null,
+        description: null,
+        error: null,
+        heartbeatInterval: null,
+        heartbeatTimeout: null,
+        id: 'task_001',
+        identifier: 'TASK-1',
+        instruction: null,
+        lastHeartbeatAt: null,
+        name: 'Task 1',
+        parentTaskId: null,
+        priority: 'normal',
+        status: 'running',
+        totalTopics: 0,
+      };
+
+      const topics = [
+        {
+          createdAt: new Date('2024-01-01T00:00:00Z'),
+          handoff: { title: 'Run 1' },
+          seq: 1,
+          status: 'completed',
+          topicId: 'topic-1',
+        },
+      ];
+
+      const comments = [
+        {
+          authorAgentId: null,
+          authorUserId: 'user_bob',
+          content: 'User comment',
+          createdAt: new Date('2024-01-02T00:00:00Z'),
+        },
+      ];
+
+      mockTaskModel.resolve.mockResolvedValue(task);
+      mockTaskModel.findAllDescendants.mockResolvedValue([]);
+      mockTaskModel.getDependencies.mockResolvedValue([]);
+      mockTaskTopicModel.findWithHandoff.mockResolvedValue(topics);
+      mockBriefModel.findByTaskId.mockResolvedValue([]);
+      mockTaskModel.getComments.mockResolvedValue(comments);
+      mockTaskModel.getTreePinnedDocuments.mockResolvedValue({ nodeMap: {}, tree: [] });
+      mockTaskModel.findByIds.mockResolvedValue([]);
+      mockTaskModel.getCheckpointConfig.mockReturnValue({});
+      mockTaskModel.getReviewConfig.mockReturnValue(undefined);
+
+      // Mock db.select to return agent and user data
+      let callCount = 0;
+      mockSelectChain.where.mockImplementation(() => {
+        callCount++;
+        // First call: agents query
+        if (callCount === 1)
+          return Promise.resolve([
+            { avatar: 'https://example.com/agent.png', id: 'agt_assignee', title: 'My Agent' },
+          ]);
+        // Second call: users query
+        return Promise.resolve([
+          { avatar: 'https://example.com/bob.png', fullName: 'Bob', id: 'user_bob' },
+        ]);
+      });
+
+      const service = new TaskService(db, userId);
+      const result = await service.getTaskDetail('TASK-1');
+
+      // Topic should have agent author
+      const topicActivity = result?.activities?.find((a) => a.type === 'topic');
+      expect(topicActivity?.author).toEqual({
+        avatar: 'https://example.com/agent.png',
+        id: 'agt_assignee',
+        name: 'My Agent',
+        type: 'agent',
+      });
+
+      // Comment should have user author
+      const commentActivity = result?.activities?.find((a) => a.type === 'comment');
+      expect(commentActivity?.author).toEqual({
+        avatar: 'https://example.com/bob.png',
+        id: 'user_bob',
+        name: 'Bob',
+        type: 'user',
+      });
     });
 
     it('should include topic count when topics exist', async () => {

--- a/src/server/services/task/index.test.ts
+++ b/src/server/services/task/index.test.ts
@@ -1,12 +1,18 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { AgentModel } from '@/database/models/agent';
 import { BriefModel } from '@/database/models/brief';
 import { TaskModel } from '@/database/models/task';
 import { TaskTopicModel } from '@/database/models/taskTopic';
+import { UserModel } from '@/database/models/user';
 import type { LobeChatDatabase } from '@/database/type';
 
 import { TaskService } from './index';
+
+vi.mock('@/database/models/agent', () => ({
+  AgentModel: vi.fn(),
+}));
 
 vi.mock('@/database/models/task', () => ({
   TaskModel: vi.fn(),
@@ -20,15 +26,17 @@ vi.mock('@/database/models/brief', () => ({
   BriefModel: vi.fn(),
 }));
 
+vi.mock('@/database/models/user', () => ({
+  UserModel: { findByIds: vi.fn().mockResolvedValue([]) },
+}));
+
 describe('TaskService', () => {
-  const mockSelectChain = {
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn().mockResolvedValue([]),
-  };
-  const db = {
-    select: vi.fn().mockReturnValue(mockSelectChain),
-  } as unknown as LobeChatDatabase;
+  const db = {} as LobeChatDatabase;
   const userId = 'user-1';
+
+  const mockAgentModel = {
+    getAgentAvatarsByIds: vi.fn().mockResolvedValue([]),
+  };
 
   const mockTaskModel = {
     findById: vi.fn(),
@@ -53,6 +61,7 @@ describe('TaskService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    (AgentModel as any).mockImplementation(() => mockAgentModel);
     (TaskModel as any).mockImplementation(() => mockTaskModel);
     (TaskTopicModel as any).mockImplementation(() => mockTaskTopicModel);
     (BriefModel as any).mockImplementation(() => mockBriefModel);
@@ -564,20 +573,13 @@ describe('TaskService', () => {
       mockTaskModel.getCheckpointConfig.mockReturnValue({});
       mockTaskModel.getReviewConfig.mockReturnValue(undefined);
 
-      // Mock db.select to return agent and user data
-      let callCount = 0;
-      mockSelectChain.where.mockImplementation(() => {
-        callCount++;
-        // First call: agents query
-        if (callCount === 1)
-          return Promise.resolve([
-            { avatar: 'https://example.com/agent.png', id: 'agt_assignee', title: 'My Agent' },
-          ]);
-        // Second call: users query
-        return Promise.resolve([
-          { avatar: 'https://example.com/bob.png', fullName: 'Bob', id: 'user_bob' },
-        ]);
-      });
+      // Mock model methods to return agent and user data
+      mockAgentModel.getAgentAvatarsByIds.mockResolvedValue([
+        { avatar: 'https://example.com/agent.png', id: 'agt_assignee', title: 'My Agent' },
+      ]);
+      vi.mocked(UserModel.findByIds).mockResolvedValue([
+        { avatar: 'https://example.com/bob.png', fullName: 'Bob', id: 'user_bob' } as any,
+      ]);
 
       const service = new TaskService(db, userId);
       const result = await service.getTaskDetail('TASK-1');

--- a/src/server/services/task/index.ts
+++ b/src/server/services/task/index.ts
@@ -1,25 +1,30 @@
 import type {
   TaskDetailActivity,
+  TaskDetailActivityAuthor,
   TaskDetailData,
   TaskDetailSubtask,
   TaskDetailWorkspaceNode,
   TaskTopicHandoff,
   WorkspaceData,
 } from '@lobechat/types';
+import { inArray } from 'drizzle-orm';
 
 import { BriefModel } from '@/database/models/brief';
 import { TaskModel } from '@/database/models/task';
 import { TaskTopicModel } from '@/database/models/taskTopic';
+import { agents, users } from '@/database/schemas';
 import type { LobeChatDatabase } from '@/database/type';
 
 const emptyWorkspace: WorkspaceData = { nodeMap: {}, tree: [] };
 
 export class TaskService {
   private briefModel: BriefModel;
+  private db: LobeChatDatabase;
   private taskModel: TaskModel;
   private taskTopicModel: TaskTopicModel;
 
   constructor(db: LobeChatDatabase, userId: string) {
+    this.db = db;
     this.taskModel = new TaskModel(db, userId);
     this.taskTopicModel = new TaskTopicModel(db, userId);
     this.briefModel = new BriefModel(db, userId);
@@ -112,8 +117,27 @@ export class TaskService {
     const toISO = (d: Date | string | null | undefined) =>
       d ? new Date(d).toISOString() : undefined;
 
+    // Collect unique agent/user IDs for author resolution
+    const agentIds = new Set<string>();
+    const userIds = new Set<string>();
+
+    // Topics are created by the task's assignee agent
+    if (task.assigneeAgentId && topics.length > 0) agentIds.add(task.assigneeAgentId);
+    // Briefs may have an agentId
+    for (const b of briefs) {
+      if (b.agentId) agentIds.add(b.agentId);
+    }
+    // Comments have authorAgentId or authorUserId
+    for (const c of comments) {
+      if (c.authorAgentId) agentIds.add(c.authorAgentId);
+      if (c.authorUserId) userIds.add(c.authorUserId);
+    }
+
+    const authorMap = await this.resolveAuthors(agentIds, userIds);
+
     const activities: TaskDetailActivity[] = [
       ...topics.map((t) => ({
+        author: task.assigneeAgentId ? authorMap.get(task.assigneeAgentId) : undefined,
         id: t.topicId ?? undefined,
         seq: t.seq,
         status: t.status,
@@ -122,6 +146,7 @@ export class TaskService {
         type: 'topic' as const,
       })),
       ...briefs.map((b) => ({
+        author: b.agentId ? authorMap.get(b.agentId) : undefined,
         briefType: b.type,
         id: b.id,
         priority: b.priority,
@@ -137,6 +162,11 @@ export class TaskService {
       })),
       ...comments.map((c) => ({
         agentId: c.authorAgentId,
+        author: c.authorAgentId
+          ? authorMap.get(c.authorAgentId)
+          : c.authorUserId
+            ? authorMap.get(c.authorUserId)
+            : undefined,
         content: c.content,
         time: toISO(c.createdAt),
         type: 'comment' as const,
@@ -183,5 +213,39 @@ export class TaskService {
       topicCount: topics.length > 0 ? topics.length : undefined,
       workspace: workspaceFolders.length > 0 ? workspaceFolders : undefined,
     };
+  }
+
+  /**
+   * Batch-resolve agent and user IDs to author info (name + avatar).
+   */
+  private async resolveAuthors(
+    agentIds: Set<string>,
+    userIds: Set<string>,
+  ): Promise<Map<string, TaskDetailActivityAuthor>> {
+    const map = new Map<string, TaskDetailActivityAuthor>();
+
+    const [agentRows, userRows] = await Promise.all([
+      agentIds.size > 0
+        ? this.db
+            .select({ avatar: agents.avatar, id: agents.id, title: agents.title })
+            .from(agents)
+            .where(inArray(agents.id, [...agentIds]))
+        : [],
+      userIds.size > 0
+        ? this.db
+            .select({ avatar: users.avatar, fullName: users.fullName, id: users.id })
+            .from(users)
+            .where(inArray(users.id, [...userIds]))
+        : [],
+    ]);
+
+    for (const a of agentRows) {
+      map.set(a.id, { avatar: a.avatar, id: a.id, name: a.title, type: 'agent' });
+    }
+    for (const u of userRows) {
+      map.set(u.id, { avatar: u.avatar, id: u.id, name: u.fullName, type: 'user' });
+    }
+
+    return map;
   }
 }

--- a/src/server/services/task/index.ts
+++ b/src/server/services/task/index.ts
@@ -7,17 +7,18 @@ import type {
   TaskTopicHandoff,
   WorkspaceData,
 } from '@lobechat/types';
-import { inArray } from 'drizzle-orm';
 
+import { AgentModel } from '@/database/models/agent';
 import { BriefModel } from '@/database/models/brief';
 import { TaskModel } from '@/database/models/task';
 import { TaskTopicModel } from '@/database/models/taskTopic';
-import { agents, users } from '@/database/schemas';
+import { UserModel } from '@/database/models/user';
 import type { LobeChatDatabase } from '@/database/type';
 
 const emptyWorkspace: WorkspaceData = { nodeMap: {}, tree: [] };
 
 export class TaskService {
+  private agentModel: AgentModel;
   private briefModel: BriefModel;
   private db: LobeChatDatabase;
   private taskModel: TaskModel;
@@ -25,6 +26,7 @@ export class TaskService {
 
   constructor(db: LobeChatDatabase, userId: string) {
     this.db = db;
+    this.agentModel = new AgentModel(db, userId);
     this.taskModel = new TaskModel(db, userId);
     this.taskTopicModel = new TaskTopicModel(db, userId);
     this.briefModel = new BriefModel(db, userId);
@@ -225,18 +227,8 @@ export class TaskService {
     const map = new Map<string, TaskDetailActivityAuthor>();
 
     const [agentRows, userRows] = await Promise.all([
-      agentIds.size > 0
-        ? this.db
-            .select({ avatar: agents.avatar, id: agents.id, title: agents.title })
-            .from(agents)
-            .where(inArray(agents.id, [...agentIds]))
-        : [],
-      userIds.size > 0
-        ? this.db
-            .select({ avatar: users.avatar, fullName: users.fullName, id: users.id })
-            .from(users)
-            .where(inArray(users.id, [...userIds]))
-        : [],
+      this.agentModel.getAgentAvatarsByIds([...agentIds]),
+      UserModel.findByIds(this.db, [...userIds]),
     ]);
 
     for (const a of agentRows) {


### PR DESCRIPTION
## Summary

- Add `author` field (`{id, type, name, avatar}`) to `TaskDetailActivity` type
- Backend batch-resolves agent/user info in `getTaskDetail` via `resolveAuthors()`
- Topics get author from task's `assigneeAgentId`, briefs from `agentId`, comments from `authorAgentId` / `authorUserId`
- Add `TaskDetailActivityAuthor` interface to `@lobechat/types`

Fixes LOBE-7013

## Test plan

- [x] Existing unit tests pass (20/20)
- [x] New test: verifies author resolution for topic (agent) and comment (user) activities
- [x] Integration tests pass (16/16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)