### PR TITLE
🔨 chore: add GatewayStreamNotifier.sendToolExecute

### DIFF
--- a/src/server/modules/AgentRuntime/GatewayStreamNotifier.ts
+++ b/src/server/modules/AgentRuntime/GatewayStreamNotifier.ts
@@ -1,6 +1,8 @@
 import debug from 'debug';
 import urlJoin from 'url-join';
 
+import type { ToolExecuteData } from '@/libs/agent-stream/types';
+
 import {
   getDefaultReasonDetail,
   type StreamChunkData,
@@ -106,6 +108,17 @@ export class GatewayStreamNotifier implements IStreamEventManager {
     return result;
   }
 
+  /**
+   * Request the client to execute a tool via Agent Gateway → WebSocket.
+   * Unlike the other push methods this is NOT fire-and-forget: callers rely
+   * on the promise outcome to decide whether to block-await a result or
+   * fall back to the interrupt-resume path. Rejects on HTTP error / timeout.
+   */
+  async sendToolExecute(operationId: string, data: ToolExecuteData): Promise<void> {
+    log('sendToolExecute operation=%s toolCallId=%s', operationId, data.toolCallId);
+    await this.httpPostAwait('/api/operations/tool-execute', { data, operationId });
+  }
+
   // ─── Read / subscribe methods: delegate directly to inner ───
 
   async subscribeStreamEvents(
@@ -137,6 +150,35 @@ export class GatewayStreamNotifier implements IStreamEventManager {
 
   private pushEvent(operationId: string, event: Record<string, unknown>) {
     this.httpPost('/api/operations/push-event', { event, operationId }).catch(() => {});
+  }
+
+  /**
+   * POST that surfaces errors back to the caller (no swallow). Used for
+   * request-response style pushes like tool_execute where the caller needs
+   * to know whether the gateway accepted the request.
+   */
+  private async httpPostAwait(path: string, body: Record<string, unknown>): Promise<void> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), POST_TIMEOUT);
+
+    try {
+      const res = await fetch(urlJoin(this.gatewayUrl, path), {
+        body: JSON.stringify(body),
+        headers: {
+          'Authorization': `Bearer ${this.serviceToken}`,
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`Gateway ${path} returned ${res.status}: ${text}`);
+      }
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   private async httpPost(path: string, body: Record<string, unknown>): Promise<void> {

--- a/src/server/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
@@ -372,4 +372,57 @@ describe('GatewayStreamNotifier', () => {
       expect(url).not.toContain('//api');
     });
   });
+
+  describe('sendToolExecute', () => {
+    const toolExecuteData = {
+      apiName: 'readFile',
+      arguments: '{"path":"/tmp/x"}',
+      executionTimeoutMs: 30_000,
+      identifier: 'local-system',
+      toolCallId: 'call-1',
+    };
+
+    beforeEach(() => {
+      // Earlier tests in this file install hanging mockImplementations that
+      // clearAllMocks doesn't reset — restore the default behavior here.
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue({ ok: true, text: () => Promise.resolve('') });
+    });
+
+    it('POSTs to /api/operations/tool-execute with the expected payload', async () => {
+      await notifier.sendToolExecute('op-1', toolExecuteData);
+
+      const calls = mockFetch.mock.calls.filter((c: any[]) =>
+        String(c[0]).includes('/api/operations/tool-execute'),
+      );
+      expect(calls).toHaveLength(1);
+
+      const [url, init] = calls[0];
+      expect(url).toBe(`${gatewayUrl}/api/operations/tool-execute`);
+      expect(init.method).toBe('POST');
+      expect(init.headers.Authorization).toBe(`Bearer ${serviceToken}`);
+      expect(JSON.parse(init.body)).toEqual({
+        data: toolExecuteData,
+        operationId: 'op-1',
+      });
+    });
+
+    it('rejects when the gateway returns a non-ok status', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        text: () => Promise.resolve('bad gateway'),
+      });
+
+      await expect(notifier.sendToolExecute('op-1', toolExecuteData)).rejects.toThrow(/502/);
+    });
+
+    it('rejects when fetch throws (network / timeout)', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network down'));
+
+      await expect(notifier.sendToolExecute('op-1', toolExecuteData)).rejects.toThrow(
+        'network down',
+      );
+    });
+  });
 });

--- a/src/server/modules/AgentRuntime/types.ts
+++ b/src/server/modules/AgentRuntime/types.ts
@@ -1,5 +1,7 @@
 import { type AgentState } from '@lobechat/agent-runtime';
 
+import type { ToolExecuteData } from '@/libs/agent-stream/types';
+
 import { type AgentOperationMetadata, type StepResult } from './AgentStateManager';
 import { type StreamChunkData, type StreamEvent } from './StreamEventManager';
 
@@ -144,6 +146,14 @@ export interface IStreamEventManager {
     operationId: string,
     event: Omit<StreamEvent, 'operationId' | 'timestamp'>,
   ) => Promise<string>;
+
+  /**
+   * Optional: dispatch a tool execution request to the client via Agent Gateway.
+   * Rejects if the gateway is unavailable — callers decide their fallback path.
+   * Only present on implementations that speak to a live gateway (not on the
+   * in-memory / Redis-only managers).
+   */
+  sendToolExecute?: (operationId: string, data: ToolExecuteData) => Promise<void>;
 
   /**
    * Subscribe to stream events (for SSE endpoint)


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Fixes LOBE-7066 (Phase 6.2 — part of LOBE-7041 Gateway client tool calling)

> Depends on: #13762 (LOBE-7063 / 6.1a — adds the \`ToolExecuteData\` type). Will rebase onto canary once that merges.

#### 🔀 Description of Change

Adds the server-side push for \`tool_execute\`:

- **Interface**: optional \`IStreamEventManager.sendToolExecute?\` — only the Gateway-backed notifier implements it; in-memory / Redis-only managers intentionally leave it undefined
- **Implementation**: \`GatewayStreamNotifier.sendToolExecute(operationId, data)\` POSTs to Gateway \`/api/operations/tool-execute\`
- **Error semantics** (diff from existing fire-and-forget): new private \`httpPostAwait\` helper reuses the 5s AbortController timeout but **rejects** on non-ok / network failure, so callers can decide whether to fall back to the interrupt-resume path when the gateway is unreachable

No caller wires this in yet — the dispatch branch in \`RuntimeExecutors\` lands with LOBE-7068 (6.3b).

#### 🧪 How to Test

- [x] \`bunx vitest run src/server/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts\` — 28/28 pass, 3 new cases for \`sendToolExecute\` (happy path, non-ok response, network error)
- [ ] No tests needed