### PR TITLE
🐛 fix: enable executor=client tools for desktop Electron callers

### DIFF
--- a/packages/types/src/agentExecution/index.ts
+++ b/packages/types/src/agentExecution/index.ts
@@ -28,6 +28,13 @@ export interface ExecAgentParams {
   appContext?: ExecAgentAppContext;
   /** Whether to auto-start execution after creating operation (default: true) */
   autoStart?: boolean;
+  /**
+   * Runtime of the client initiating this request. Used by the server to
+   * enable `executor: 'client'` tools (e.g. local-system) when the caller
+   * is a desktop Electron client that will receive `tool_execute` events
+   * over the same Agent Gateway WebSocket.
+   */
+  clientRuntime?: 'desktop' | 'web';
   /** Explicit device ID to bind to the topic and activate for this run */
   deviceId?: string;
   /** Optional existing message IDs to include in context */

--- a/src/server/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/src/server/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -520,4 +520,66 @@ describe('createServerAgentToolsEngine', () => {
       expect(result.enabledToolIds).not.toContain(RemoteDeviceManifest.identifier);
     });
   });
+
+  describe('clientRuntime === "desktop" (Phase 6.4)', () => {
+    it('enables LocalSystem when the caller itself is a desktop client, with no registered remote device', () => {
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { plugins: [LocalSystemManifest.identifier] },
+        clientRuntime: 'desktop',
+        // Gateway is configured on the server (so `runtimeMode` becomes
+        // `local`), but no remote device has been registered or activated.
+        deviceContext: { gatewayConfigured: true },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        toolIds: [LocalSystemManifest.identifier],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).toContain(LocalSystemManifest.identifier);
+    });
+
+    it('still requires gateway to be configured on the server', () => {
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { plugins: [LocalSystemManifest.identifier] },
+        clientRuntime: 'desktop',
+        // No server-side gateway → no way to push tool_execute even if the
+        // client would be able to handle it.
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        toolIds: [LocalSystemManifest.identifier],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).not.toContain(LocalSystemManifest.identifier);
+    });
+
+    it('does not enable LocalSystem for web callers even when gateway is configured', () => {
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { plugins: [LocalSystemManifest.identifier] },
+        clientRuntime: 'web',
+        deviceContext: { gatewayConfigured: true },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        toolIds: [LocalSystemManifest.identifier],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).not.toContain(LocalSystemManifest.identifier);
+    });
+  });
 });

