### PR TITLE
🐛 fix(editor): bump @lobehub/editor to 4.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
     "@lobehub/analytics": "^1.6.0",
     "@lobehub/charts": "^5.0.0",
     "@lobehub/desktop-ipc-typings": "workspace:*",
-    "@lobehub/editor": "^4.5.0",
+    "@lobehub/editor": "^4.8.1",
     "@lobehub/icons": "^5.0.0",
     "@lobehub/market-sdk": "0.32.2",
     "@lobehub/tts": "^5.1.2",


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 Description of Change

Bump `@lobehub/editor` from `^4.5.0` to `^4.8.1` so `lobe-chat` resolves the editor build that includes the Lexical compatibility patch required by `keepId` imports.

This fixes the severe regression where editor initial data could fail to load and document history recovery could fall back to empty content after node ids were rekeyed.

#### 📝 Additional Information

- Base branch: `canary`
- No matching GitHub issue was linked
- Validation:
  - confirmed `@lobehub/editor@4.8.1` is published
  - packed the patched editor locally and replaced downstream `node_modules/@lobehub/editor`
  - verified `keepId` import preserves existing ids and new nodes continue from the max id (`4/5 -> 6/7`)
