### PR TITLE
🐛 fix: dispatch executor=client tools to desktop callers when DEVICE_GATEWAY is configured

### DIFF
--- a/src/server/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/src/server/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -586,5 +586,31 @@ describe('createServerAgentToolsEngine', () => {
 
       expect(result.enabledToolIds).not.toContain(LocalSystemManifest.identifier);
     });
+
+    it('suppresses RemoteDevice when caller is a desktop client', () => {
+      // Even when device-proxy is configured, a desktop caller has local IPC
+      // so the proxy is redundant. Otherwise the LLM might pick RemoteDevice
+      // first (via `listOnlineDevices` / `activateDevice`) and route tool calls
+      // to a *different* registered device instead of back to the caller.
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: {
+          plugins: [LocalSystemManifest.identifier, RemoteDeviceManifest.identifier],
+        },
+        clientRuntime: 'desktop',
+        deviceContext: { gatewayConfigured: true },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        toolIds: [LocalSystemManifest.identifier, RemoteDeviceManifest.identifier],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).toContain(LocalSystemManifest.identifier);
+      expect(result.enabledToolIds).not.toContain(RemoteDeviceManifest.identifier);
+    });
   });
 });

--- a/src/server/modules/Mecha/AgentToolsEngine/index.ts
+++ b/src/server/modules/Mecha/AgentToolsEngine/index.ts
@@ -180,8 +180,11 @@ export const createServerAgentToolsEngine = (
         // Only auto-enable in bot conversations; otherwise let user's plugin selection take effect
         ...(isBotConversation && { [MessageManifest.identifier]: true }),
         // Remote-device proxy: shown only when the server has a proxy but
-        // no specific device is auto-activated yet (user must pick).
-        [RemoteDeviceManifest.identifier]: hasDeviceProxy && !deviceContext?.autoActivated,
+        // no specific device is auto-activated yet (user must pick). When
+        // the caller itself can execute `executor: 'client'` tools, the
+        // proxy is redundant — local-system goes directly to the caller.
+        [RemoteDeviceManifest.identifier]:
+          hasDeviceProxy && !deviceContext?.autoActivated && !hasClientExecutor,
         [AgentDocumentsManifest.identifier]: hasAgentDocuments,
         [WebBrowsingManifest.identifier]: isSearchEnabled,
       },

--- a/src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
@@ -389,6 +389,91 @@ describe('AiAgentService.execAgent - device tool pipeline (LOBE-5636)', () => {
     });
   });
 