--- a/src/server/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/src/server/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -522,14 +522,14 @@ describe('createServerAgentToolsEngine', () => {
   });
 
   describe('clientRuntime === "desktop" (Phase 6.4)', () => {
-    it('enables LocalSystem when the caller itself is a desktop client, with no registered remote device', () => {
+    it('enables LocalSystem when caller is desktop, regardless of device-proxy config', () => {
+      // The Agent Gateway WS used to push `tool_execute` is orthogonal to
+      // the legacy device-proxy. A desktop Electron caller is already the
+      // execution target — no device-proxy prerequisite required.
       const context = createMockContext();
       const engine = createServerAgentToolsEngine(context, {
         agentConfig: { plugins: [LocalSystemManifest.identifier] },
         clientRuntime: 'desktop',
-        // Gateway is configured on the server (so `runtimeMode` becomes
-        // `local`), but no remote device has been registered or activated.
-        deviceContext: { gatewayConfigured: true },
         model: 'gpt-4',
         provider: 'openai',
       });
@@ -543,13 +543,18 @@ describe('createServerAgentToolsEngine', () => {
       expect(result.enabledToolIds).toContain(LocalSystemManifest.identifier);
     });
 
-    it('still requires gateway to be configured on the server', () => {
+    it('respects agent-level runtimeMode opt-out for desktop callers', () => {
+      // User has configured the agent to NOT use local runtime on desktop.
+      // Even though the caller is a desktop client, local-system stays off.
       const context = createMockContext();
       const engine = createServerAgentToolsEngine(context, {
-        agentConfig: { plugins: [LocalSystemManifest.identifier] },
+        agentConfig: {
+          chatConfig: {
+            runtimeEnv: { runtimeMode: { desktop: 'none' } },
+          },
+          plugins: [LocalSystemManifest.identifier],
+        },
         clientRuntime: 'desktop',
-        // No server-side gateway → no way to push tool_execute even if the
-        // client would be able to handle it.
         model: 'gpt-4',
         provider: 'openai',
       });

--- a/src/server/modules/Mecha/AgentToolsEngine/index.ts
+++ b/src/server/modules/Mecha/AgentToolsEngine/index.ts
@@ -94,6 +94,7 @@ export const createServerAgentToolsEngine = (
   const {
     additionalManifests,
     agentConfig,
+    clientRuntime,
     deviceContext,
     globalMemoryEnabled = false,
     hasAgentDocuments = false,
@@ -102,6 +103,10 @@ export const createServerAgentToolsEngine = (
     model,
     provider,
   } = params;
+  // Phase 6.4: the caller itself can execute `executor: 'client'` tools
+  // (local-system / stdio MCP) over its Agent Gateway WS. This is orthogonal
+  // to the legacy device-proxy flow described by `deviceContext`.
+  const hasClientExecutor = clientRuntime === 'desktop';
   const searchMode = agentConfig.chatConfig?.searchMode ?? 'auto';
   const isSearchEnabled = searchMode !== 'off';
 
@@ -138,11 +143,13 @@ export const createServerAgentToolsEngine = (
         // System-level rules (may override user selection for specific tools)
         [CloudSandboxManifest.identifier]: runtimeMode === 'cloud',
         [KnowledgeBaseManifest.identifier]: hasEnabledKnowledgeBases,
+        // Enable local-system when the caller itself is a desktop Electron
+        // client (Phase 6.4 tool_execute path), OR when a legacy remote
+        // device is registered, online, and auto-activated.
         [LocalSystemManifest.identifier]:
           runtimeMode === 'local' &&
           !!deviceContext?.gatewayConfigured &&
-          !!deviceContext?.deviceOnline &&
-          !!deviceContext?.autoActivated,
+          (hasClientExecutor || (!!deviceContext?.deviceOnline && !!deviceContext?.autoActivated)),
         [MemoryManifest.identifier]: globalMemoryEnabled,
         // Only auto-enable in bot conversations; otherwise let user's plugin selection take effect
         ...(isBotConversation && { [MessageManifest.identifier]: true }),

--- a/src/server/modules/Mecha/AgentToolsEngine/index.ts
+++ b/src/server/modules/Mecha/AgentToolsEngine/index.ts
@@ -165,15 +165,17 @@ export const createServerAgentToolsEngine = (
         // System-level rules (may override user selection for specific tools)
         [CloudSandboxManifest.identifier]: runtimeMode === 'cloud',
         [KnowledgeBaseManifest.identifier]: hasEnabledKnowledgeBases,
-        // Local-system requires, in this order:
-        //  (a) user opted into local runtime on this platform (runtimeMode);
-        //  (b) server has a Gateway path to push tool_execute (hasDeviceProxy);
-        //  (c) a concrete execution target — either the caller itself
-        //      (Phase 6.4), or a legacy activated remote device.
+        // Local-system: user must have opted into local runtime on this
+        // platform (`runtimeMode === 'local'`), AND one execution channel
+        // must exist:
+        //  - `hasClientExecutor` — Phase 6.4 dispatch over the Agent Gateway
+        //    WS that this request is already riding on; no extra server-side
+        //    prerequisite needed;
+        //  - legacy device-proxy with an online & auto-activated device.
         [LocalSystemManifest.identifier]:
           runtimeMode === 'local' &&
-          hasDeviceProxy &&
-          (hasClientExecutor || (!!deviceContext?.deviceOnline && !!deviceContext?.autoActivated)),
+          (hasClientExecutor ||
+            (hasDeviceProxy && !!deviceContext?.deviceOnline && !!deviceContext?.autoActivated)),
         [MemoryManifest.identifier]: globalMemoryEnabled,
         // Only auto-enable in bot conversations; otherwise let user's plugin selection take effect
         ...(isBotConversation && { [MessageManifest.identifier]: true }),

--- a/src/server/modules/Mecha/AgentToolsEngine/index.ts
+++ b/src/server/modules/Mecha/AgentToolsEngine/index.ts
@@ -20,6 +20,7 @@ import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
 import { alwaysOnToolIds, builtinTools, defaultToolIds } from '@lobechat/builtin-tools';
 import { createEnableChecker, type LobeToolManifest } from '@lobechat/context-engine';
 import { ToolsEngine } from '@lobechat/context-engine';
+import { type RuntimeEnvMode, type RuntimePlatform } from '@lobechat/types';
 import debug from 'debug';
 
 import {
@@ -103,28 +104,49 @@ export const createServerAgentToolsEngine = (
     model,
     provider,
   } = params;
-  // Phase 6.4: the caller itself can execute `executor: 'client'` tools
-  // (local-system / stdio MCP) over its Agent Gateway WS. This is orthogonal
-  // to the legacy device-proxy flow described by `deviceContext`.
+
+  // ─── Tool-dispatch capability flags ───
+  //
+  // Two orthogonal signals control whether client-side tools can run.
+  //
+  //  1. `hasClientExecutor` — the caller itself is an Electron desktop
+  //     client and can receive `tool_execute` events over the Agent
+  //     Gateway WebSocket (Phase 6.4).
+  //  2. `hasDeviceProxy` — the server has a device-proxy configured that
+  //     can tunnel commands to a *separately registered* desktop device
+  //     (legacy Remote Device flow).
+  //
+  // Either, both, or neither can be true independently.
   const hasClientExecutor = clientRuntime === 'desktop';
+  const hasDeviceProxy = !!deviceContext?.gatewayConfigured;
+
+  // ─── Platform / runtime mode ───
+  //
+  // `platform` is a property of the caller, not of the server. Prefer the
+  // explicit `clientRuntime` signal; fall back to treating a server with
+  // a configured device-proxy as desktop for callers that don't yet send
+  // `clientRuntime` (backwards compat).
+  const platform: RuntimePlatform = clientRuntime ?? (hasDeviceProxy ? 'desktop' : 'web');
+
+  // User-configured runtime mode for the current platform, with a
+  // platform-appropriate default when unset.
+  const runtimeMode: RuntimeEnvMode =
+    agentConfig.chatConfig?.runtimeEnv?.runtimeMode?.[platform] ??
+    (platform === 'desktop' ? 'local' : 'none');
+
   const searchMode = agentConfig.chatConfig?.searchMode ?? 'auto';
   const isSearchEnabled = searchMode !== 'off';
 
-  // Determine runtime mode based on platform
-  const isDesktopClient = !!deviceContext?.gatewayConfigured;
-  const platform = isDesktopClient ? 'desktop' : 'web';
-  const runtimeMode =
-    agentConfig.chatConfig?.runtimeEnv?.runtimeMode?.[platform] ??
-    (isDesktopClient ? 'local' : 'none');
-
   log(
-    'Creating agent tools engine for model=%s, provider=%s, searchMode=%s, runtimeMode=%s, additionalManifests=%d, deviceGateway=%s',
+    'Creating agent tools engine model=%s provider=%s searchMode=%s platform=%s runtimeMode=%s additionalManifests=%d hasClientExecutor=%s hasDeviceProxy=%s',
     model,
     provider,
     searchMode,
+    platform,
     runtimeMode,
     additionalManifests?.length ?? 0,
-    !!deviceContext?.gatewayConfigured,
+    hasClientExecutor,
+    hasDeviceProxy,
   );
 
   return createServerToolsEngine(context, {
@@ -143,18 +165,21 @@ export const createServerAgentToolsEngine = (
         // System-level rules (may override user selection for specific tools)
         [CloudSandboxManifest.identifier]: runtimeMode === 'cloud',
         [KnowledgeBaseManifest.identifier]: hasEnabledKnowledgeBases,
-        // Enable local-system when the caller itself is a desktop Electron
-        // client (Phase 6.4 tool_execute path), OR when a legacy remote
-        // device is registered, online, and auto-activated.
+        // Local-system requires, in this order:
+        //  (a) user opted into local runtime on this platform (runtimeMode);
+        //  (b) server has a Gateway path to push tool_execute (hasDeviceProxy);
+        //  (c) a concrete execution target — either the caller itself
+        //      (Phase 6.4), or a legacy activated remote device.
         [LocalSystemManifest.identifier]:
           runtimeMode === 'local' &&
-          !!deviceContext?.gatewayConfigured &&
+          hasDeviceProxy &&
           (hasClientExecutor || (!!deviceContext?.deviceOnline && !!deviceContext?.autoActivated)),
         [MemoryManifest.identifier]: globalMemoryEnabled,
         // Only auto-enable in bot conversations; otherwise let user's plugin selection take effect
         ...(isBotConversation && { [MessageManifest.identifier]: true }),
-        [RemoteDeviceManifest.identifier]:
-          !!deviceContext?.gatewayConfigured && !deviceContext?.autoActivated,
+        // Remote-device proxy: shown only when the server has a proxy but
+        // no specific device is auto-activated yet (user must pick).
+        [RemoteDeviceManifest.identifier]: hasDeviceProxy && !deviceContext?.autoActivated,
         [AgentDocumentsManifest.identifier]: hasAgentDocuments,
         [WebBrowsingManifest.identifier]: isSearchEnabled,
       },

--- a/src/server/modules/Mecha/AgentToolsEngine/types.ts
+++ b/src/server/modules/Mecha/AgentToolsEngine/types.ts
@@ -44,6 +44,13 @@ export interface ServerCreateAgentToolsEngineParams {
     /** Plugin IDs enabled for this agent */
     plugins?: string[];
   };
+  /**
+   * Runtime of the client initiating this request. When `'desktop'`, the
+   * caller itself is an Electron client connected via the Agent Gateway WS,
+   * so tools with `executor: 'client'` (e.g. local-system, stdio MCP) can be
+   * dispatched back to it via `tool_execute` — no remote-device proxy needed.
+   */
+  clientRuntime?: 'desktop' | 'web';
   /** Device gateway context for remote tool calling */
   deviceContext?: {
     /** When true, a device has been auto-activated — Remote Device tool is unnecessary */

--- a/src/server/routers/lambda/aiAgent.ts
+++ b/src/server/routers/lambda/aiAgent.ts
@@ -91,6 +91,12 @@ const ExecAgentSchema = z
       .optional(),
     /** Whether to auto-start execution after creating operation */
     autoStart: z.boolean().optional().default(true),
+    /**
+     * Runtime of the client initiating this request.
+     * 'desktop' enables `executor: 'client'` tools (local-system, stdio MCP)
+     * to be dispatched over the Agent Gateway WS.
+     */
+    clientRuntime: z.enum(['desktop', 'web']).optional(),
     /** Explicit device ID to bind to the topic and activate for this run */
     deviceId: z.string().optional(),
     /** Optional existing message IDs to include in context */
@@ -530,6 +536,7 @@ export const aiAgentRouter = router({
       prompt,
       appContext,
       autoStart = true,
+      clientRuntime,
       deviceId,
       existingMessageIds = [],
       fileIds,
@@ -543,6 +550,7 @@ export const aiAgentRouter = router({
         agentId,
         appContext,
         autoStart,
+        clientRuntime,
         deviceId,
         existingMessageIds,
         fileIds,

--- a/src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
@@ -224,6 +224,44 @@ describe('AiAgentService.execAgent - device tool pipeline (LOBE-5636)', () => {
     });
   });
 
+  describe('clientRuntime forwarded to createServerAgentToolsEngine', () => {
+    it('forwards clientRuntime="desktop" so the engine enables local-system for Electron callers', async () => {
+      mockGetAgentConfig.mockResolvedValue(createBaseAgentConfig());
+
+      await service.execAgent({
+        agentId: 'agent-1',
+        clientRuntime: 'desktop',
+        prompt: 'Hello',
+      });
+
+      expect(mockCreateServerAgentToolsEngine).toHaveBeenCalledTimes(1);
+      const params = mockCreateServerAgentToolsEngine.mock.calls[0][1];
+      expect(params.clientRuntime).toBe('desktop');
+    });
+
+    it('forwards clientRuntime="web" verbatim', async () => {
+      mockGetAgentConfig.mockResolvedValue(createBaseAgentConfig());
+
+      await service.execAgent({
+        agentId: 'agent-1',
+        clientRuntime: 'web',
+        prompt: 'Hello',
+      });
+
+      const params = mockCreateServerAgentToolsEngine.mock.calls[0][1];
+      expect(params.clientRuntime).toBe('web');
+    });
+
+    it('omits clientRuntime when the caller does not specify one', async () => {
+      mockGetAgentConfig.mockResolvedValue(createBaseAgentConfig());
+
+      await service.execAgent({ agentId: 'agent-1', prompt: 'Hello' });
+
+      const params = mockCreateServerAgentToolsEngine.mock.calls[0][1];
+      expect(params.clientRuntime).toBeUndefined();
+    });
+  });
+
   describe('RemoteDevice systemRole override', () => {
     it('should override RemoteDevice systemRole with dynamic prompt when enabled by ToolsEngine', async () => {
       const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -223,6 +223,7 @@ export class AiAgentService {
       appContext,
       autoStart = true,
       botContext,
+      clientRuntime,
       deviceId: requestedDeviceId,
       botPlatformContext,
       discordContext,
@@ -565,6 +566,7 @@ export class AiAgentService {
           chatConfig: agentConfig.chatConfig ?? undefined,
           plugins: agentPlugins,
         },
+        clientRuntime,
         deviceContext: gatewayConfigured
           ? {
               autoActivated: activeDeviceId ? true : undefined,


### PR DESCRIPTION
## Background

Part of [LOBE-7076](https://linear.app/lobehub/issue/LOBE-7076) (Phase 6.4 — Gateway 客户端 Tool Calling 前端实现). The server side of Phase 6 is already in place:

- [LOBE-7067](https://linear.app/lobehub/issue/LOBE-7067) Phase 6.3a — `toolExecutorMap` statically derived from manifest
- [LOBE-7068](https://linear.app/lobehub/issue/LOBE-7068) Phase 6.3b — `RuntimeExecutors.call_tool` routes `executor === 'client'` → `GatewayStreamNotifier.sendToolExecute` → Agent Gateway WS → client

The one remaining gap: `local-system` (and stdio MCP) could only enter the agent's tool manifest when a **separately registered** remote device was online + auto-activated (legacy device-proxy flow). So a desktop Electron caller sitting on the other end of the Agent Gateway WS — the very target Phase 6.4 wants to dispatch to — never saw `local-system` in its manifest and never got a `tool_execute` pushed to it.

## What this PR does

Adds a new, orthogonal signal: **the caller tells the server what runtime it is**.

`ExecAgentParams.clientRuntime?: 'desktop' | 'web'` — when a caller sends `'desktop'`, the server knows this request is coming in over an Agent Gateway WebSocket from an Electron client that can execute `executor: 'client'` tools locally.

`AgentToolsEngine` then enables `local-system` under one of two independent conditions:

```ts
[LocalSystemManifest.identifier]:
  runtimeMode === 'local' &&
  (hasClientExecutor                              // Phase 6.4 — new
    || (hasDeviceProxy && deviceOnline && autoActivated));  // legacy — unchanged
```

Once `local-system` is in the manifest, `toolExecutorMap[local-system] = 'client'` kicks in (LOBE-7067), and `RuntimeExecutors.call_tool` dispatches it over the Gateway WS to the caller (LOBE-7068).

### Two orthogonal capability flags

| Flag | Meaning | Source |
|------|---------|--------|
| `hasClientExecutor` | Caller itself can receive `tool_execute` over the Agent Gateway WS | `clientRuntime === 'desktop'` |
| `hasDeviceProxy`    | Server has a device-proxy tunneling to a *separately registered* desktop | `deviceProxy.isConfigured` |

These are independent. The Phase 6.4 WS dispatch has nothing to do with device-proxy — the WS used for `tool_execute` is the same one streaming agent events, so as long as the caller is connected, the channel is live.

### User opt-in is honored

`local-system` only enables when `runtimeMode === 'local'`, which resolves to `agentConfig.chatConfig.runtimeEnv.runtimeMode[platform]` — the user's per-agent per-platform runtime-env preference. Setting `runtimeMode.desktop = 'none'` keeps `local-system` off even for desktop callers.

## Changes

- `packages/types`: `ExecAgentParams.clientRuntime?: 'desktop' | 'web'`
- `src/server/routers/lambda/aiAgent.ts`: tRPC schema accepts + forwards the field
- `src/server/services/aiAgent/index.ts`: forwards it to `createServerAgentToolsEngine`
- `src/server/modules/Mecha/AgentToolsEngine`:
  - New `clientRuntime` param
  - `platform` now derived from the caller (`clientRuntime`) first, falling back to `hasDeviceProxy` for backwards compat — previously it was *only* derived from the server's proxy config, which conflated "server can reach a desktop" with "caller is a desktop"
  - Renamed the misleading `isDesktopClient` (which actually meant "server has device-proxy") to `hasDeviceProxy`
  - Added `hasClientExecutor` as a first-class sibling flag
  - LocalSystem enable rule restructured as shown above; RemoteDevice rule unchanged

## Out of scope (follow-up PR)

The frontend side of Phase 6.4, already implemented locally:

- `AgentStreamClient.sendToolResult` on the WebSocket client
- New `internal_executeClientTool` action: parses args → invokes local executor → always sends `tool_result` back (including on every error path, so the server's BLPOP never hangs)
- `gatewayEventHandler` routes `tool_execute` events as fire-and-forget to the action
- `executeGatewayAgent` sends `clientRuntime: isDesktop ? 'desktop' : 'web'` — the signal this PR consumes

## Test plan

- [x] 28/28 `AgentToolsEngine` tests pass — includes 3 new cases for the desktop/web/opt-out branches
- [x] 10/10 `execAgent.deviceToolPipeline` tests pass — includes 3 new cases verifying `clientRuntime` is forwarded verbatim
- [x] Full type-check clean
- [ ] End-to-end verification via Electron desktop calling a real local-system tool — gated on this PR being deployed to canary so the frontend follow-up PR can exercise it against a real backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)