### PR TITLE
🐛 fix(agent-runtime): carry persisted assistant id into state.messages

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -964,8 +964,16 @@ export const createRuntimeExecutors = (
           // ===== 2. Then accumulate to AgentState =====
           const newState = structuredClone(state);
 
+          // Carry the persisted DB id so downstream executors (notably
+          // `request_human_approve`) can look up the parent assistant from
+          // `state.messages` without an extra DB round-trip. Without the id
+          // the lookup at `request_human_approve` (which filters on `m.id`)
+          // falls through to a DB query; when human-approve fires on the
+          // fresh LLM turn, both code paths miss and the op errors with
+          // "No assistant message found as parent for pending tool messages".
           newState.messages.push({
             content,
+            id: assistantMessageItem.id,
             reasoning: finalReasoning,
             role: 'assistant',
             tool_calls: tool_calls.length > 0 ? tool_calls : undefined,

--- a/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -361,11 +361,58 @@ describe('RuntimeExecutors', () => {
 
       expect(result.newState.messages.at(-1)).toEqual(
         expect.objectContaining({
+          id: 'msg-123',
           reasoning: { content: 'Need to inspect the search results first.' },
           role: 'assistant',
           tool_calls: [expect.objectContaining({ id: 'call_1' })],
         }),
       );
+    });
+
+    it('should push assistant message with persisted DB id so request_human_approve can find parent', async () => {
+      const toolCallPayload = [
+        {
+          function: { arguments: '{}', name: 'search' },
+          id: 'call_sensitive',
+          type: 'function',
+        },
+      ];
+
+      const mockChat = vi.fn().mockImplementation(async (_payload, options) => {
+        await options?.callback?.onToolsCalling?.({ toolsCalling: toolCallPayload });
+        await options?.callback?.onCompletion?.({
+          usage: { totalInputTokens: 1, totalOutputTokens: 2, totalTokens: 3 },
+        });
+        return new Response('done');
+      });
+      vi.mocked(initModelRuntimeFromDB).mockResolvedValueOnce({ chat: mockChat } as any);
+
+      mockMessageModel.create.mockResolvedValueOnce({ id: 'persisted-assistant-id' });
+
+      const executors = createRuntimeExecutors(ctx);
+      const state = createMockState();
+
+      const result = await executors.call_llm!(
+        {
+          payload: {
+            messages: [{ content: 'Hello', role: 'user' }],
+            model: 'gpt-4',
+            provider: 'openai',
+            tools: [],
+          },
+          type: 'call_llm' as const,
+        },
+        state,
+      );
+
+      const lastAssistant = result.newState.messages.at(-1);
+      expect(lastAssistant).toMatchObject({
+        id: 'persisted-assistant-id',
+        role: 'assistant',
+      });
+      // The id must match the same message that nextContext exposes as
+      // parentMessageId, so request_human_approve sees a single source of truth.
+      expect((result.nextContext?.payload as any).parentMessageId).toBe('persisted-assistant-id');
     });
 
     it('should execute compress_context and return compression_result', async () => {


### PR DESCRIPTION
## Summary

Fixes the server-side human approval flow crashing with:

```
[request_human_approve] No assistant message found as parent for pending tool messages
```

whenever human-approve policy fires on the *fresh* LLM turn (i.e. the tool call that triggered approval came from the LLM call immediately preceding).

## Root cause

`call_llm` persists the assistant message early and gets its DB id at `assistantMessageItem.id`, but when it pushes the finished assistant turn into `state.messages` it **drops the id**:

```ts
// Before
newState.messages.push({
  content,
  reasoning: finalReasoning,
  role: 'assistant',
  tool_calls: ...,
});
```

Downstream, `request_human_approve` looks for the parent:

```ts
(state.messages ?? []).slice().reverse()
  .find((m) => m.role === 'assistant' && m.id)?.id   // filter on m.id — never matches
```

and then falls back to a DB query by `agentId/threadId/topicId`. The DB fallback is not reliably finding the just-written row in every topology (e.g. group-agent operations), and both paths miss → throw.

Since `call_llm` already exposes the same id via `nextContext.payload.parentMessageId`, the fix is just to keep the two sources in sync.

## Change

- `src/server/modules/AgentRuntime/RuntimeExecutors.ts`: include `id: assistantMessageItem.id` on the pushed assistant message in `call_llm`.
- `src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts`:
  - extend the existing "preserve reasoning when assistant returns tool calls" test to assert the id is pushed
  - add a dedicated test that `state.messages` last assistant id equals `nextContext.parentMessageId` (single source of truth contract)

## Test plan

- [x] `bunx vitest run src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts` — 86 passed
- [x] `bun run type-check` clean
- [ ] Reproduce the original trace scenario: tool call on lobe-group-agent-builder (or any tool that requires human approval) from a fresh LLM turn, verify the op no longer errors at the `request_human_approve` step

## Observed trace

Tracing op `op_1776232832930_agt_Caun1Y70jpzB_tpc_FsEiRboaWrK9_WxA1HuMq` erroring 143ms into step 1 with the "No assistant message found as parent" message — after this fix the in-memory lookup hits immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)