### PR TITLE
 🔨 chore: add headless approval and apiKey WS auth to `lh agent run`

### DIFF
--- a/apps/cli/src/api/http.ts
+++ b/apps/cli/src/api/http.ts
@@ -37,7 +37,25 @@ export async function getAuthInfo(): Promise<AuthInfo> {
   };
 }
 
-export async function getAgentStreamAuthInfo(): Promise<Pick<AuthInfo, 'headers' | 'serverUrl'>> {
+export type AgentStreamTokenType = 'jwt' | 'apiKey';
+
+export interface AgentStreamAuthInfo {
+  headers: Record<string, string>;
+  serverUrl: string;
+  /**
+   * Raw token value (without header prefix). Used for WebSocket auth messages
+   * where header-based auth is not available.
+   */
+  token: string;
+  /**
+   * How the token should be verified by downstream services (agent gateway WS).
+   * jwt  → validate with JWKS
+   * apiKey → validate by calling /api/v1/users/me
+   */
+  tokenType: AgentStreamTokenType;
+}
+
+export async function getAgentStreamAuthInfo(): Promise<AgentStreamAuthInfo> {
   const serverUrl = resolveServerUrl();
 
   const envJwt = process.env.LOBEHUB_JWT;
@@ -45,6 +63,8 @@ export async function getAgentStreamAuthInfo(): Promise<Pick<AuthInfo, 'headers'
     return {
       headers: { 'Oidc-Auth': envJwt },
       serverUrl,
+      token: envJwt,
+      tokenType: 'jwt',
     };
   }
 
@@ -53,6 +73,8 @@ export async function getAgentStreamAuthInfo(): Promise<Pick<AuthInfo, 'headers'
     return {
       headers: { 'X-API-Key': envApiKey },
       serverUrl,
+      token: envApiKey,
+      tokenType: 'apiKey',
     };
   }
 
@@ -64,11 +86,15 @@ export async function getAgentStreamAuthInfo(): Promise<Pick<AuthInfo, 'headers'
     return {
       headers: {},
       serverUrl,
+      token: '',
+      tokenType: 'jwt',
     };
   }
 
   return {
     headers: { 'Oidc-Auth': result.credentials.accessToken },
     serverUrl,
+    token: result.credentials.accessToken,
+    tokenType: 'jwt',
   };
 }

--- a/apps/cli/src/commands/agent.ts
+++ b/apps/cli/src/commands/agent.ts
@@ -258,6 +258,10 @@ export function registerAgentCommand(program: Command) {
       '--device <target>',
       'Target device ID, or use "local" for the current connected device',
     )
+    .option(
+      '--no-headless',
+      "Disable headless mode and wait for human approval on tool calls (default: headless — tools auto-run, matching the CLI's non-interactive nature)",
+    )
     .option('--json', 'Output full JSON event stream')
     .option('-v, --verbose', 'Show detailed tool call info')
     .option('--replay <file>', 'Replay events from a saved JSON file (offline)')
