### PR TITLE
✨ feat: add GLM-5.1 model support for Zhipu provider

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/zhipu.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/zhipu.ts
@@ -1,6 +1,36 @@
 import type { AIChatModelCard } from '../../../types/aiModel';
 
+// price: https://docs.z.ai/guides/overview/pricing
+// ref: https://docs.z.ai/guides/llm/glm-5.1
+
 export const zhipuChatModels: AIChatModelCard[] = [
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
+      "Zai's latest flagship model, aligned with Claude Opus 4.6 on overall and coding capabilities. Excels at long-horizon tasks with autonomous work up to 8 hours, an ideal foundation for Autonomous Agents and long-horizon Coding Agents.",
+    displayName: 'GLM-5.1',
+    enabled: true,
+    id: 'glm-5.1',
+    maxOutput: 131_072,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 1.4, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.26, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4.4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-27',
+    settings: {
+      extendParams: ['enableReasoning'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
   {
     abilities: {
       functionCall: true,

--- a/packages/model-bank/src/aiModels/zhipu.ts
+++ b/packages/model-bank/src/aiModels/zhipu.ts
@@ -16,6 +16,67 @@ const zhipuChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 200_000,
     description:
+      'GLM-5.1 is Zhipu’s latest flagship model, aligned with Claude Opus 4.6 on overall and coding capabilities. It excels at long-horizon tasks, able to autonomously plan, execute, and iterate for up to 8 hours in a single task, making it an ideal foundation for Autonomous Agents and long-horizon Coding Agents.',
+    displayName: 'GLM-5.1',
+    enabled: true,
+    id: 'glm-5.1',
+    maxOutput: 131_072,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 1.3,
+              '[0.032, infinity]': 2,
+            },
+            pricingParams: ['textInput'],
+          },
+          name: 'textInput_cacheRead',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 6,
+              '[0.032, infinity]': 8,
+            },
+            pricingParams: ['textInput'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 24,
+              '[0.032, infinity]': 28,
+            },
+            pricingParams: ['textInput'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-03-27',
+    settings: {
+      extendParams: ['enableReasoning'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
       'GLM-5-Turbo is a foundation model deeply optimized for agentic scenarios. It has been specifically optimized for core requirements of agent tasks from the training phase, enhancing key capabilities such as tool invocation, command following, and long-chain execution. It is ideal for building high-performance agent assistants.',
     displayName: 'GLM-5-Turbo',
     id: 'glm-5-turbo',

--- a/packages/model-runtime/src/providers/zhipu/index.test.ts
+++ b/packages/model-runtime/src/providers/zhipu/index.test.ts
@@ -384,6 +384,29 @@ describe('LobeZhipuAI - custom features', () => {
       });
     });
 
+    describe('tool_stream for streaming tool calls', () => {
+      it.each([
+        ['glm-4.6', true, true],
+        ['glm-4.7', true, true],
+        ['glm-5', true, true],
+        ['glm-5.1', true, true],
+        ['glm-4.5', true, undefined],
+        ['glm-5-turbo', true, undefined],
+        ['glm-4', true, undefined],
+        ['glm-5.1', false, undefined],
+      ] as const)('model=%s stream=%s → tool_stream=%s', async (model, stream, expected) => {
+        await instance.chat({
+          messages: [{ content: 'Hello', role: 'user' }],
+          model,
+          stream,
+          temperature: 0.5,
+        });
+
+        const callArgs = (instance['client'].chat.completions.create as any).mock.calls[0][0];
+        expect(callArgs.tool_stream).toBe(expected);
+      });
+    });
+
     describe('Preserve other payload properties', () => {
       it('should preserve all other properties', async () => {
         await instance.chat({

--- a/packages/model-runtime/src/providers/zhipu/index.ts
+++ b/packages/model-runtime/src/providers/zhipu/index.ts
@@ -81,7 +81,7 @@ export const params = {
         model,
         stream,
         thinking: thinking ? { type: thinking.type } : undefined,
-        tool_stream: stream && /^glm-(?:4\.(?:6|7)|5)$/.test(model) ? true : undefined,
+        tool_stream: stream && /^glm-(?:4\.(?:6|7)|5(?:\.1)?)$/.test(model) ? true : undefined,
         tools: zhipuTools,
       } as any;
     },


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Related to LOBE-6509

#### 🔀 Description of Change

Add GLM-5.1 support to the Zhipu provider family (both self-hosted bigmodel.cn and LobeHub-hosted).

- **`packages/model-bank/src/aiModels/zhipu.ts`**: add `glm-5.1` card with 200K context, 128K max output, CNY tiered pricing (¥6/¥24 input/output at ≤32K, ¥8/¥28 at >32K)
- **`packages/model-bank/src/aiModels/lobehub/chat/zhipu.ts`**: add `glm-5.1` card with fixed USD pricing (\$1.4 input / \$0.26 cache / \$4.4 output), sourced from `docs.z.ai`
- **`packages/model-runtime/src/providers/zhipu/index.ts`**: extend `tool_stream` enablement regex from `/^glm-(?:4\.(?:6|7)|5)$/` to `/^glm-(?:4\.(?:6|7)|5(?:\.1)?)$/` — GLM-5.1 supports `tool_stream=true` per migration guide
- **`packages/model-runtime/src/providers/zhipu/index.test.ts`**: add parameterized `tool_stream` test matrix covering positive (glm-4.6/4.7/5/5.1 streaming) and negative (glm-4.5/5-turbo/4 streaming, glm-5.1 non-streaming) cases

**GLM-5.1 highlights** (per [migration guide](https://docs.z.ai/guides/overview/migrate-to-glm-new)):
- Aligned with Claude Opus 4.6 on coding & general capabilities
- 8-hour autonomous long-horizon task execution
- New: `tool_stream=true` for streaming tool call arguments
- Default `thinking: { type: 'enabled' }` (same as GLM-5/4.7)

No breaking changes — drop-in replacement for GLM-5.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Run: \`bunx vitest run --silent='passed-only' 'src/providers/zhipu/index.test.ts'\` — 60/60 passing.

#### 📝 Additional Information

- Pricing sources:
  - Self-hosted (CNY): https://bigmodel.cn/pricing
  - LobeHub-hosted (USD): https://docs.z.ai/guides/overview/pricing
- Previous GLM-5.1 PRs covered siliconcloud (#13700) and glmCodingPlan (#13405); this PR completes coverage for the native Zhipu provider.