### PR TITLE
💄 style(nav-panel): remove nav panel content switch animation

### DIFF
--- a/src/features/NavPanel/components/NavPanelDraggable.tsx
+++ b/src/features/NavPanel/components/NavPanelDraggable.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { DraggablePanel, Freeze } from '@lobehub/ui';
+import { DraggablePanel } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
-import { AnimatePresence, m, useIsPresent } from 'motion/react';
 import { type ReactNode } from 'react';
-import { memo, Suspense, useLayoutEffect, useMemo, useRef } from 'react';
+import { memo, Suspense, useMemo, useRef } from 'react';
 
 import { isDesktop } from '@/const/version';
 import { TOGGLE_BUTTON_ID } from '@/features/NavPanel/ToggleLeftPanelButton';
@@ -12,41 +11,10 @@ import Footer from '@/routes/(main)/home/_layout/Footer';
 import { USER_DROPDOWN_ICON_ID } from '@/routes/(main)/home/_layout/Header/components/User';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
-import { useUserStore } from '@/store/user';
-import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 import { isMacOS } from '@/utils/platform';
 
 import { useNavPanelSizeChangeHandler } from '../hooks/useNavPanel';
 import { BACK_BUTTON_ID } from './BackButton';
-
-type MotionDirection = -1 | 0 | 1;
-
-const MOTION_OFFSET = 8;
-
-const isMotionDisabled = (mode?: string) => mode === 'disabled';
-
-const getMotionDirectionByHistory = (history: string[], nextKey: string): MotionDirection => {
-  const currentKey = history.at(-1);
-  if (currentKey === nextKey) return 0;
-
-  return history.includes(nextKey) ? -1 : 1;
-};
-
-const motionVariants = {
-  animate: { opacity: 1, x: 0 },
-  exit: (direction: MotionDirection) => ({
-    opacity: 0,
-    x: -direction * MOTION_OFFSET,
-  }),
-  initial: (direction: MotionDirection) => ({
-    opacity: 0,
-    x: direction * MOTION_OFFSET,
-  }),
-  transition: {
-    duration: 0.28,
-    ease: [0.4, 0, 0.2, 1],
-  },
-} as const;
 
 const draggableStyles = createStaticStyles(({ css, cssVar }) => ({
   content: css`
@@ -71,8 +39,6 @@ const draggableStyles = createStaticStyles(({ css, cssVar }) => ({
     min-height: 0;
   `,
   layer: css`
-    will-change: opacity, transform;
-
     position: absolute;
     inset: 0;
 
@@ -135,29 +101,15 @@ interface NavPanelDraggableProps {
   };
 }
 
-interface ExitingFrozenContentProps {
-  children: ReactNode;
-}
-
 const classNames = {
   content: draggableStyles.content,
 };
-
-const ExitingFrozenContent = memo<ExitingFrozenContentProps>(({ children }) => {
-  const isPresent = useIsPresent();
-
-  return <Freeze frozen={!isPresent}>{children}</Freeze>;
-});
-
-ExitingFrozenContent.displayName = 'ExitingFrozenContent';
 
 export const NavPanelDraggable = memo<NavPanelDraggableProps>(({ activeContent }) => {
   const [expand, togglePanel] = useGlobalStore((s) => [
     systemStatusSelectors.showLeftPanel(s),
     s.toggleLeftPanel,
   ]);
-  const animationMode = useUserStore(userGeneralSettingsSelectors.animationMode);
-  const shouldUseMotion = !isMotionDisabled(animationMode);
   const handleSizeChange = useNavPanelSizeChangeHandler();
 
   const defaultWidthRef = useRef(0);
@@ -180,35 +132,6 @@ export const NavPanelDraggable = memo<NavPanelDraggableProps>(({ activeContent }
     [],
   );
 
-  const historyRef = useRef([activeContent.key]);
-  const directionRef = useRef<MotionDirection>(0);
-
-  const history = historyRef.current;
-  const direction = shouldUseMotion ? getMotionDirectionByHistory(history, activeContent.key) : 0;
-  if (direction !== 0) {
-    directionRef.current = direction;
-  }
-
-  useLayoutEffect(() => {
-    if (!shouldUseMotion) return;
-
-    const snapshot = historyRef.current;
-    const currentKey = snapshot.at(-1);
-    const nextKey = activeContent.key;
-
-    if (currentKey === nextKey) return;
-
-    const existingIndex = snapshot.lastIndexOf(nextKey);
-    if (existingIndex !== -1) {
-      snapshot.splice(existingIndex + 1);
-      return;
-    }
-
-    snapshot.push(nextKey);
-  }, [activeContent.key, shouldUseMotion]);
-
-  const motionDirection = shouldUseMotion ? directionRef.current : 0;
-
   return (
     <DraggablePanel
       className={draggableStyles.panel}
@@ -225,26 +148,9 @@ export const NavPanelDraggable = memo<NavPanelDraggableProps>(({ activeContent }
       onSizeDragging={handleSizeChange}
     >
       <div className={draggableStyles.inner}>
-        {shouldUseMotion ? (
-          <AnimatePresence custom={motionDirection} initial={false} mode="sync">
-            <m.div
-              animate="animate"
-              className={draggableStyles.layer}
-              custom={motionDirection}
-              exit="exit"
-              initial="initial"
-              key={activeContent.key}
-              transition={motionVariants.transition}
-              variants={motionVariants}
-            >
-              <ExitingFrozenContent>{activeContent.node}</ExitingFrozenContent>
-            </m.div>
-          </AnimatePresence>
-        ) : (
-          <div className={draggableStyles.layer} key={activeContent.key}>
-            {activeContent.node}
-          </div>
-        )}
+        <div className={draggableStyles.layer} key={activeContent.key}>
+          {activeContent.node}
+        </div>
       </div>
       <Suspense>
         <Footer />


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

N/A — UX adjustment.

#### 🔀 Description of Change

Drops the \`motion/react\` slide + fade transition on \`NavPanelDraggable\` when \`activeContent.key\` changes (e.g. navigating from \`/\` to \`/agent\`). The sidebar content now swaps directly without a 0.28s x-translate animation.

Removed:
- \`AnimatePresence\` / \`m.div\` wrapping
- \`motionVariants\`, \`MOTION_OFFSET\`, direction-tracking refs and \`useLayoutEffect\`
- \`ExitingFrozenContent\` helper (based on \`useIsPresent\` + \`Freeze\`)
- \`animationMode\` read (the user setting itself is still used by AppTheme / chat messages)

Kept:
- \`activeContent.key\` as the React \`key\` on the wrapper div so React still unmounts old content on switch.

#### 🧪 How to Test

- [x] Tested locally
- [x] No tests needed

Navigate between \`/\`, \`/agent/:aid\`, \`/group/:gid\`, \`/community\`, etc. — the left nav panel now swaps content instantly.

#### 📝 Additional Information

Net: -99 / +5 lines.