@@ -267,6 +271,7 @@ export function registerAgentCommand(program: Command) {
         agentId?: string;
         autoStart?: boolean;
         device?: string;
+        headless?: boolean;
         json?: boolean;
         prompt?: string;
         replay?: string;
@@ -340,6 +345,11 @@ export function registerAgentCommand(program: Command) {
         if (options.slug) input.slug = options.slug;
         if (options.topicId) input.appContext = { topicId: options.topicId };
         if (options.autoStart === false) input.autoStart = false;
+        // commander's --no-headless sets `headless` to false. Anything else
+        // (undefined, true) → headless mode is on and tool calls auto-execute.
+        if (options.headless !== false) {
+          input.userInterventionConfig = { approvalMode: 'headless' };
+        }
 
         const result = await client.aiAgent.execAgent.mutate(input as any);
         const r = result as any;
@@ -355,16 +365,16 @@ export function registerAgentCommand(program: Command) {
         }
 
         // 2. Connect to stream (WebSocket via Gateway, or fallback to SSE)
-        const { serverUrl, headers } = await getAgentStreamAuthInfo();
+        const { serverUrl, headers, token, tokenType } = await getAgentStreamAuthInfo();
         const agentGatewayUrl = options.sse ? undefined : resolveAgentGatewayUrl();
 
         if (agentGatewayUrl) {
-          const token = headers['Oidc-Auth'] || headers['X-API-Key'] || '';
           await streamAgentEventsViaWebSocket({
             gatewayUrl: agentGatewayUrl,
             json: options.json,
             operationId,
             token,
+            tokenType,
             verbose: options.verbose,
           });
         } else {

--- a/apps/cli/src/utils/agentStream.test.ts
+++ b/apps/cli/src/utils/agentStream.test.ts
@@ -280,9 +280,30 @@ describe('streamAgentEventsViaWebSocket', () => {
 
     const ws = capturedWs!;
     expect(ws.sent.map((s) => JSON.parse(s))).toEqual([
-      { token: 'test-token', type: 'auth' },
+      { token: 'test-token', tokenType: 'jwt', type: 'auth' },
       { lastEventId: '', type: 'resume' },
     ]);
+
+    ws.simulateMessage({ id: '1', type: 'session_complete' });
+    await promise;
+  });
+
+  it('should send tokenType=apiKey when the caller uses an API key', async () => {
+    const promise = streamAgentEventsViaWebSocket({
+      gatewayUrl: 'https://gw.test.com',
+      operationId: 'op-1',
+      token: 'lh_sk_abc',
+      tokenType: 'apiKey',
+    });
+
+    await flush();
+
+    const ws = capturedWs!;
+    expect(ws.sent.map((s) => JSON.parse(s))[0]).toEqual({
+      token: 'lh_sk_abc',
+      tokenType: 'apiKey',
+      type: 'auth',
+    });
 
     ws.simulateMessage({ id: '1', type: 'session_complete' });
     await promise;

--- a/apps/cli/src/utils/agentStream.ts
+++ b/apps/cli/src/utils/agentStream.ts
@@ -21,6 +21,11 @@ interface WebSocketStreamOptions extends StreamOptions {
   gatewayUrl: string;
   operationId: string;
   token: string;
+  /**
+   * How the gateway should verify `token`. `jwt` is the default for
+   * backwards compatibility with existing callers.
+   */
+  tokenType?: 'jwt' | 'apiKey';
 }
 
 /**
@@ -168,13 +173,13 @@ const HEARTBEAT_INTERVAL = 30_000;
 export async function streamAgentEventsViaWebSocket(
   options: WebSocketStreamOptions,
 ): Promise<void> {
-  const { gatewayUrl, operationId, token, ...streamOpts } = options;
+  const { gatewayUrl, operationId, token, tokenType = 'jwt', ...streamOpts } = options;
   const wsUrl = urlJoin(
     gatewayUrl.replace(/^http/, 'ws'),
     `/ws?operationId=${encodeURIComponent(operationId)}`,
   );
 
-  log.debug(`Connecting to gateway: ${wsUrl}`);
+  log.debug(`Connecting to gateway: ${wsUrl} (auth: ${tokenType})`);
 
   return new Promise<void>((resolve, reject) => {
     const ws = new WebSocket(wsUrl);
@@ -192,7 +197,7 @@ export async function streamAgentEventsViaWebSocket(
     };
 
     ws.onopen = () => {
-      ws.send(JSON.stringify({ token, type: 'auth' }));
+      ws.send(JSON.stringify({ token, tokenType, type: 'auth' }));
     };
 
     ws.onmessage = (event) => {

--- a/src/server/routers/lambda/aiAgent.ts
+++ b/src/server/routers/lambda/aiAgent.ts
@@ -1,7 +1,7 @@
 import { type AgentRuntimeContext } from '@lobechat/agent-runtime';
 import { parse } from '@lobechat/conversation-flow';
 import { type TaskCurrentActivity, type TaskStatusResult } from '@lobechat/types';
-import { ThreadStatus, ThreadType } from '@lobechat/types';
+import { ThreadStatus, ThreadType, UserInterventionConfigSchema } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 import pMap from 'p-map';
@@ -109,6 +109,12 @@ const ExecAgentSchema = z
     prompt: z.string(),
     /** The agent slug to run (either agentId or slug is required) */
     slug: z.string().optional(),
+    /**
+     * User intervention configuration for tool approvals.
+     * Pass `{ approvalMode: 'headless' }` from headless clients (CLI, cron, bots)
+     * so tool calls auto-execute without waiting for human approval.
+     */
+    userInterventionConfig: UserInterventionConfigSchema.optional(),
   })
   .refine((data) => data.agentId || data.slug, {
     message: 'Either agentId or slug must be provided',
@@ -541,6 +547,7 @@ export const aiAgentRouter = router({
       existingMessageIds = [],
       fileIds,
       parentMessageId,
+      userInterventionConfig,
     } = input;
 
     log('execAgent: identifier=%s, prompt=%s', agentId || slug, prompt.slice(0, 50));
@@ -559,6 +566,7 @@ export const aiAgentRouter = router({
         // When parentMessageId is provided, this is a regeneration/continue — skip user message creation
         resume: !!parentMessageId,
         slug,
+        userInterventionConfig,
       });
     } catch (error: any) {
       console.error('execAgent failed: %O', error);


### PR DESCRIPTION
## Summary

Two independent issues that together block `lh agent run` when auth'd via `LOBEHUB_CLI_API_KEY`:

1. **CLI didn't request headless mode** — without `userInterventionConfig: { approvalMode: 'headless' }`, the runtime waits for human tool-call approval that never arrives in a non-interactive CLI context, so commands like `Run ls ~ | grep dev in my device` hang forever.
2. **WebSocket auth dropped `tokenType`** — the auth handshake was `{ token, type: 'auth' }`, missing the `tokenType` field. The agent gateway defaulted to JWT verification and rejected API keys.

## Changes

- `src/server/routers/lambda/aiAgent.ts` — `ExecAgentSchema` now accepts `userInterventionConfig` (`UserInterventionConfigSchema`), and the router passes it through to `aiAgentService.execAgent`. Same shape the web/cron paths already use (e.g. `task.ts:884`, `AgentBridgeService.ts:731`).
- `apps/cli/src/commands/agent.ts` — new `--no-headless` opt-out flag (default is headless). Sends `userInterventionConfig: { approvalMode: 'headless' }` unless disabled. Reads `token` and `tokenType` from `getAgentStreamAuthInfo()` and forwards them to the WS stream.
- `apps/cli/src/api/http.ts` — `getAgentStreamAuthInfo()` now also returns `{ token, tokenType: 'jwt' | 'apiKey' }` so callers don't have to re-derive the type from header names.
- `apps/cli/src/utils/agentStream.ts` — `WebSocketStreamOptions` accepts `tokenType` (defaults to `'jwt'`), and the auth message now includes it: `{ token, tokenType, type: 'auth' }`. This matches what `@lobechat/device-gateway-client` already sends on the device-gateway WS.
- Tests: updated existing expectation for the auth message, added a new test covering the `tokenType: 'apiKey'` path.

## Scope notes

- `--no-headless` opt-out is included for completeness. Default stays headless because an interactive CLI prompt doesn't exist yet and a missing flag was the bug in the first place.
- Backend schema is additive and optional — older CLI clients continue to work, newer clients enable headless.
- The agent gateway server side already knows how to verify an API key (same `resolveSocketAuth` pattern as device-gateway); this PR just wires up the CLI side.

## Test plan

- [x] `bunx vitest run apps/cli/src/utils/agentStream.test.ts` — 14/14 green (includes new apiKey auth test)
- [x] `bunx vitest run src/server/routers/lambda/__tests__/aiAgent.test.ts` — 10/10 green
- [x] `bun run type-check` — no new errors attributable to this PR
- [ ] Manual repro from the issue:
  ```bash
  lh logout
  export LOBEHUB_CLI_API_KEY='***'
  lh login --server http://localhost:3010
  lh connect --daemon --gateway http://localhost:8787
  lh agent run --slug inbox --device local --prompt 'Run ls ~ | grep dev in my device'
  ```

Fixes LOBE-6939

🤖 Generated with [Claude Code](https://claude.com/claude-code)