### PR TITLE
🐛 fix(agent-runtime): skip client-executor marking when gateway is configured

### DIFF
--- a/src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
@@ -1,3 +1,4 @@
+import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
 import { RemoteDeviceManifest } from '@lobechat/builtin-tool-remote-device';
 import type * as ModelBankModule from 'model-bank';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -11,6 +12,7 @@ const {
   mockGetAgentConfig,
   mockGetEnabledPluginManifests,
   mockMessageCreate,
+  mockPluginQuery,
   mockQueryDeviceList,
 } = vi.hoisted(() => ({
   mockCreateOperation: vi.fn(),
@@ -19,6 +21,7 @@ const {
   mockGetAgentConfig: vi.fn(),
   mockGetEnabledPluginManifests: vi.fn(),
   mockMessageCreate: vi.fn(),
+  mockPluginQuery: vi.fn(),
   mockQueryDeviceList: vi.fn(),
 }));
 
@@ -51,7 +54,7 @@ vi.mock('@/server/services/agent', () => ({
 
 vi.mock('@/database/models/plugin', () => ({
   PluginModel: vi.fn().mockImplementation(() => ({
-    query: vi.fn().mockResolvedValue([]),
+    query: mockPluginQuery,
   })),
 }));
 
@@ -160,6 +163,7 @@ describe('AiAgentService.execAgent - device tool pipeline (LOBE-5636)', () => {
       success: true,
     });
     mockQueryDeviceList.mockResolvedValue([]);
+    mockPluginQuery.mockResolvedValue([]);
     mockGenerateToolsDetailed.mockReturnValue({ enabledToolIds: [], tools: [] });
     mockGetEnabledPluginManifests.mockReturnValue(new Map());
     service = new AiAgentService(mockDb, userId);
@@ -275,6 +279,75 @@ describe('AiAgentService.execAgent - device tool pipeline (LOBE-5636)', () => {
 
       // RemoteDevice should NOT be in manifestMap — no manual injection
       expect(manifestMap[RemoteDeviceManifest.identifier]).toBeUndefined();
+    });
+  });
+
+  describe('toolExecutorMap gating on gatewayConfigured (regression for #13769)', () => {
+    it('should mark local-system as client when gateway is NOT configured (standalone Electron)', async () => {
+      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
+      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(false);
+
+      mockGetEnabledPluginManifests.mockReturnValue(
+        new Map([[LocalSystemManifest.identifier, LocalSystemManifest]]),
+      );
+      mockGetAgentConfig.mockResolvedValue(createBaseAgentConfig());
+
+      await service.execAgent({ agentId: 'agent-1', prompt: 'Hello' });
+
+      const executorMap = mockCreateOperation.mock.calls[0][0].toolSet.executorMap;
+      expect(executorMap[LocalSystemManifest.identifier]).toBe('client');
+    });
+
+    it('should NOT mark local-system as client when gateway IS configured (cloud)', async () => {
+      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
+      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(true);
+      mockQueryDeviceList.mockResolvedValue([
+        { deviceId: 'dev-1', deviceName: 'My PC', platform: 'win32' },
+      ]);
+
+      mockGetEnabledPluginManifests.mockReturnValue(
+        new Map([[LocalSystemManifest.identifier, LocalSystemManifest]]),
+      );
+      mockGetAgentConfig.mockResolvedValue(createBaseAgentConfig());
+
+      await service.execAgent({ agentId: 'agent-1', prompt: 'Hello' });
+
+      const executorMap = mockCreateOperation.mock.calls[0][0].toolSet.executorMap;
+      expect(executorMap[LocalSystemManifest.identifier]).toBeUndefined();
+    });
+
+    it('should mark stdio MCP plugin as client only when gateway is NOT configured', async () => {
+      const stdioPlugin = {
+        customParams: { mcp: { type: 'stdio' } },
+        identifier: 'my-stdio-mcp',
+      } as any;
+      const stdioManifest = {
+        api: [{ description: 't', name: 'a', parameters: {} }],
+        identifier: 'my-stdio-mcp',
+        meta: { title: 'Stdio' },
+      };
+
+      mockPluginQuery.mockResolvedValue([stdioPlugin]);
+      mockGetEnabledPluginManifests.mockReturnValue(new Map([['my-stdio-mcp', stdioManifest]]));
+      mockGetAgentConfig.mockResolvedValue(createBaseAgentConfig({ plugins: ['my-stdio-mcp'] }));
+
+      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
+
+      // Gateway NOT configured → should mark as client
+      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(false);
+      await service.execAgent({ agentId: 'agent-1', prompt: 'Hello' });
+      let executorMap = mockCreateOperation.mock.calls[0][0].toolSet.executorMap;
+      expect(executorMap['my-stdio-mcp']).toBe('client');
+
+      // Gateway configured → should NOT mark as client
+      mockCreateOperation.mockClear();
+      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(true);
+      mockQueryDeviceList.mockResolvedValue([
+        { deviceId: 'dev-1', deviceName: 'PC', platform: 'win32' },
+      ]);
+      await service.execAgent({ agentId: 'agent-1', prompt: 'Hello' });
+      executorMap = mockCreateOperation.mock.calls[0][0].toolSet.executorMap;
+      expect(executorMap['my-stdio-mcp']).toBeUndefined();
     });
   });
 

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -623,13 +623,17 @@ export class AiAgentService {
       // require local IPC / subprocess capabilities:
       //   - local-system builtin: Electron IPC for file + command execution
       //   - stdio MCP plugins: subprocess lives on the user's machine
-      // Dispatcher in RuntimeExecutors reads this to route via Agent Gateway WS.
-      if (manifestMap.has(LocalSystemManifest.identifier)) {
-        toolExecutorMap[LocalSystemManifest.identifier] = 'client';
-      }
-      for (const plugin of installedPlugins) {
-        if (plugin.customParams?.mcp?.type === 'stdio' && manifestMap.has(plugin.identifier)) {
-          toolExecutorMap[plugin.identifier] = 'client';
+      // Only applies when gateway is NOT configured (standalone Electron). When
+      // deviceContext is present, tools are routed via the RemoteDevice proxy,
+      // so marking them as `client` would misdispatch through dispatchClientTool.
+      if (!gatewayConfigured) {
+        if (manifestMap.has(LocalSystemManifest.identifier)) {
+          toolExecutorMap[LocalSystemManifest.identifier] = 'client';
+        }
+        for (const plugin of installedPlugins) {
+          if (plugin.customParams?.mcp?.type === 'stdio' && manifestMap.has(plugin.identifier)) {
+            toolExecutorMap[plugin.identifier] = 'client';
+          }
         }
       }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up regression from #13769.

#### 🔀 Description of Change

Tools flagged as \`executor: 'client'\` are dispatched via \`dispatchClientTool\` through the Agent Gateway WS path. In cloud deployments where the gateway is configured but no desktop device is connected on the current conversation, \`local-system\` (and stdio MCP plugins) were unconditionally marked as \`'client'\`, causing the dispatcher to hit \`/api/operations/tool-execute\` and return \`404 / dispatch_failed\`.

Only mark these tools as \`'client'\` when the gateway is **not** configured (standalone Electron). When \`deviceContext\` is available, tool routing flows through the RemoteDevice proxy instead, which is the correct cloud path.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Added 3 regression tests in \`execAgent.deviceToolPipeline.test.ts\`:
- \`local-system\` marked \`'client'\` when gateway NOT configured
- \`local-system\` NOT marked \`'client'\` when gateway IS configured
- stdio MCP plugin gated on the same condition

\`\`\`
bunx vitest run src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
# 10 tests passed
\`\`\`

#### 📝 Additional Information

Repro trace: \`local-system\` call from a cloud web session failed in 210ms with \`Gateway /api/operations/tool-execute returned 404\`.