### PR TITLE
💄 style: show loading state for assistant message during optimistic update

### DIFF
--- a/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
@@ -21,13 +21,15 @@ const MessageContent = memo<UIChatMessage>(
     const markdownProps = useMarkdown(id);
     // Use ConversationStore instead of ChatStore
     const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
+    const isCreating = useConversationStore(messageStateSelectors.isMessageCreating(id));
     const isCollapsed = useConversationStore(messageStateSelectors.isMessageCollapsed(id));
     const isReasoning = useConversationStore(messageStateSelectors.isMessageInReasoning(id));
     const addReaction = useConversationStore((s) => s.addReaction);
     const removeReaction = useConversationStore((s) => s.removeReaction);
     const userId = useUserStore(userProfileSelectors.userId)!;
 
-    const isToolCallGenerating = generating && (content === LOADING_FLAT || !content) && !!tools;
+    const isLoading = generating || isCreating;
+    const isToolCallGenerating = isLoading && (content === LOADING_FLAT || !content) && !!tools;
 
     const showSearch = !!search && (!!search.citations?.length || !!search.imageResults?.length);
     const showImageItems = !!imageList && imageList.length > 0;
@@ -78,7 +80,7 @@ const MessageContent = memo<UIChatMessage>(
         {showReasoning && <Reasoning {...props.reasoning} id={id} />}
         <DisplayContent
           content={content}
-          generating={generating}
+          generating={isLoading}
           hasImages={showImageItems}
           id={id}
           isMultimodal={metadata?.isMultimodal}

--- a/src/features/Conversation/Messages/Assistant/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/index.tsx
@@ -56,9 +56,10 @@ const AssistantMessage = memo<AssistantMessageProps>(({ id, index, disableEditin
 
   const avatar = useAgentMeta(agentId);
 
-  // Get editing, generating, and interrupted state from ConversationStore
+  // Get editing, generating, creating, and interrupted state from ConversationStore
   const editing = useConversationStore(messageStateSelectors.isMessageEditing(id));
   const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
+  const isCreating = useConversationStore(messageStateSelectors.isMessageCreating(id));
   const interrupted = useConversationStore(messageStateSelectors.isMessageInterrupted(id));
 
   const errorContent = useErrorContent(error);
@@ -96,7 +97,7 @@ const AssistantMessage = memo<AssistantMessageProps>(({ id, index, disableEditin
       customErrorRender={(error) => <ErrorMessageExtra data={item} error={error} />}
       editing={editing}
       id={id}
-      loading={generating}
+      loading={generating || isCreating}
       message={message}
       placement={'left'}
       time={createdAt}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

During `sendMessage` optimistic update, the assistant message is created with `content: LOADING_FLAT` ("...") but the loading indicator (`<ContentLoading>`) was not displayed. 

**Root cause:** `isMessageGenerating` only checks `AI_RUNTIME_OPERATION_TYPES` (`execAgentRuntime` / `execServerAgentRuntime`), which doesn't include the `sendMessage` operation type. During the gap between `sendMessage` and `execAgentRuntime`, `generating` is `false`, so `DisplayContent` returns `null` for the "..." content.

**Fix:** Also check `isMessageCreating` (which covers the `sendMessage` operation) alongside `isMessageGenerating` so the loading dots appear immediately when the message is sent.

#### 🧪 How to Test

- [x] No tests needed

1. Send a message in any conversation
2. Observe the assistant message area immediately after sending
3. The "..." loading indicator should now appear during the brief sendMessage phase before streaming begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)