### PR TITLE
fix(desktop): use low urgency for Linux notifications to prevent GNOME Shell freeze

### DIFF
--- a/apps/desktop/src/main/controllers/NotificationCtr.ts
+++ b/apps/desktop/src/main/controllers/NotificationCtr.ts
@@ -3,7 +3,7 @@ import type {
   ShowDesktopNotificationParams,
 } from '@lobechat/electron-client-ipc';
 import { app, Notification } from 'electron';
-import { macOS, windows } from 'electron-is';
+import { linux, macOS, windows } from 'electron-is';
 
 import { getIpcContext } from '@/utils/ipc';
 import { createLogger } from '@/utils/logger';
@@ -131,7 +131,12 @@ export default class NotificationCtr extends ControllerModule {
         silent: params.silent || false,
         timeoutType: 'default',
         title: params.title,
-        urgency: 'normal',
+        // On Linux/GNOME Shell, urgency 'normal' causes notifications to appear as banners.
+        // Clicking the dismiss (X) button on such banners can freeze the system for 30-45 seconds
+        // due to heavy gnome-shell processing. Using 'low' urgency routes notifications to the
+        // message tray instead, preventing the banner's X button from being shown.
+        // The urgency option is ignored on macOS and Windows.
+        urgency: linux() ? 'low' : 'normal',
       });
 
       // Add more event listeners for debugging

--- a/apps/desktop/src/main/controllers/__tests__/NotificationCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/NotificationCtr.test.ts
@@ -41,6 +41,7 @@ vi.mock('electron', () => {
 
 // Mock electron-is
 vi.mock('electron-is', () => ({
+  linux: vi.fn(() => false),
   macOS: vi.fn(() => false),
   windows: vi.fn(() => false),
 }));
@@ -178,6 +179,26 @@ describe('NotificationCtr', () => {
         urgency: 'normal',
       });
       expect(result).toEqual({ success: true });
+    });
+
+    it('should use low urgency on Linux to prevent GNOME Shell freeze', async () => {
+      const { linux } = await import('electron-is');
+      const { Notification } = await import('electron');
+      vi.mocked(linux).mockReturnValue(true);
+      vi.mocked(Notification.isSupported).mockReturnValue(true);
+      mockBrowserWindow.isVisible.mockReturnValue(false);
+
+      const promise = controller.showDesktopNotification(params);
+      vi.advanceTimersByTime(100);
+      await promise;
+
+      expect(Notification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          urgency: 'low',
+        }),
+      );
+
+      vi.mocked(linux).mockReturnValue(false);
     });
 
     it('should show notification when window is minimized', async () => {


### PR DESCRIPTION
Fixes #13538

## Problem

On Linux with GNOME Shell, clicking the dismiss (X) button on LobeHub desktop notification banners causes the entire screen to freeze for 30–45 seconds. During the freeze:

- System load spikes from ~1.0 to **16.67**
- Available memory drops from ~4800 MB to **~900 MB**
- `gnome-shell` CPU usage increases significantly

This is caused by heavy gnome-shell processing triggered when an Electron notification with `urgency: 'normal'` is dismissed via the banner's X button.

## Solution

Set `urgency` to `'low'` on Linux platforms. With `urgency: 'low'`, notifications are routed directly to the GNOME message tray instead of appearing as banner pop-ups. This prevents the banner's dismiss button (X) from being shown, eliminating the interaction that triggers the freeze.

The `urgency` option is a Linux-only Electron property and is ignored on macOS and Windows, so this change has no impact on other platforms.

## Testing

- Added a test case that verifies `urgency: 'low'` is used when `linux()` returns `true`
- Existing tests continue to pass (non-Linux path still uses `urgency: 'normal'`)

## Notes

Users on Linux will no longer see desktop notification banners; notifications will appear in the GNOME message tray instead. This is a deliberate trade-off to avoid the system freeze.