### PR TITLE
🔨 chore: wire Gateway-mode stop via direct tRPC interrupt

### DIFF
--- a/src/store/chat/slices/aiChat/actions/__tests__/conversationControl.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/conversationControl.test.ts
@@ -85,6 +85,49 @@ describe('ConversationControl actions', () => {
 
       expect(result.current.operations[operationId!].status).toBe('running');
     });
+
+    it('cancels Gateway-mode execServerAgentRuntime ops and invokes their cancel handler', () => {
+      const { result } = renderHook(() => useChatStore());
+
+      act(() => {
+        useChatStore.setState({
+          activeAgentId: TEST_IDS.SESSION_ID,
+          activeTopicId: TEST_IDS.TOPIC_ID,
+        });
+      });
+
+      let operationId!: string;
+      act(() => {
+        const res = result.current.startOperation({
+          type: 'execServerAgentRuntime',
+          context: { agentId: TEST_IDS.SESSION_ID, topicId: TEST_IDS.TOPIC_ID },
+        });
+        operationId = res.operationId;
+      });
+
+      const cancelHandler = vi.fn();
+      act(() => {
+        result.current.onOperationCancel(operationId, cancelHandler);
+      });
+
+      expect(result.current.operations[operationId].status).toBe('running');
+
+      act(() => {
+        result.current.stopGenerateMessage();
+      });
+
+      // Operation gets cancelled and the handler (which would fire the WS interrupt
+      // in real code) is invoked with the operation context.
+      expect(result.current.operations[operationId].status).toBe('cancelled');
+      expect(cancelHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operationId,
+          type: 'execServerAgentRuntime',
+        }),
+      );
+      // isAborting flag is also flipped so the UI loading state clears immediately.
+      expect(result.current.operations[operationId].metadata.isAborting).toBe(true);
+    });
   });
 
   describe('cancelSendMessageInServer', () => {

--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -281,6 +281,7 @@ describe('GatewayActionImpl', () => {
         associateMessageWithOperation: vi.fn(),
         connectToGateway: vi.fn(),
         internal_updateTopicLoading: vi.fn(),
+        onOperationCancel: vi.fn(),
         replaceMessages: vi.fn(),
         switchTopic: vi.fn(),
       })) as any;
@@ -397,6 +398,66 @@ describe('GatewayActionImpl', () => {
           prompt: '',
         }),
       );
+    });
+
+    it('registers a cancel handler that forwards WS interrupt with the server operationId', async () => {
+      const onOperationCancel = vi.fn();
+      const startOperation = vi.fn(() => ({ operationId: 'gw-op-local' }));
+
+      const mockClient = createMockClient();
+      const state: Record<string, any> = { gatewayConnections: {} };
+      const set = vi.fn((updater: any) => {
+        if (typeof updater === 'function') Object.assign(state, updater(state));
+        else Object.assign(state, updater);
+      });
+      const get = vi.fn(() => ({
+        ...state,
+        associateMessageWithOperation: vi.fn(),
+        connectToGateway: vi.fn(),
+        internal_updateTopicLoading: vi.fn(),
+        onOperationCancel,
+        replaceMessages: vi.fn(),
+        startOperation,
+        switchTopic: vi.fn(),
+      })) as any;
+
+      (globalThis as any).window = {
+        global_serverConfigStore: {
+          getState: () => ({ serverConfig: { agentGatewayUrl: 'https://gateway.test.com' } }),
+        },
+      };
+
+      const action = new GatewayActionImpl(set as any, get, undefined);
+      action.createClient = vi.fn(() => mockClient);
+      const interruptSpy = vi.spyOn(action, 'interruptGatewayAgent').mockImplementation(() => {});
+
+      vi.mocked(aiAgentService.execAgentTask).mockResolvedValue({
+        agentId: 'agent-1',
+        assistantMessageId: 'ast-1',
+        autoStarted: true,
+        createdAt: new Date().toISOString(),
+        message: 'ok',
+        operationId: 'server-op-xyz',
+        status: 'created',
+        success: true,
+        timestamp: new Date().toISOString(),
+        token: 'test-token',
+        topicId: 'topic-1',
+        userMessageId: 'usr-1',
+      });
+
+      await action.executeGatewayAgent({
+        context: { agentId: 'agent-1', topicId: 'topic-1', threadId: null, scope: 'main' },
+        message: 'Hello',
+      });
+
+      // Handler was registered against the local operation id...
+      expect(onOperationCancel).toHaveBeenCalledWith('gw-op-local', expect.any(Function));
+
+      // ...and, when invoked, interrupts the *server-side* operation id
+      const [, handler] = onOperationCancel.mock.calls[0];
+      handler();
+      expect(interruptSpy).toHaveBeenCalledWith('server-op-xyz');
     });
   });
 });