+  describe('clientRuntime="desktop" bypasses the DEVICE_GATEWAY gate (Phase 6.4)', () => {
+    it('marks local-system as client when caller is desktop, even with DEVICE_GATEWAY configured', async () => {
+      // On cloud canary, DEVICE_GATEWAY is configured AND a remote Linux VM
+      // may be registered. Before this fix, `!gatewayConfigured` was false, so
+      // local-system was never stamped `executor='client'` — and dispatch fell
+      // through to the Remote Device proxy (which then tried to read the file
+      // on the wrong host). When clientRuntime='desktop', the caller itself is
+      // the execution target and wins.
+      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
+      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(true);
+      mockQueryDeviceList.mockResolvedValue([
+        { deviceId: 'dev-1', deviceName: 'Remote VM', platform: 'linux' },
+      ]);
+
+      mockGetEnabledPluginManifests.mockReturnValue(
+        new Map([[LocalSystemManifest.identifier, LocalSystemManifest]]),
+      );
+      mockGetAgentConfig.mockResolvedValue(createBaseAgentConfig());
+
+      await service.execAgent({
+        agentId: 'agent-1',
+        clientRuntime: 'desktop',
+        prompt: 'Hello',
+      });
+
+      const executorMap = mockCreateOperation.mock.calls[0][0].toolSet.executorMap;
+      expect(executorMap[LocalSystemManifest.identifier]).toBe('client');
+    });
+
+    it('marks stdio MCP as client when caller is desktop, even with DEVICE_GATEWAY configured', async () => {
+      const stdioPlugin = {
+        customParams: { mcp: { type: 'stdio' } },
+        identifier: 'my-stdio-mcp',
+      } as any;
+      const stdioManifest = {
+        api: [{ description: 't', name: 'a', parameters: {} }],
+        identifier: 'my-stdio-mcp',
+        meta: { title: 'Stdio' },
+      };
+
+      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
+      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(true);
+      mockQueryDeviceList.mockResolvedValue([
+        { deviceId: 'dev-1', deviceName: 'Remote VM', platform: 'linux' },
+      ]);
+
+      mockPluginQuery.mockResolvedValue([stdioPlugin]);
+      mockGetEnabledPluginManifests.mockReturnValue(new Map([['my-stdio-mcp', stdioManifest]]));
+      mockGetAgentConfig.mockResolvedValue(createBaseAgentConfig({ plugins: ['my-stdio-mcp'] }));
+
+      await service.execAgent({
+        agentId: 'agent-1',
+        clientRuntime: 'desktop',
+        prompt: 'Hello',
+      });
+
+      const executorMap = mockCreateOperation.mock.calls[0][0].toolSet.executorMap;
+      expect(executorMap['my-stdio-mcp']).toBe('client');
+    });
+
+    it('keeps legacy routing for web callers with DEVICE_GATEWAY configured', async () => {
+      // Web client + DEVICE_GATEWAY configured → tools still route through
+      // Remote Device proxy; executor stays unset (legacy behaviour).
+      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
+      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(true);
+      mockQueryDeviceList.mockResolvedValue([
+        { deviceId: 'dev-1', deviceName: 'Remote VM', platform: 'linux' },
+      ]);
+
+      mockGetEnabledPluginManifests.mockReturnValue(
+        new Map([[LocalSystemManifest.identifier, LocalSystemManifest]]),
+      );
+      mockGetAgentConfig.mockResolvedValue(createBaseAgentConfig());
+
+      await service.execAgent({
+        agentId: 'agent-1',
+        clientRuntime: 'web',
+        prompt: 'Hello',
+      });
+
+      const executorMap = mockCreateOperation.mock.calls[0][0].toolSet.executorMap;
+      expect(executorMap[LocalSystemManifest.identifier]).toBeUndefined();
+    });
+  });
+
   describe('toolManifestMap fully derived from ToolsEngine', () => {
     it('should derive manifestMap entirely from getEnabledPluginManifests', async () => {
       const mockManifest = {

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -625,10 +625,21 @@ export class AiAgentService {
       // require local IPC / subprocess capabilities:
       //   - local-system builtin: Electron IPC for file + command execution
       //   - stdio MCP plugins: subprocess lives on the user's machine
-      // Only applies when gateway is NOT configured (standalone Electron). When
-      // deviceContext is present, tools are routed via the RemoteDevice proxy,
-      // so marking them as `client` would misdispatch through dispatchClientTool.
-      if (!gatewayConfigured) {
+      //
+      // Two triggers, in priority order:
+      //  (a) `clientRuntime === 'desktop'` — the caller itself is an Electron
+      //      client on the Agent Gateway WS and is ready to receive
+      //      `tool_execute`. This is the Phase 6.4 path and is authoritative
+      //      regardless of whether DEVICE_GATEWAY (the legacy device-proxy) is
+      //      also configured.
+      //  (b) `!gatewayConfigured` — no DEVICE_GATEWAY configured on the server,
+      //      so legacy Remote Device proxy isn't an option and any client
+      //      tooling falls through to the Gateway WS (standalone Electron).
+      //
+      // When DEVICE_GATEWAY is configured AND the caller is a web client, we
+      // leave executor unset so tools route via RemoteDevice proxy.
+      const shouldDispatchToClient = clientRuntime === 'desktop' || !gatewayConfigured;
+      if (shouldDispatchToClient) {
         if (manifestMap.has(LocalSystemManifest.identifier)) {
           toolExecutorMap[LocalSystemManifest.identifier] = 'client';
         }


### PR DESCRIPTION
## Background

Part of [LOBE-7076](https://linear.app/lobehub/issue/LOBE-7076) Phase 6.4. Follow-up to #13787 and #13790.

End-to-end tracing on canary uncovered that a desktop Electron caller never actually reaches the Phase 6.4 `tool_execute` path when the user has both DEVICE_GATEWAY configured *and* a separately registered remote device. This PR fixes both sides of that gap.

## What was happening

Calling the agent with "read `/tmp/lobe7076/test.txt`" from Electron on canary produced this trace:

1. `lobe-remote-device.listOnlineDevices` → found a registered Linux VM, online
2. `lobe-remote-device.activateDevice` → activated the VM
3. `lobe-local-system.readLocalFile` → **dispatched to the VM** via `deviceProxy.executeToolCall` → `ENOENT` (the file only exists on the caller's Mac)

Both the tool selection (step 1-2) and the routing (step 3) were wrong for a desktop caller.

## Fix 1 — suppress RemoteDevice for desktop callers

`AgentToolsEngine`:

```ts
[RemoteDeviceManifest.identifier]:
  hasDeviceProxy && !deviceContext?.autoActivated && !hasClientExecutor;
                                                     // ^^^^^^^^^^^^^^^^^^^ new
```

`lobe-remote-device` exists so a web caller can tunnel to a separately registered desktop. A desktop caller *is* the target — no proxy needed. Removing it from the manifest stops the LLM from going down steps 1-2 in the first place.

## Fix 2 — mark `executor='client'` for desktop callers

`aiAgent.execAgent`:

```ts
// before
if (!gatewayConfigured) {
  if (manifestMap.has(LocalSystemManifest.identifier)) {
    toolExecutorMap[LocalSystemManifest.identifier] = 'client';
  }
  ...
}

// after
const shouldDispatchToClient = clientRuntime === 'desktop' || !gatewayConfigured;
if (shouldDispatchToClient) {
  ...
}
```

On canary, `gatewayConfigured === true`, so the old gate was a pure false → `executor` stayed unset → `RuntimeExecutors.call_tool` fell through to the server-side `localSystem` runtime, which proxies to a registered device. A `clientRuntime === 'desktop'` signal is authoritative: the caller is on the Agent Gateway WS and `dispatchClientTool` / `sendToolExecute` will land correctly.

Legacy behaviour is preserved for web callers and for callers that don't send `clientRuntime` (e.g. bot/queue-mode invocations).

## Why the two fixes belong together

Either one alone leaves a working regression:

- Fix 1 without Fix 2: LLM no longer sees `lobe-remote-device`, so it picks `local-system.readLocalFile` directly → still routed to the (non-existent) activated device → throws `activeDeviceId is required`.
- Fix 2 without Fix 1: LLM still has `lobe-remote-device` in its menu and may pick it first out of habit (or because the agent's system prompt primes it), bypassing the `dispatchClientTool` path entirely.

## Tests

- `AgentToolsEngine.__tests__/index.test.ts`: +1 case — RemoteDevice suppressed for `clientRuntime: 'desktop'` + `gatewayConfigured: true` (29 total, 28 pre-existing)
- `execAgent.deviceToolPipeline.test.ts`: +3 cases (16 total)
  - local-system gets `executor='client'` for desktop + DEVICE_GATEWAY configured
  - stdio MCP gets `executor='client'` for desktop + DEVICE_GATEWAY configured
  - web caller preserves legacy routing (`executor` unset)
- Type-check clean

## Test plan

- [x] 45 / 45 server tests pass
- [ ] Live canary E2E after merge: Electron desktop caller asks agent to read a local file → WS frames show `tool_execute` inbound + `tool_result` outbound, no `lobe-remote-device` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)