### PR TITLE
💄 style(chat): tighten execServerAgentRuntime loading copy

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -234,7 +234,7 @@
   "operation.contextCompression": "Context too long, compressing history...",
   "operation.execAgentRuntime": "Preparing response",
   "operation.execClientTask": "Executing task",
-  "operation.execServerAgentRuntime": "Running… You can switch tasks or close the page — the task will keep going.",
+  "operation.execServerAgentRuntime": "Task is running in the server. You are safe to leave this page",
   "operation.sendMessage": "Sending message",
   "owner": "Group owner",
   "pageCopilot.title": "Page Agent",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -234,7 +234,7 @@
   "operation.contextCompression": "上下文过长，正在压缩历史记录……",
   "operation.execAgentRuntime": "准备响应中",
   "operation.execClientTask": "执行任务中",
-  "operation.execServerAgentRuntime": "运行中… 您可以切换任务或关闭页面——任务将继续执行。",
+  "operation.execServerAgentRuntime": "任务正在服务器运行，您可以放心离开此页面",
   "operation.sendMessage": "消息发送中",
   "owner": "群主",
   "pageCopilot.title": "文稿助理",

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -254,7 +254,7 @@ export default {
   'operation.execAgentRuntime': 'Preparing response',
   'operation.execClientTask': 'Executing task',
   'operation.execServerAgentRuntime':
-    'Running… You can switch tasks or close the page — the task will keep going.',
+    'Task is running in the server. You are safe to leave this page',
   'operation.sendMessage': 'Sending message',
   'owner': 'Group owner',
   'pageCopilot.title': 'Page Agent',


### PR DESCRIPTION
## Summary

- Current \`operation.execServerAgentRuntime\` copy crammed status + two affordances into one line and read as an explanation rather than a loading status.
- Replaces it with a shorter status-first line that tells users where the work is happening and the single reassurance they actually need.
  - EN: \`Task is running in the server. You are safe to leave this page.\`
  - zh-CN: \`任务正在服务器运行，您可以放心离开此页面。\`
- Only en-US and zh-CN are edited in this PR — CI translates the remaining locales from the default source (\`src/locales/default/chat.ts\`).

## Test plan

- [x] Visually diff the loading indicator in Gateway mode — new copy should render in place of the old one for the running \`execServerAgentRuntime\` op.
- [ ] Let translate CI re-generate the other locale files after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)