### PR TITLE
🐛 fix(inbox): restore inbox avatar fallback after deletion

### DIFF
--- a/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.tsx
@@ -75,7 +75,7 @@ const AgentHeader = memo(() => {
 
   // Handle avatar delete
   const handleAvatarDelete = useCallback(() => {
-    updateMeta({ avatar: undefined });
+    updateMeta({ avatar: null });
   }, [updateMeta]);
 
   // Handle background color change (immediate save)

--- a/src/routes/(main)/group/profile/features/MemberProfile/AgentHeader.tsx
+++ b/src/routes/(main)/group/profile/features/MemberProfile/AgentHeader.tsx
@@ -87,7 +87,7 @@ const AgentHeader = memo<AgentHeaderProps>(({ readOnly }) => {
 
   // Handle avatar delete
   const handleAvatarDelete = useCallback(() => {
-    optimisticUpdateAgentMeta(agentId, { avatar: undefined });
+    optimisticUpdateAgentMeta(agentId, { avatar: null });
   }, [optimisticUpdateAgentMeta, agentId]);
 
   // Handle background color change (immediate save) - save to agent store (supervisor agent)

--- a/src/services/agent.ts
+++ b/src/services/agent.ts
@@ -1,4 +1,4 @@
-import { type AgentItem, type LobeAgentConfig, type MetaData } from '@lobechat/types';
+import { type AgentItem, type LobeAgentConfig } from '@lobechat/types';
 import { type PartialDeep } from 'type-fest';
 
 import { lambdaClient } from '@/libs/trpc/client';
@@ -13,6 +13,13 @@ type MarketAgentModel =
       parameters?: Partial<LobeAgentConfig['params']>;
       provider?: LobeAgentConfig['provider'];
     };
+
+type AgentMetaUpdate = Partial<
+  Pick<
+    AgentItem,
+    'avatar' | 'backgroundColor' | 'description' | 'marketIdentifier' | 'tags' | 'title'
+  >
+>;
 
 /**
  * Normalize market agent config to standard agent config.
@@ -182,7 +189,7 @@ class AgentService {
   /**
    * Update agent meta and return the updated agent data
    */
-  updateAgentMeta = async (agentId: string, meta: Partial<MetaData>, signal?: AbortSignal) => {
+  updateAgentMeta = async (agentId: string, meta: AgentMetaUpdate, signal?: AbortSignal) => {
     return lambdaClient.agent.updateAgentConfig.mutate({ agentId, value: meta }, { signal });
   };
 

--- a/src/store/agent/selectors/selectors.test.ts
+++ b/src/store/agent/selectors/selectors.test.ts
@@ -2,6 +2,7 @@ import { DEFAULT_PROVIDER } from '@lobechat/business-const';
 import {
   DEFAULT_AGENT_CONFIG,
   DEFAULT_AVATAR,
+  DEFAULT_INBOX_AVATAR,
   DEFAULT_MODEL,
   DEFAUTT_AGENT_TTS_CONFIG,
   INBOX_SESSION_ID,
@@ -136,6 +137,18 @@ describe('agentSelectors', () => {
 
       expect(meta.avatar).toBe(DEFAULT_AVATAR);
     });
+
+    it('should return inbox avatar fallback for inbox agent with no custom avatar', () => {
+      const state = createState({
+        activeAgentId: 'inbox-agent',
+        agentMap: { 'inbox-agent': {} },
+        builtinAgentIdMap: { [INBOX_SESSION_ID]: 'inbox-agent' },
+      });
+
+      const meta = agentSelectors.currentAgentMeta(state);
+
+      expect(meta.avatar).toBe(DEFAULT_INBOX_AVATAR);
+    });
   });
 
   describe('getAgentMetaById', () => {
@@ -160,6 +173,17 @@ describe('agentSelectors', () => {
       const meta = agentSelectors.getAgentMetaById('non-existent')(state);
 
       expect(meta).toEqual({});
+    });
+
+    it('should return inbox avatar fallback for inbox agent with no custom avatar', () => {
+      const state = createState({
+        agentMap: { 'inbox-agent': {} },
+        builtinAgentIdMap: { [INBOX_SESSION_ID]: 'inbox-agent' },
+      });
+
+      const meta = agentSelectors.getAgentMetaById('inbox-agent')(state);
+
+      expect(meta.avatar).toBe(DEFAULT_INBOX_AVATAR);
     });
   });
 

--- a/src/store/agent/selectors/selectors.ts
+++ b/src/store/agent/selectors/selectors.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_AGENT_CONFIG,
   DEFAULT_AVATAR,
   DEFAULT_BACKGROUND_COLOR,
+  DEFAULT_INBOX_AVATAR,
   DEFAULT_MODEL,
   DEFAUTT_AGENT_TTS_CONFIG,
   isDesktop,
@@ -33,7 +34,14 @@ const currentAgentData = (s: AgentStoreState) =>
 
 const currentAgentTitle = (s: AgentStoreState) => currentAgentData(s)?.title;
 
-const currentAgentAvatar = (s: AgentStoreState) => currentAgentData(s)?.avatar || DEFAULT_AVATAR;
+const getDefaultAvatarByAgentId = (s: AgentStoreState, agentId?: string) => {
+  const inboxAgentId = builtinAgentSelectors.inboxAgentId(s);
+
+  return agentId && inboxAgentId === agentId ? DEFAULT_INBOX_AVATAR : DEFAULT_AVATAR;
+};
+
+const currentAgentAvatar = (s: AgentStoreState) =>
+  currentAgentData(s)?.avatar || getDefaultAvatarByAgentId(s, s.activeAgentId);
 
 const currentAgentDescription = (s: AgentStoreState) => currentAgentData(s)?.description;
 
@@ -49,7 +57,7 @@ const currentAgentTags = (s: AgentStoreState) => currentAgentData(s)?.tags || []
 const currentAgentMeta = (s: AgentStoreState): MetaData => {
   const data = currentAgentData(s);
   return {
-    avatar: data?.avatar || DEFAULT_AVATAR,
+    avatar: data?.avatar || getDefaultAvatarByAgentId(s, s.activeAgentId),
     backgroundColor: data?.backgroundColor || DEFAULT_BACKGROUND_COLOR,
     description: data?.description || undefined,
     marketIdentifier: data?.marketIdentifier || undefined,
@@ -69,7 +77,7 @@ const getAgentMetaById =
     if (!data) return {};
 
     return {
-      avatar: data.avatar || DEFAULT_AVATAR,
+      avatar: data.avatar || getDefaultAvatarByAgentId(s, agentId),
       backgroundColor: data.backgroundColor || DEFAULT_BACKGROUND_COLOR,
       description: data.description || undefined,
       marketIdentifier: data.marketIdentifier || undefined,

--- a/src/store/agent/slices/agent/action.test.ts
+++ b/src/store/agent/slices/agent/action.test.ts
@@ -266,6 +266,29 @@ describe('AgentSlice Actions', () => {
         expect.any(AbortSignal),
       );
     });
+
+    it('should preserve explicit null when clearing avatar', async () => {
+      const { result } = renderHook(() => useAgentStore());
+
+      vi.mocked(agentService.updateAgentMeta).mockResolvedValue({
+        agent: { avatar: null } as any,
+        success: true,
+      });
+
+      act(() => {
+        useAgentStore.setState({ activeAgentId: 'agent-1' });
+      });
+
+      await act(async () => {
+        await result.current.updateAgentMeta({ avatar: null });
+      });
+
+      expect(agentService.updateAgentMeta).toHaveBeenCalledWith(
+        'agent-1',
+        { avatar: null },
+        expect.any(AbortSignal),
+      );
+    });
   });
 
   describe('updateAgentChatConfig', () => {

--- a/src/store/agent/slices/agent/action.ts
+++ b/src/store/agent/slices/agent/action.ts
@@ -20,8 +20,12 @@ import {
 import type { StoreSetter } from '@/store/types';
 import { getUserStoreState } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
-import type { LobeAgentChatConfig, LobeAgentConfig, RuntimeEnvConfig } from '@/types/agent';
-import type { MetaData } from '@/types/meta';
+import type {
+  AgentItem,
+  LobeAgentChatConfig,
+  LobeAgentConfig,
+  RuntimeEnvConfig,
+} from '@/types/agent';
 import { merge } from '@/utils/merge';
 
 import type { AgentStore } from '../../store';
@@ -29,6 +33,12 @@ import { setLocalAgentWorkingDirectory } from '../../utils/localAgentWorkingDire
 import type { AgentSliceState, LoadingState, SaveStatus } from './initialState';
 
 const FETCH_AGENT_CONFIG_KEY = 'FETCH_AGENT_CONFIG';
+type AgentMetaUpdate = Partial<
+  Pick<
+    AgentItem,
+    'avatar' | 'backgroundColor' | 'description' | 'marketIdentifier' | 'tags' | 'title'
+  >
+>;
 
 /**
  * Agent Slice Actions
@@ -227,7 +237,7 @@ export class AgentSliceActionImpl {
     }
   };
 
-  updateAgentMeta = async (meta: Partial<MetaData>): Promise<void> => {
+  updateAgentMeta = async (meta: AgentMetaUpdate): Promise<void> => {
     const { activeAgentId } = this.#get();
 
     if (!activeAgentId) return;
@@ -369,7 +379,7 @@ export class AgentSliceActionImpl {
 
   optimisticUpdateAgentMeta = async (
     id: string,
-    meta: Partial<MetaData>,
+    meta: AgentMetaUpdate,
     signal?: AbortSignal,
   ): Promise<void> => {
     const { internal_dispatchAgentMap, updateSaveStatus } = this.#get();


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- None

#### 🔀 Description of Change

- restore the dedicated inbox avatar fallback when the inbox agent no longer has a custom avatar
- persist avatar deletion as `null` so clearing the avatar is not swallowed by the update merge path
- add regression coverage for inbox selector fallback and avatar clearing behavior

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Local verification:
- `bunx vitest run --silent='passed-only' 'src/store/agent/selectors/selectors.test.ts' 'src/store/agent/slices/agent/action.test.ts'`
- `bun run type-check`

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Inbox agent avatar fell back to the generic agent default after deletion. | Inbox agent avatar falls back to the dedicated inbox avatar after deletion. |

#### 📝 Additional Information

- The branch was recreated from `origin/canary` to ensure the PR contains only this fix.
