### PR TITLE
💄 style: add delete action to agent profile dropdown menu

### DIFF
--- a/src/routes/(main)/agent/profile/features/Header/index.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.tsx
@@ -1,8 +1,8 @@
 import { ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
 import { ShapesUploadIcon } from '@lobehub/ui/icons';
-import { Modal } from 'antd';
+import { App, Modal } from 'antd';
 import isEqual from 'fast-deep-equal';
-import { BotMessageSquareIcon, MoreHorizontal, Settings2Icon } from 'lucide-react';
+import { BotMessageSquareIcon, MoreHorizontal, Settings2Icon, Trash } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -14,6 +14,7 @@ import { useMarketAuth } from '@/layout/AuthProvider/MarketAuth';
 import { resolveMarketAuthError } from '@/layout/AuthProvider/MarketAuth/errors';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
+import { useHomeStore } from '@/store/home';
 
 import AgentForkTag from './AgentForkTag';
 import ForkConfirmModal from './AgentPublishButton/ForkConfirmModal';
@@ -24,10 +25,13 @@ import AgentVersionReviewTag, { useVersionReviewStatus } from './AgentVersionRev
 import AutoSaveHint from './AutoSaveHint';
 
 const Header = memo(() => {
-  const { t } = useTranslation(['setting', 'marketAuth']);
+  const { t } = useTranslation(['setting', 'marketAuth', 'chat']);
+  const { modal } = App.useApp();
 
   const meta = useAgentStore(agentSelectors.currentAgentMeta, isEqual);
   const systemRole = useAgentStore(agentSelectors.currentAgentSystemRole);
+  const activeAgentId = useAgentStore((s) => s.activeAgentId);
+  const removeAgent = useHomeStore((s) => s.removeAgent);
   const { isAuthenticated, isLoading: isAuthLoading, signIn } = useMarketAuth();
   const { isUnderReview } = useVersionReviewStatus();
 
@@ -111,6 +115,19 @@ const Header = memo(() => {
     await publish();
   }, [publish]);
 
+  const handleDelete = useCallback(() => {
+    if (!activeAgentId) return;
+    modal.confirm({
+      centered: true,
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        await removeAgent(activeAgentId);
+        message.success(t('confirmRemoveSessionSuccess', { ns: 'chat' }));
+      },
+      title: t('confirmRemoveSessionItemAlert', { ns: 'chat' }),
+    });
+  }, [activeAgentId, modal, removeAgent, t]);
+
   const menuItems = useMemo(
     () => [
       {
@@ -126,8 +143,16 @@ const Header = memo(() => {
         label: t('publishToCommunity', { ns: 'setting' }),
         onClick: handlePublishClick,
       },
+      { type: 'divider' as const },
+      {
+        danger: true,
+        icon: <Icon icon={Trash} />,
+        key: 'delete',
+        label: t('delete', { ns: 'common' }),
+        onClick: handleDelete,
+      },
     ],
-    [handlePublishClick, t],
+    [handlePublishClick, handleDelete, t],
   );
 
   return (

--- a/src/routes/(main)/agent/profile/features/Header/index.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.tsx
@@ -5,6 +5,7 @@ import isEqual from 'fast-deep-equal';
 import { BotMessageSquareIcon, MoreHorizontal, Settings2Icon, Trash } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 
 import { message } from '@/components/AntdStaticMethods';
 import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
@@ -27,6 +28,7 @@ import AutoSaveHint from './AutoSaveHint';
 const Header = memo(() => {
   const { t } = useTranslation(['setting', 'marketAuth', 'chat']);
   const { modal } = App.useApp();
+  const navigate = useNavigate();
 
   const meta = useAgentStore(agentSelectors.currentAgentMeta, isEqual);
   const systemRole = useAgentStore(agentSelectors.currentAgentSystemRole);
@@ -123,10 +125,11 @@ const Header = memo(() => {
       onOk: async () => {
         await removeAgent(activeAgentId);
         message.success(t('confirmRemoveSessionSuccess', { ns: 'chat' }));
+        navigate('/');
       },
       title: t('confirmRemoveSessionItemAlert', { ns: 'chat' }),
     });
-  }, [activeAgentId, modal, removeAgent, t]);
+  }, [activeAgentId, modal, navigate, removeAgent, t]);
 
   const menuItems = useMemo(
     () => [


### PR DESCRIPTION
## Summary

- Add "Delete" option to the three-dot (`···`) dropdown menu in Agent Profile header
- Uses `modal.confirm` with danger styling for confirmation
- Calls `useHomeStore.removeAgent` which deletes the agent and redirects to inbox

Fixes LOBE-6582

## Test plan

- [ ] Open an agent profile page
- [ ] Click the three-dot menu → verify "Delete" option appears at the bottom with red styling
- [ ] Click "Delete" → verify confirmation modal appears
- [ ] Confirm deletion → verify agent is deleted and user is redirected

🤖 Generated with [Claude Code](https://claude.com/claude-code)