### PR TITLE
🐛 fix: drop manifests missing `api` before feeding ToolsEngine

### DIFF
--- a/src/helpers/toolEngineering/index.ts
+++ b/src/helpers/toolEngineering/index.ts
@@ -39,6 +39,43 @@ export interface ToolsEngineConfig {
 }
 
 /**
+ * A manifest is usable by ToolsEngine only if it has a non-empty `api` array.
+ * ToolsEngine.convertManifestsToTools calls `manifest.api.map(...)` unconditionally,
+ * so any entry with `api` missing / non-array will crash the whole tools build.
+ * Sources that populate manifests (installed plugins, Klavis, LobeHub skills, MCP)
+ * have no shared schema validation, so we guard defensively at the merge point.
+ */
+const isValidToolManifest = (m: ToolManifest | undefined): m is ToolManifest =>
+  !!m && typeof m === 'object' && Array.isArray((m as ToolManifest).api);
+
+const dropInvalidManifests = (manifests: (ToolManifest | undefined)[], source: string) => {
+  const valid: ToolManifest[] = [];
+  const dropped: Array<{ identifier?: string; reason: string }> = [];
+
+  for (const m of manifests) {
+    if (isValidToolManifest(m)) {
+      valid.push(m);
+    } else if (m) {
+      dropped.push({
+        identifier: (m as { identifier?: string }).identifier,
+        reason: Array.isArray((m as { api?: unknown }).api)
+          ? 'unknown'
+          : 'missing `api` field (expected array)',
+      });
+    }
+  }
+
+  if (dropped.length > 0) {
+    console.warn(
+      `[toolEngineering] Dropped ${dropped.length} invalid manifest(s) from ${source}:`,
+      dropped,
+    );
+  }
+
+  return valid;
+};
+
+/**
  * Initialize ToolsEngine with current manifest schemas and configurable options
  */
 export const createToolsEngine = (config: ToolsEngineConfig = {}): ToolsEngine => {
@@ -62,13 +99,14 @@ export const createToolsEngine = (config: ToolsEngineConfig = {}): ToolsEngine =
     .map((tool) => tool.manifest as ToolManifest)
     .filter(Boolean);
 
-  // Combine all manifests
+  // Combine all manifests, dropping entries that would crash ToolsEngine.
+  // Each source is filtered separately so the warning pinpoints the origin.
   const allManifests = [
-    ...pluginManifests,
-    ...builtinManifests,
-    ...klavisManifests,
-    ...lobehubSkillManifests,
-    ...additionalManifests,
+    ...dropInvalidManifests(pluginManifests, 'installedPlugins'),
+    ...dropInvalidManifests(builtinManifests, 'builtinTools'),
+    ...dropInvalidManifests(klavisManifests, 'klavis'),
+    ...dropInvalidManifests(lobehubSkillManifests, 'lobehubSkills'),
+    ...dropInvalidManifests(additionalManifests, 'additionalManifests'),
   ];
 
   return new ToolsEngine({


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A (crash report from desktop renderer)

#### 🔀 Description of Change

Users see this crash on the chat page:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'map')
    at ToolsEngine.convertManifestsToTools (index-...js)
    at ToolsEngine.generateToolsDetailed
    at TokenTag-...js
\`\`\`

**Root cause**

\`ToolsEngine.convertManifestsToTools\` (\`packages/context-engine/src/engine/tools/ToolsEngine.ts:265-266\`) does:

\`\`\`ts
const tools = manifests.flatMap((manifest) => manifest.api.map((api) => ({ ... })));
\`\`\`

\`manifest\` itself is defined (otherwise it would fail on \`.api\` rather than \`.map\`), but \`manifest.api\` is \`undefined\` for at least one entry — so \`undefined.map(...)\` throws. One bad manifest takes down the whole tools build, and everything that calls \`generateTools*\` (TokenTag, streaming executor, agent runtime) breaks with it.

**Why it gets through**

\`createToolsEngine\` merges manifests from five sources. Only some filter falsy entries, and none validate \`api\`:

| Source | Existing guard |
|---|---|
| \`installedPluginManifestList\` | \`.filter(!!i)\` — catches falsy only |
| \`builtinTools.map(...)\` | **none** |
| \`klavisManifests\` | \`.filter(Boolean)\` — catches falsy only |
| \`lobehubSkillManifests\` | \`.filter(Boolean)\` — catches falsy only |
| \`additionalManifests\` | none |

A truthy-but-malformed manifest (missing \`api\`, or \`api\` not an array) slips through any of them.

**Fix**

Guard defensively at the merge point with \`isValidToolManifest\` / \`dropInvalidManifests\`. Each source is filtered separately and a \`console.warn\` logs the source + identifier of every dropped entry, so we can trace the bad data back to where it was populated.

#### 🧪 How to Test

- [x] Tested locally (\`bun run type-check\` + existing \`src/helpers/toolEngineering/index.test.ts\` — 14/14 passing)
- [ ] Added/updated tests
- [x] No new tests needed immediately — change is additive; existing tests still cover the happy path. Follow-up can add an invalid-manifest regression test.

#### 📝 Additional Information

This is a **stop the bleed** fix. Once the warning surfaces the bad source in real user sessions / CI, the proper follow-up is to fix whichever populator is writing a manifest without \`api\` (probable suspects: marketplace / custom plugin manifest fetcher returning partial JSON; Klavis or LobeHub-Skill tool sync on schema drift). The warning payload includes \`identifier\` when available to make that tractable.