--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -9,6 +9,7 @@ import { GatewayActionImpl } from '../gateway';
 vi.mock('@/services/aiAgent', () => ({
   aiAgentService: {
     execAgentTask: vi.fn(),
+    interruptTask: vi.fn(),
   },
 }));
 
@@ -400,7 +401,7 @@ describe('GatewayActionImpl', () => {
       );
     });
 
-    it('registers a cancel handler that forwards WS interrupt with the server operationId', async () => {
+    it('registers a cancel handler that calls aiAgentService.interruptTask with the server operationId', async () => {
       const onOperationCancel = vi.fn();
       const startOperation = vi.fn(() => ({ operationId: 'gw-op-local' }));
 
@@ -429,7 +430,9 @@ describe('GatewayActionImpl', () => {
 
       const action = new GatewayActionImpl(set as any, get, undefined);
       action.createClient = vi.fn(() => mockClient);
-      const interruptSpy = vi.spyOn(action, 'interruptGatewayAgent').mockImplementation(() => {});
+      const interruptTaskSpy = vi
+        .mocked(aiAgentService.interruptTask)
+        .mockResolvedValue({ operationId: 'server-op-xyz', success: true });
 
       vi.mocked(aiAgentService.execAgentTask).mockResolvedValue({
         agentId: 'agent-1',
@@ -454,10 +457,10 @@ describe('GatewayActionImpl', () => {
       // Handler was registered against the local operation id...
       expect(onOperationCancel).toHaveBeenCalledWith('gw-op-local', expect.any(Function));
 
-      // ...and, when invoked, interrupts the *server-side* operation id
+      // ...and, when invoked, fires tRPC interruptTask with the *server-side* operation id
       const [, handler] = onOperationCancel.mock.calls[0];
-      handler();
-      expect(interruptSpy).toHaveBeenCalledWith('server-op-xyz');
+      await handler();
+      expect(interruptTaskSpy).toHaveBeenCalledWith({ operationId: 'server-op-xyz' });
     });
   });
 });

--- a/src/store/chat/slices/aiChat/actions/conversationControl.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationControl.ts
@@ -31,10 +31,15 @@ export class ConversationControlActionImpl {
   stopGenerateMessage = (): void => {
     const { activeAgentId, activeTopicId, cancelOperations } = this.#get();
 
-    // Cancel all running execAgentRuntime operations in the current context
+    // Cancel running agent-runtime operations in the current context —
+    // both client-side (execAgentRuntime) and Gateway-mode
+    // (execServerAgentRuntime). For the Gateway-mode branch, a cancel
+    // handler registered in `executeGatewayAgent` / `reconnectToGatewayOperation`
+    // picks up the cancellation and forwards an `interrupt` frame over the
+    // Agent Gateway WebSocket so the server-side loop aborts.
     cancelOperations(
       {
-        type: 'execAgentRuntime',
+        type: ['execAgentRuntime', 'execServerAgentRuntime'],
         status: 'running',
         agentId: activeAgentId,
         topicId: activeTopicId,

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -275,6 +275,14 @@ export class GatewayActionImpl {
     // Associate the server-created assistant message with the gateway operation
     this.#get().associateMessageWithOperation(result.assistantMessageId, gatewayOpId);
 
+    // When the local operation is cancelled (e.g. user clicks stop), forward
+    // the interrupt over the Gateway WS so the server-side agent loop aborts.
+    // Closure captures `result.operationId` (server-side id, the key under
+    // `gatewayConnections`) so we don't depend on any metadata lookup.
+    this.#get().onOperationCancel(gatewayOpId, () => {
+      this.interruptGatewayAgent(result.operationId);
+    });
+
     const eventHandler = createGatewayEventHandler(this.#get, {
       assistantMessageId: result.assistantMessageId,
       context: execContext,
@@ -343,6 +351,12 @@ export class GatewayActionImpl {
     });
 
     this.#get().associateMessageWithOperation(assistantMessageId, gatewayOpId);
+
+    // Forward local-op cancellation to the server-side agent loop over WS.
+    // See note in executeGatewayAgent for details.
+    this.#get().onOperationCancel(gatewayOpId, () => {
+      this.interruptGatewayAgent(operationId);
+    });
 
     const eventHandler = createGatewayEventHandler(this.#get, {
       assistantMessageId,

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -276,11 +276,14 @@ export class GatewayActionImpl {
     this.#get().associateMessageWithOperation(result.assistantMessageId, gatewayOpId);
 
     // When the local operation is cancelled (e.g. user clicks stop), forward
-    // the interrupt over the Gateway WS so the server-side agent loop aborts.
-    // Closure captures `result.operationId` (server-side id, the key under
-    // `gatewayConnections`) so we don't depend on any metadata lookup.
-    this.#get().onOperationCancel(gatewayOpId, () => {
-      this.interruptGatewayAgent(result.operationId);
+    // the interrupt directly to the server via the existing tRPC endpoint.
+    // Closure captures `result.operationId` (the server-side id) so we don't
+    // depend on any metadata lookup. Fire-and-forget — errors are logged but
+    // never block the local cancel flow.
+    this.#get().onOperationCancel(gatewayOpId, async () => {
+      await aiAgentService
+        .interruptTask({ operationId: result.operationId })
+        .catch((err) => console.error('[Gateway] interruptTask failed:', err));
     });
 
     const eventHandler = createGatewayEventHandler(this.#get, {
@@ -352,10 +355,12 @@ export class GatewayActionImpl {
 
     this.#get().associateMessageWithOperation(assistantMessageId, gatewayOpId);
 
-    // Forward local-op cancellation to the server-side agent loop over WS.
+    // Forward local-op cancellation to the server-side agent loop via tRPC.
     // See note in executeGatewayAgent for details.
-    this.#get().onOperationCancel(gatewayOpId, () => {
-      this.interruptGatewayAgent(operationId);
+    this.#get().onOperationCancel(gatewayOpId, async () => {
+      await aiAgentService
+        .interruptTask({ operationId })
+        .catch((err) => console.error('[Gateway] interruptTask failed:', err));
     });
 
     const eventHandler = createGatewayEventHandler(this.#get, {

--- a/src/store/chat/slices/operation/actions.ts
+++ b/src/store/chat/slices/operation/actions.ts
@@ -389,9 +389,13 @@ export class OperationActionsImpl {
       // Ignore abort errors
     }
 
-    // 2. Set isAborting flag immediately for execAgentRuntime operations
-    // This ensures UI (loading button) responds instantly to user cancellation
-    if (operation.type === 'execAgentRuntime') {
+    // 2. Set isAborting flag immediately for agent-runtime operations.
+    // This ensures UI (loading button) responds instantly to user cancellation.
+    // Applies to both client-side (execAgentRuntime) and Gateway-mode
+    // (execServerAgentRuntime) runs — the latter needs the flag so the UI
+    // transitions out of loading right away, without waiting for the
+    // round-trip WS `session_complete` after the server acknowledges interrupt.
+    if (operation.type === 'execAgentRuntime' || operation.type === 'execServerAgentRuntime') {
       this.#get().updateOperationMetadata(operationId, { isAborting: true });
     }
 


### PR DESCRIPTION
## Background

Client-side fix for the parent issue [LOBE-7142](https://linear.app/lobehub/issue/LOBE-7142) (*Gateway 模式 Stop / Interrupt 实现*).

Before this PR, clicking UI stop during a Gateway-mode (\`execServerAgentRuntime\`) run silently did nothing — the local op filter was \`type: 'execAgentRuntime'\` only, and there was no bridge from local cancellation to the server-side agent loop.

## Root cause

| Layer | State |
|-------|-------|
| \`stopGenerateMessage\` | filter only matched \`execAgentRuntime\` |
| Server-side \`interruptTask\` tRPC endpoint | ✅ already exists — \`AiAgentService.interruptTask\` → \`AgentRuntimeService.interruptOperation\` → \`coordinator.saveAgentState\` (\`status='interrupted'\`) |
| Server-side step-boundary polling | ✅ already exists — \`executeStep\` at \`AgentRuntimeService.ts:474\` and \`:565\` checks state and early-returns on \`'interrupted'\` |
| Client-side bridge | ❌ missing |

All the server plumbing is already on canary. The only thing missing was calling \`aiAgentService.interruptTask({ operationId })\` from the client at the right moment.

## What this PR does

### \`conversationControl.ts::stopGenerateMessage\`
Extend the type filter so both \`execAgentRuntime\` (client-side) and \`execServerAgentRuntime\` (Gateway) ops are cancelled by a single call.

### \`gateway.ts::executeGatewayAgent\` + \`reconnectToGatewayOperation\`
Register an \`onOperationCancel\` handler on the *local* \`gatewayOpId\`. When the local op is cancelled (e.g. user clicks stop → \`cancelOperations\`), the handler fires \`aiAgentService.interruptTask({ operationId: result.operationId })\` — passing the **server-side** operation id captured in closure.

The tRPC round-trip triggers \`AgentRuntimeService.interruptOperation\`, which flips the DB state to \`'interrupted'\`. The running agent loop's existing step-boundary polling picks it up on the next boundary and short-circuits. No new server code, no new routes, no Agent Gateway changes needed.

### \`operation/actions.ts::cancelOperation\`
The existing \`isAborting\` metadata flag was only set for \`execAgentRuntime\`. Extend to \`execServerAgentRuntime\` so the UI loading state transitions out **immediately** on stop, without waiting for the tRPC round-trip to resolve or for the server to emit \`session_complete\`.

## Why direct tRPC instead of WS interrupt (as the parent spec initially proposed)

The original [LOBE-7142](https://linear.app/lobehub/issue/LOBE-7142) spec mirrored the [LOBE-7134](https://linear.app/lobehub/issue/LOBE-7134) \`tool_result\` callback pattern: UI → WS → Agent Gateway DO → HTTP → cloud route → Redis LPUSH → agent loop LPOP.

That turned out to be the wrong pattern for \`interrupt\`:

| Dimension | Via Agent Gateway WS (spec) | Direct tRPC (this PR) |
|-----------|------------------------------|------------------------|
| Hops | 3 (client → Gateway → cloud) | 1 |
| New server code | new route + Redis LPUSH/LPOP in \`executeStep\` | zero |
| External repo coord | Agent Gateway DO \`_forwardInterrupt\` | zero |
| Cross-replica safety | Redis key | DB state (already cross-replica) |
| Abort granularity | step boundary | step boundary (identical) |

The only argument for WS was "symmetry with tool_execute/tool_result", but those are stream-like payloads mid-execution while \`interrupt\` is a one-shot control signal — there's no benefit to routing it through the same channel. Mid-step abort (e.g. closing an in-flight LLM HTTP stream) would require threading an AbortSignal into \`runtime.step(...)\`, which WS doesn't help with either.

This removes the need for sub-issues [LOBE-7145](https://linear.app/lobehub/issue/LOBE-7145) (new route), [LOBE-7146](https://linear.app/lobehub/issue/LOBE-7146) (Redis LPOP), and [LOBE-7147](https://linear.app/lobehub/issue/LOBE-7147) (Agent Gateway DO forwarding) — all being closed as not-planned.

\`AgentStreamClient.sendInterrupt()\` and \`interruptGatewayAgent()\` are kept as public API but no longer called from the cancel flow. Dead-code removal is out of scope here; can be a separate cleanup if desired.

## Test plan

- [x] \`conversationControl.test.ts\` — new case: \`stopGenerateMessage\` cancels \`execServerAgentRuntime\`, invokes the registered handler, sets \`isAborting: true\`.
- [x] \`gateway.test.ts\` — new case: \`executeGatewayAgent\` registers the handler against the local opId, and when invoked, the handler calls \`aiAgentService.interruptTask\` with the **server** opId.
- [x] 123 / 123 touched-slice tests pass; type-check clean.
- [ ] Live canary E2E: trigger a long Gateway-mode conversation, click stop, verify tRPC call fires + server operation flips to \`interrupted\` + UI loading clears (running right after this update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)