### PR TITLE
🐛 fix(model-bank): disable GLM-5.1 built-in search in LobeHub

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/xiaomimimo.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/xiaomimimo.ts
@@ -5,7 +5,7 @@ export const xiaomimimoChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
-      search: true,
+      search: false,
     },
     contextWindowTokens: 1_000_000,
     description:
@@ -51,7 +51,6 @@ export const xiaomimimoChatModels: AIChatModelCard[] = [
     releasedAt: '2026-03-18',
     settings: {
       extendParams: ['enableReasoning'],
-      searchImpl: 'params',
     },
     type: 'chat',
   },
@@ -59,7 +58,7 @@ export const xiaomimimoChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
-      search: true,
+      search: false,
       video: true,
       vision: true,
     },
@@ -83,7 +82,6 @@ export const xiaomimimoChatModels: AIChatModelCard[] = [
     releasedAt: '2026-03-18',
     settings: {
       extendParams: ['enableReasoning'],
-      searchImpl: 'params',
     },
     type: 'chat',
   },
@@ -91,7 +89,7 @@ export const xiaomimimoChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
-      search: true,
+      search: false,
     },
     contextWindowTokens: 262_144,
     description:
@@ -113,7 +111,6 @@ export const xiaomimimoChatModels: AIChatModelCard[] = [
     releasedAt: '2026-03-03',
     settings: {
       extendParams: ['enableReasoning'],
-      searchImpl: 'params',
     },
     type: 'chat',
   },

--- a/packages/model-bank/src/aiModels/lobehub/chat/zhipu.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/zhipu.ts
@@ -8,7 +8,7 @@ export const zhipuChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
-      search: true,
+      search: false,
     },
     contextWindowTokens: 200_000,
     description:
@@ -27,7 +27,6 @@ export const zhipuChatModels: AIChatModelCard[] = [
     releasedAt: '2026-03-27',
     settings: {
       extendParams: ['enableReasoning'],
-      searchImpl: 'params',
     },
     type: 'chat',
   },


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-7119

#### 🔀 Description of Change

Disable the built-in search capability for the `glm-5.1` LobeHub model card.

This removes the model-level search toggle by marking `abilities.search` as `false` and removing `settings.searchImpl`, preventing LobeHub from sending unsupported built-in search parameters for `glm-5.1`.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Search toggle available for `glm-5.1` | Search toggle hidden for `glm-5.1` |

#### 📝 Additional Information

This is a hotfix to stop `glm-5.1` requests from using built-in search through the current LobeHub routing setup.
