### PR TITLE
🔨 chore: add `tool_execute` / `tool_result` protocol types

### DIFF
--- a/src/libs/agent-stream/types.ts
+++ b/src/libs/agent-stream/types.ts
@@ -9,6 +9,7 @@ export type AgentStreamEventType =
   | 'stream_retry'
   | 'tool_start'
   | 'tool_end'
+  | 'tool_execute'
   | 'step_start'
   | 'step_complete'
   | 'error';
@@ -71,6 +72,22 @@ export interface StepCompleteData {
   reasonDetail?: string;
 }
 
+/**
+ * Server → Client: request the client to execute a tool locally and return the result.
+ */
+export interface ToolExecuteData {
+  /** Tool function name (e.g. "readFile"). */
+  apiName: string;
+  /** JSON-encoded argument string as returned by the LLM. */
+  arguments: string;
+  /** Per-invocation deadline. Server caps against its own function budget. */
+  executionTimeoutMs: number;
+  /** Tool plugin identifier (e.g. "local-system"). */
+  identifier: string;
+  /** Unique tool call id; used as the correlation key for the returned result. */
+  toolCallId: string;
+}
+
 // ─── WebSocket Protocol Messages ───
 
 // Client → Server
@@ -92,7 +109,26 @@ export interface InterruptMessage {
   type: 'interrupt';
 }
 
-export type ClientMessage = AuthMessage | HeartbeatMessage | InterruptMessage | ResumeMessage;
+/**
+ * Client → Server: tool execution result, correlated by toolCallId.
+ */
+export interface ToolResultMessage {
+  content: string | null;
+  error?: {
+    message: string;
+    type?: string;
+  };
+  success: boolean;
+  toolCallId: string;
+  type: 'tool_result';
+}
+
+export type ClientMessage =
+  | AuthMessage
+  | HeartbeatMessage
+  | InterruptMessage
+  | ResumeMessage
+  | ToolResultMessage;
 
 // Server → Client
 export interface AuthSuccessMessage {

--- a/src/libs/agent-stream/types.ts
+++ b/src/libs/agent-stream/types.ts
@@ -114,6 +114,7 @@ export interface InterruptMessage {
  */
 export interface ToolResultMessage {
   content: string | null;
+  state?: any;
   error?: {
     message: string;
     type?: string;

--- a/src/libs/agent-stream/types.ts
+++ b/src/libs/agent-stream/types.ts
@@ -114,11 +114,11 @@ export interface InterruptMessage {
  */
 export interface ToolResultMessage {
   content: string | null;
-  state?: any;
   error?: {
     message: string;
     type?: string;
   };
+  state?: any;
   success: boolean;
   toolCallId: string;
   type: 'tool_result';


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Fixes LOBE-7063 (Phase 6.1a — part of LOBE-7041 Gateway client tool calling)

#### 🔀 Description of Change

Introduces the WS protocol-level types for the Gateway-mediated client tool execution flow planned in LOBE-7041. Pure type scaffolding — no runtime wiring, no behavior change.

- **Server → Client**: new \`tool_execute\` event type + \`ToolExecuteData\` payload
  (\`toolCallId\`, \`identifier\`, \`apiName\`, \`arguments\`, \`executionTimeoutMs\`)
- **Client → Server**: new \`ToolResultMessage\` added to \`ClientMessage\` union,
  with \`{ success, content, error? }\` correlated by \`toolCallId\`

Subsequent PRs (6.1b/c, 6.2, 6.3a/b) consume these types to wire up the actual transport, BLPOP waiter, dispatcher branch, etc.

#### 🧪 How to Test

- [x] Type-check clean on this file
- [x] No tests needed (pure type declarations; unused at runtime in this PR)
- [ ] No tests needed