### PR TITLE
♻️ refactor(builtin-tool-task): polish task tool paths

### DIFF
--- a/apps/cli/src/commands/task/index.ts
+++ b/apps/cli/src/commands/task/index.ts
@@ -56,7 +56,7 @@ export function registerTaskCommand(program: Command) {
         const client = await getTrpcClient();
 
         const input: Record<string, any> = {};
-        if (options.status) input.status = options.status;
+        if (options.status) input.statuses = [options.status];
         if (options.root) input.parentTaskId = null;
         if (options.parent) input.parentTaskId = options.parent;
         if (options.agent) input.assigneeAgentId = options.agent;

--- a/locales/en-US/topic.json
+++ b/locales/en-US/topic.json
@@ -36,6 +36,7 @@
   "loadMore": "Load More",
   "searchPlaceholder": "Search Topics...",
   "searchResultEmpty": "No search results found.",
+  "taskManager.welcome": "Ask me about your tasks",
   "temp": "Temporary",
   "title": "Topic"
 }

--- a/locales/zh-CN/topic.json
+++ b/locales/zh-CN/topic.json
@@ -36,6 +36,7 @@
   "loadMore": "更多",
   "searchPlaceholder": "搜索话题…",
   "searchResultEmpty": "暂无搜索结果",
+  "taskManager.welcome": "问我关于你的任务",
   "temp": "临时",
   "title": "话题"
 }

--- a/packages/builtin-tool-task/package.json
+++ b/packages/builtin-tool-task/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./executor": "./src/executor/index.ts"
   },
   "main": "./src/index.ts",
   "devDependencies": {

--- a/packages/builtin-tool-task/package.json
+++ b/packages/builtin-tool-task/package.json
@@ -7,6 +7,9 @@
     "./executor": "./src/executor/index.ts"
   },
   "main": "./src/index.ts",
+  "dependencies": {
+    "@lobechat/prompts": "workspace:*"
+  },
   "devDependencies": {
     "@lobechat/types": "workspace:*"
   }

--- a/packages/builtin-tool-task/src/constants.ts
+++ b/packages/builtin-tool-task/src/constants.ts
@@ -1,0 +1,1 @@
+export const UNFINISHED_TASK_STATUSES = ['backlog', 'running', 'paused'] as const;

--- a/packages/builtin-tool-task/src/constants.ts
+++ b/packages/builtin-tool-task/src/constants.ts
@@ -1,1 +1,10 @@
+export const TASK_STATUSES = [
+  'backlog',
+  'running',
+  'paused',
+  'completed',
+  'failed',
+  'canceled',
+] as const;
+
 export const UNFINISHED_TASK_STATUSES = ['backlog', 'running', 'paused'] as const;

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -1,0 +1,402 @@
+import {
+  formatTaskCreated,
+  formatTaskDetail,
+  formatTaskEdited,
+  formatTaskList,
+  priorityLabel,
+} from '@lobechat/prompts';
+import type { BuiltinToolContext, BuiltinToolResult } from '@lobechat/types';
+import { BaseExecutor } from '@lobechat/types';
+import debug from 'debug';
+
+import { mutate } from '@/libs/swr';
+import { taskService } from '@/services/task';
+import { getTaskStoreState } from '@/store/task';
+
+import { TaskIdentifier } from '../manifest';
+import { TaskApiName } from '../types';
+
+const FETCH_TASK_DETAIL_KEY = 'fetchTaskDetail';
+const FETCH_TASK_LIST_KEY = 'fetchTaskList';
+const FETCH_TASK_GROUP_LIST_KEY = 'fetchTaskGroupList';
+
+const log = debug('lobe-task:executor');
+
+/**
+ * Resolve the current task identifier from store state.
+ * Used as fallback when LLM omits the identifier parameter.
+ */
+const getCurrentTaskId = (): string | undefined => {
+  try {
+    return getTaskStoreState().activeTaskId;
+  } catch {
+    return undefined;
+  }
+};
+
+const refreshTaskUI = async (taskId?: string, agentId?: string) => {
+  const promises: Promise<any>[] = [];
+  if (taskId) promises.push(mutate([FETCH_TASK_DETAIL_KEY, taskId]));
+  promises.push(mutate([FETCH_TASK_LIST_KEY, agentId]));
+  promises.push(mutate([FETCH_TASK_GROUP_LIST_KEY, agentId]));
+  await Promise.all(promises);
+};
+
+class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
+  readonly identifier = TaskIdentifier;
+  protected readonly apiEnum = TaskApiName;
+
+  createTask = async (
+    params: {
+      instruction: string;
+      name: string;
+      parentIdentifier?: string;
+      priority?: number;
+      review?: {
+        autoRetry?: boolean;
+        criteria?: Array<{ name: string; threshold: number }>;
+        enabled?: boolean;
+        maxIterations?: number;
+      };
+      sortOrder?: number;
+    },
+    ctx?: BuiltinToolContext,
+  ): Promise<BuiltinToolResult> => {
+    try {
+      log('[TaskExecutor] createTask - params:', params);
+
+      // Resolve parentTaskId: explicit > current task
+      let parentTaskId: string | undefined;
+      let parentLabel: string | undefined;
+
+      if (params.parentIdentifier) {
+        const parent = await taskService.find(params.parentIdentifier);
+        if (!parent.data) {
+          return {
+            content: `Parent task not found: ${params.parentIdentifier}`,
+            error: {
+              message: `Parent task not found: ${params.parentIdentifier}`,
+              type: 'TaskNotFound',
+            },
+            success: false,
+          };
+        }
+        parentTaskId = parent.data.id;
+        parentLabel = parent.data.identifier;
+      } else {
+        const currentId = getCurrentTaskId();
+        if (currentId) {
+          parentTaskId = currentId;
+          parentLabel = 'current task';
+        }
+      }
+
+      const result = await taskService.create({
+        assigneeAgentId: ctx?.agentId,
+        instruction: params.instruction,
+        name: params.name,
+        parentTaskId,
+        priority: params.priority,
+      });
+
+      const task = result.data;
+      if (!task) {
+        return {
+          content: 'Failed to create task',
+          error: { message: 'No data returned', type: 'CreateFailed' },
+          success: false,
+        };
+      }
+
+      // Post-create: write review config if provided
+      if (params.review) {
+        await taskService.updateConfig(task.id, { review: { enabled: true, ...params.review } });
+      }
+
+      await refreshTaskUI(undefined, ctx?.agentId);
+
+      return {
+        content: formatTaskCreated({
+          identifier: task.identifier,
+          instruction: params.instruction,
+          name: task.name,
+          parentLabel,
+          priority: task.priority,
+          status: task.status,
+        }),
+        state: { identifier: task.identifier, success: true },
+        success: true,
+      };
+    } catch (error) {
+      log('[TaskExecutor] createTask - error:', error);
+      const message = error instanceof Error ? error.message : 'Failed to create task';
+      return {
+        content: `Failed to create task: ${message}`,
+        error: { message, type: 'CreateTaskFailed' },
+        success: false,
+      };
+    }
+  };
+
+  deleteTask = async (
+    params: { identifier: string },
+    ctx?: BuiltinToolContext,
+  ): Promise<BuiltinToolResult> => {
+    try {
+      log('[TaskExecutor] deleteTask - params:', params);
+
+      const found = await taskService.find(params.identifier);
+      if (!found.data) {
+        return {
+          content: `Task not found: ${params.identifier}`,
+          error: { message: `Task not found: ${params.identifier}`, type: 'TaskNotFound' },
+          success: false,
+        };
+      }
+
+      await taskService.delete(found.data.id);
+      await refreshTaskUI(undefined, ctx?.agentId);
+
+      return {
+        content: `Task ${found.data.identifier} "${found.data.name || ''}" has been deleted.`,
+        state: { success: true },
+        success: true,
+      };
+    } catch (error) {
+      log('[TaskExecutor] deleteTask - error:', error);
+      const message = error instanceof Error ? error.message : 'Failed to delete task';
+      return {
+        content: `Failed to delete task: ${message}`,
+        error: { message, type: 'DeleteTaskFailed' },
+        success: false,
+      };
+    }
+  };
+
+  editTask = async (
+    params: {
+      addDependency?: string;
+      identifier: string;
+      instruction?: string;
+      name?: string;
+      priority?: number;
+      removeDependency?: string;
+      review?: {
+        autoRetry?: boolean;
+        criteria?: Array<{ name: string; threshold: number }>;
+        enabled?: boolean;
+        maxIterations?: number;
+      };
+    },
+    ctx?: BuiltinToolContext,
+  ): Promise<BuiltinToolResult> => {
+    try {
+      log('[TaskExecutor] editTask - params:', params);
+
+      const found = await taskService.find(params.identifier);
+      if (!found.data) {
+        return {
+          content: `Task not found: ${params.identifier}`,
+          error: { message: `Task not found: ${params.identifier}`, type: 'TaskNotFound' },
+          success: false,
+        };
+      }
+
+      const task = found.data;
+      const changes: string[] = [];
+      const updateData: Record<string, unknown> = {};
+
+      if (params.name !== undefined) {
+        updateData.name = params.name;
+        changes.push(`name → "${params.name}"`);
+      }
+      if (params.instruction !== undefined) {
+        updateData.instruction = params.instruction;
+        changes.push('instruction updated');
+      }
+      if (params.priority !== undefined) {
+        updateData.priority = params.priority;
+        changes.push(`priority → ${priorityLabel(params.priority)}`);
+      }
+
+      if (Object.keys(updateData).length > 0) {
+        await taskService.update(task.id, updateData);
+      }
+
+      if (params.review) {
+        await taskService.updateConfig(task.id, { review: { enabled: true, ...params.review } });
+        changes.push('review config updated');
+      }
+
+      // TRPC addDependency/removeDependency resolve both params
+      if (params.addDependency) {
+        await taskService.addDependency(task.identifier, params.addDependency);
+        changes.push(`dependency added: blocks on ${params.addDependency}`);
+      }
+      if (params.removeDependency) {
+        await taskService.removeDependency(task.identifier, params.removeDependency);
+        changes.push(`dependency removed: ${params.removeDependency}`);
+      }
+
+      await refreshTaskUI(task.id, ctx?.agentId);
+
+      return {
+        content: formatTaskEdited(task.identifier, changes),
+        state: { identifier: task.identifier, success: true },
+        success: true,
+      };
+    } catch (error) {
+      log('[TaskExecutor] editTask - error:', error);
+      const message = error instanceof Error ? error.message : 'Failed to edit task';
+      return {
+        content: `Failed to edit task: ${message}`,
+        error: { message, type: 'EditTaskFailed' },
+        success: false,
+      };
+    }
+  };
+
+  listTasks = async (
+    params: { parentIdentifier?: string; status?: string },
+    ctx?: BuiltinToolContext,
+  ): Promise<BuiltinToolResult> => {
+    try {
+      log('[TaskExecutor] listTasks - params:', params);
+
+      // TRPC list does NOT resolve parentTaskId, must resolve manually
+      let parentId: string | undefined;
+      let parentLabel = 'current task';
+
+      if (params.parentIdentifier) {
+        const parent = await taskService.find(params.parentIdentifier);
+        if (!parent.data) {
+          return {
+            content: `Parent task not found: ${params.parentIdentifier}`,
+            error: {
+              message: `Parent task not found: ${params.parentIdentifier}`,
+              type: 'TaskNotFound',
+            },
+            success: false,
+          };
+        }
+        parentId = parent.data.id;
+        parentLabel = parent.data.identifier;
+      } else {
+        parentId = getCurrentTaskId();
+      }
+
+      if (!parentId) {
+        return {
+          content: 'No task context available. Provide a parentIdentifier.',
+          error: { message: 'No task context', type: 'NoTaskContext' },
+          success: false,
+        };
+      }
+
+      const result = await taskService.list({
+        parentTaskId: parentId,
+        status: params.status,
+      });
+
+      const tasks = result.data || [];
+
+      return {
+        content: formatTaskList(tasks as any[], parentLabel, params.status),
+        state: { count: tasks.length, success: true },
+        success: true,
+      };
+    } catch (error) {
+      log('[TaskExecutor] listTasks - error:', error);
+      const message = error instanceof Error ? error.message : 'Failed to list tasks';
+      return {
+        content: `Failed to list tasks: ${message}`,
+        error: { message, type: 'ListTasksFailed' },
+        success: false,
+      };
+    }
+  };
+
+  updateTaskStatus = async (
+    params: { identifier?: string; status: string },
+    ctx?: BuiltinToolContext,
+  ): Promise<BuiltinToolResult> => {
+    try {
+      log('[TaskExecutor] updateTaskStatus - params:', params);
+
+      const id = params.identifier || getCurrentTaskId();
+      if (!id) {
+        return {
+          content: 'No task identifier provided and no current task context.',
+          error: { message: 'No task identifier', type: 'NoTaskContext' },
+          success: false,
+        };
+      }
+
+      await taskService.updateStatus(
+        id,
+        params.status as 'backlog' | 'canceled' | 'completed' | 'failed' | 'paused' | 'running',
+      );
+
+      await refreshTaskUI(id, ctx?.agentId);
+
+      return {
+        content: `Task ${id} status updated to ${params.status}.`,
+        state: { status: params.status, success: true },
+        success: true,
+      };
+    } catch (error) {
+      log('[TaskExecutor] updateTaskStatus - error:', error);
+      const message = error instanceof Error ? error.message : 'Failed to update task status';
+      return {
+        content: `Failed to update task status: ${message}`,
+        error: { message, type: 'UpdateStatusFailed' },
+        success: false,
+      };
+    }
+  };
+
+  viewTask = async (
+    params: { identifier?: string },
+    _ctx?: BuiltinToolContext,
+  ): Promise<BuiltinToolResult> => {
+    try {
+      log('[TaskExecutor] viewTask - params:', params);
+
+      const id = params.identifier || getCurrentTaskId();
+      if (!id) {
+        return {
+          content: 'No task identifier provided and no current task context.',
+          error: { message: 'No task identifier', type: 'NoTaskContext' },
+          success: false,
+        };
+      }
+
+      const result = await taskService.getDetail(id);
+      const detail = result.data;
+
+      if (!detail) {
+        return {
+          content: `Task not found: ${id}`,
+          error: { message: `Task not found: ${id}`, type: 'TaskNotFound' },
+          success: false,
+        };
+      }
+
+      return {
+        content: formatTaskDetail(detail),
+        state: { identifier: detail.identifier, success: true },
+        success: true,
+      };
+    } catch (error) {
+      log('[TaskExecutor] viewTask - error:', error);
+      const message = error instanceof Error ? error.message : 'Failed to view task';
+      return {
+        content: `Failed to view task: ${message}`,
+        error: { message, type: 'ViewTaskFailed' },
+        success: false,
+      };
+    }
+  };
+}
+
+export const taskExecutor = new TaskExecutor();

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -13,6 +13,7 @@ import { mutate } from '@/libs/swr';
 import { taskService } from '@/services/task';
 import { getTaskStoreState } from '@/store/task';
 
+import { UNFINISHED_TASK_STATUSES } from '../constants';
 import { TaskIdentifier } from '../manifest';
 import { TaskApiName } from '../types';
 
@@ -257,16 +258,20 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
   };
 
   listTasks = async (
-    params: { parentIdentifier?: string; status?: string },
+    params: {
+      assigneeAgentId?: string;
+      limit?: number;
+      offset?: number;
+      parentIdentifier?: string;
+      priorities?: number[];
+      statuses?: string[];
+    },
     ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
     try {
       log('[TaskExecutor] listTasks - params:', params);
 
-      // TRPC list does NOT resolve parentTaskId, must resolve manually
-      let parentId: string | undefined;
-      let parentLabel = 'current task';
-
+      let parentTaskId: string | null | undefined;
       if (params.parentIdentifier) {
         const parent = await taskService.find(params.parentIdentifier);
         if (!parent.data) {
@@ -279,30 +284,41 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
             success: false,
           };
         }
-        parentId = parent.data.id;
-        parentLabel = parent.data.identifier;
-      } else {
-        parentId = getCurrentTaskId();
+        parentTaskId = parent.data.id;
       }
 
-      if (!parentId) {
-        return {
-          content: 'No task context available. Provide a parentIdentifier.',
-          error: { message: 'No task context', type: 'NoTaskContext' },
-          success: false,
-        };
-      }
+      const noFilters =
+        !params.parentIdentifier &&
+        !params.statuses?.length &&
+        !params.priorities?.length &&
+        !params.assigneeAgentId;
+
+      const limit = Math.min(params.limit ?? 20, 100);
+
+      const resolvedStatuses =
+        params.statuses ?? (noFilters ? [...UNFINISHED_TASK_STATUSES] : undefined);
+      const resolvedAgentId = params.assigneeAgentId ?? (noFilters ? ctx?.agentId : undefined);
+      const resolvedParentTaskId = parentTaskId ?? (noFilters ? null : undefined);
 
       const result = await taskService.list({
-        parentTaskId: parentId,
-        status: params.status,
+        assigneeAgentId: resolvedAgentId,
+        limit,
+        offset: params.offset ?? 0,
+        parentTaskId: resolvedParentTaskId,
+        priorities: params.priorities,
+        statuses: resolvedStatuses,
       });
 
-      const tasks = result.data || [];
+      const tasks = result.data ?? [];
 
       return {
-        content: formatTaskList(tasks as any[], parentLabel, params.status),
-        state: { count: tasks.length, success: true },
+        content: formatTaskList(tasks, {
+          assigneeAgentId: params.assigneeAgentId,
+          parentIdentifier: params.parentIdentifier,
+          priorities: params.priorities,
+          statuses: params.statuses,
+        }),
+        state: { count: tasks.length, success: true, total: result.total },
         success: true,
       };
     } catch (error) {

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -1,4 +1,6 @@
 import {
+  formatDependencyAdded,
+  formatDependencyRemoved,
   formatTaskCreated,
   formatTaskDeleted,
   formatTaskDetail,
@@ -138,12 +140,13 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
 
   editTask = async (
     params: {
-      addDependency?: string;
+      addDependencies?: string[];
+      description?: string;
       identifier: string;
       instruction?: string;
       name?: string;
       priority?: number;
-      removeDependency?: string;
+      removeDependencies?: string[];
       review?: {
         autoRetry?: boolean;
         criteria?: Array<{ name: string; threshold: number }>;
@@ -151,24 +154,22 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
         maxIterations?: number;
       };
     },
-    ctx?: BuiltinToolContext,
+    _ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
     try {
       log('[TaskExecutor] editTask - params:', params);
 
-      const found = await taskService.find(params.identifier);
-      if (!found.data) {
-        return {
-          content: `Task not found: ${params.identifier}`,
-          error: { message: `Task not found: ${params.identifier}`, type: 'TaskNotFound' },
-          success: false,
-        };
-      }
-
-      const task = found.data;
+      const { identifier, review, addDependencies, removeDependencies } = params;
+      const store = getTaskStoreState();
       const changes: string[] = [];
-      const updateData: Record<string, unknown> = {};
+      const ops: Promise<unknown>[] = [];
 
+      const updateData: {
+        description?: string;
+        instruction?: string;
+        name?: string;
+        priority?: number;
+      } = {};
       if (params.name !== undefined) {
         updateData.name = params.name;
         changes.push(`name → "${params.name}"`);
@@ -177,35 +178,43 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
         updateData.instruction = params.instruction;
         changes.push('instruction updated');
       }
+      if (params.description !== undefined) {
+        updateData.description = params.description;
+        changes.push('description updated');
+      }
       if (params.priority !== undefined) {
         updateData.priority = params.priority;
         changes.push(`priority → ${priorityLabel(params.priority)}`);
       }
 
       if (Object.keys(updateData).length > 0) {
-        await taskService.update(task.id, updateData);
+        ops.push(store.updateTask(identifier, updateData));
       }
 
-      if (params.review) {
-        await taskService.updateConfig(task.id, { review: { enabled: true, ...params.review } });
+      if (review) {
+        // TODO [LOBE-7199]: align criteria/rubrics schema and switch to typed store.updateReview
+        ops.push(taskService.updateConfig(identifier, { review: { enabled: true, ...review } }));
         changes.push('review config updated');
       }
 
-      // TRPC addDependency/removeDependency resolve both params
-      if (params.addDependency) {
-        await taskService.addDependency(task.identifier, params.addDependency);
-        changes.push(`dependency added: blocks on ${params.addDependency}`);
+      if (addDependencies?.length) {
+        addDependencies.forEach((dep) => {
+          ops.push(store.addDependency(identifier, dep));
+          changes.push(formatDependencyAdded(identifier, dep));
+        });
       }
-      if (params.removeDependency) {
-        await taskService.removeDependency(task.identifier, params.removeDependency);
-        changes.push(`dependency removed: ${params.removeDependency}`);
+      if (removeDependencies?.length) {
+        removeDependencies.forEach((dep) => {
+          ops.push(store.removeDependency(identifier, dep));
+          changes.push(formatDependencyRemoved(identifier, dep));
+        });
       }
 
-      await refreshTaskUI(task.id, ctx?.agentId);
+      await Promise.all(ops);
 
       return {
-        content: formatTaskEdited(task.identifier, changes),
-        state: { identifier: task.identifier, success: true },
+        content: formatTaskEdited(identifier, changes),
+        state: { identifier, success: true },
         success: true,
       };
     } catch (error) {

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -66,41 +66,14 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
     try {
       log('[TaskExecutor] createTask - params:', params);
 
-      // Resolve parentTaskId: explicit > current task
-      let parentTaskId: string | undefined;
-      let parentLabel: string | undefined;
-
-      if (params.parentIdentifier) {
-        const parent = await taskService.find(params.parentIdentifier);
-        if (!parent.data) {
-          return {
-            content: `Parent task not found: ${params.parentIdentifier}`,
-            error: {
-              message: `Parent task not found: ${params.parentIdentifier}`,
-              type: 'TaskNotFound',
-            },
-            success: false,
-          };
-        }
-        parentTaskId = parent.data.id;
-        parentLabel = parent.data.identifier;
-      } else {
-        const currentId = getCurrentTaskId();
-        if (currentId) {
-          parentTaskId = currentId;
-          parentLabel = 'current task';
-        }
-      }
-
-      const result = await taskService.create({
+      const task = await getTaskStoreState().createTask({
         assigneeAgentId: ctx?.agentId,
         instruction: params.instruction,
         name: params.name,
-        parentTaskId,
+        parentTaskId: params.parentIdentifier,
         priority: params.priority,
       });
 
-      const task = result.data;
       if (!task) {
         return {
           content: 'Failed to create task',
@@ -109,19 +82,16 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
         };
       }
 
-      // Post-create: write review config if provided
       if (params.review) {
         await taskService.updateConfig(task.id, { review: { enabled: true, ...params.review } });
       }
-
-      await refreshTaskUI(undefined, ctx?.agentId);
 
       return {
         content: formatTaskCreated({
           identifier: task.identifier,
           instruction: params.instruction,
           name: task.name,
-          parentLabel,
+          parentLabel: params.parentIdentifier,
           priority: task.priority,
           status: task.status,
         }),

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -8,7 +8,7 @@ import {
   formatTaskList,
   priorityLabel,
 } from '@lobechat/prompts';
-import type { BuiltinToolContext, BuiltinToolResult } from '@lobechat/types';
+import type { BuiltinToolContext, BuiltinToolResult, TaskStatus } from '@lobechat/types';
 import { BaseExecutor } from '@lobechat/types';
 import debug from 'debug';
 
@@ -16,7 +16,7 @@ import { mutate } from '@/libs/swr';
 import { taskService } from '@/services/task';
 import { getTaskStoreState } from '@/store/task';
 
-import { UNFINISHED_TASK_STATUSES } from '../constants';
+import { normalizeListTasksParams } from '../listTasks';
 import { TaskIdentifier } from '../manifest';
 import { TaskApiName } from '../types';
 
@@ -213,14 +213,14 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
       offset?: number;
       parentIdentifier?: string;
       priorities?: number[];
-      statuses?: string[];
+      statuses?: TaskStatus[];
     },
     ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
     try {
       log('[TaskExecutor] listTasks - params:', params);
 
-      let parentTaskId: string | null | undefined;
+      let parentTaskId: string | undefined;
       if (params.parentIdentifier) {
         const parent = await taskService.find(params.parentIdentifier);
         if (!parent.data) {
@@ -236,37 +236,17 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
         parentTaskId = parent.data.id;
       }
 
-      const noFilters =
-        !params.parentIdentifier &&
-        !params.statuses?.length &&
-        !params.priorities?.length &&
-        !params.assigneeAgentId;
-
-      const limit = Math.min(params.limit ?? 20, 100);
-
-      const resolvedStatuses =
-        params.statuses ?? (noFilters ? [...UNFINISHED_TASK_STATUSES] : undefined);
-      const resolvedAgentId = params.assigneeAgentId ?? (noFilters ? ctx?.agentId : undefined);
-      const resolvedParentTaskId = parentTaskId ?? (noFilters ? null : undefined);
-
-      const result = await taskService.list({
-        assigneeAgentId: resolvedAgentId,
-        limit,
-        offset: params.offset ?? 0,
-        parentTaskId: resolvedParentTaskId,
-        priorities: params.priorities,
-        statuses: resolvedStatuses,
+      const normalized = normalizeListTasksParams(params, {
+        currentAgentId: ctx?.agentId,
+        parentTaskId,
       });
+
+      const result = await getTaskStoreState().fetchTaskList(normalized.query);
 
       const tasks = result.data ?? [];
 
       return {
-        content: formatTaskList(tasks, {
-          assigneeAgentId: params.assigneeAgentId,
-          parentIdentifier: params.parentIdentifier,
-          priorities: params.priorities,
-          statuses: params.statuses,
-        }),
+        content: formatTaskList(tasks, normalized.displayFilters),
         state: { count: tasks.length, success: true, total: result.total },
         success: true,
       };

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -36,12 +36,13 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
   ): Promise<BuiltinToolResult> => {
     try {
       log('[TaskExecutor] createTask - params:', params);
+      const parentIdentifier = params.parentIdentifier?.trim() || undefined;
 
       const task = await getTaskStoreState().createTask({
         assigneeAgentId: ctx?.agentId,
         instruction: params.instruction,
         name: params.name,
-        parentTaskId: params.parentIdentifier,
+        parentTaskId: parentIdentifier,
         priority: params.priority,
       });
 
@@ -58,7 +59,7 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
           identifier: task.identifier,
           instruction: params.instruction,
           name: task.name,
-          parentLabel: params.parentIdentifier,
+          parentLabel: parentIdentifier,
           priority: task.priority,
           status: task.status,
         }),

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -56,12 +56,6 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
       name: string;
       parentIdentifier?: string;
       priority?: number;
-      review?: {
-        autoRetry?: boolean;
-        criteria?: Array<{ name: string; threshold: number }>;
-        enabled?: boolean;
-        maxIterations?: number;
-      };
       sortOrder?: number;
     },
     ctx?: BuiltinToolContext,
@@ -83,10 +77,6 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
           error: { message: 'No data returned', type: 'CreateFailed' },
           success: false,
         };
-      }
-
-      if (params.review) {
-        await taskService.updateConfig(task.id, { review: { enabled: true, ...params.review } });
       }
 
       return {
@@ -147,19 +137,13 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
       name?: string;
       priority?: number;
       removeDependencies?: string[];
-      review?: {
-        autoRetry?: boolean;
-        criteria?: Array<{ name: string; threshold: number }>;
-        enabled?: boolean;
-        maxIterations?: number;
-      };
     },
     _ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
     try {
       log('[TaskExecutor] editTask - params:', params);
 
-      const { identifier, review, addDependencies, removeDependencies } = params;
+      const { identifier, addDependencies, removeDependencies } = params;
       const store = getTaskStoreState();
       const changes: string[] = [];
       const ops: Promise<unknown>[] = [];
@@ -189,12 +173,6 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
 
       if (Object.keys(updateData).length > 0) {
         ops.push(store.updateTask(identifier, updateData));
-      }
-
-      if (review) {
-        // TODO [LOBE-7199]: align criteria/rubrics schema and switch to typed store.updateReview
-        ops.push(taskService.updateConfig(identifier, { review: { enabled: true, ...review } }));
-        changes.push('review config updated');
       }
 
       if (addDependencies?.length) {

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -1,5 +1,6 @@
 import {
   formatTaskCreated,
+  formatTaskDeleted,
   formatTaskDetail,
   formatTaskEdited,
   formatTaskList,
@@ -111,26 +112,17 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
 
   deleteTask = async (
     params: { identifier: string },
-    ctx?: BuiltinToolContext,
+    _ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
     try {
       log('[TaskExecutor] deleteTask - params:', params);
 
-      const found = await taskService.find(params.identifier);
-      if (!found.data) {
-        return {
-          content: `Task not found: ${params.identifier}`,
-          error: { message: `Task not found: ${params.identifier}`, type: 'TaskNotFound' },
-          success: false,
-        };
-      }
-
-      await taskService.delete(found.data.id);
-      await refreshTaskUI(undefined, ctx?.agentId);
+      const deleted = await getTaskStoreState().deleteTask(params.identifier);
+      const label = deleted?.identifier ?? params.identifier;
 
       return {
-        content: `Task ${found.data.identifier} "${found.data.name || ''}" has been deleted.`,
-        state: { success: true },
+        content: formatTaskDeleted(label, deleted?.name),
+        state: { identifier: label, success: true },
         success: true,
       };
     } catch (error) {

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -207,25 +207,8 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
     try {
       log('[TaskExecutor] listTasks - params:', params);
 
-      let parentTaskId: string | undefined;
-      if (params.parentIdentifier) {
-        const parent = await taskService.find(params.parentIdentifier);
-        if (!parent.data) {
-          return {
-            content: `Parent task not found: ${params.parentIdentifier}`,
-            error: {
-              message: `Parent task not found: ${params.parentIdentifier}`,
-              type: 'TaskNotFound',
-            },
-            success: false,
-          };
-        }
-        parentTaskId = parent.data.id;
-      }
-
       const normalized = normalizeListTasksParams(params, {
         currentAgentId: ctx?.agentId,
-        parentTaskId,
       });
 
       const result = await getTaskStoreState().fetchTaskList(normalized.query);

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -12,17 +12,12 @@ import type { BuiltinToolContext, BuiltinToolResult, TaskStatus } from '@lobecha
 import { BaseExecutor } from '@lobechat/types';
 import debug from 'debug';
 
-import { mutate } from '@/libs/swr';
 import { taskService } from '@/services/task';
 import { getTaskStoreState } from '@/store/task';
 
 import { normalizeListTasksParams } from '../listTasks';
 import { TaskIdentifier } from '../manifest';
 import { TaskApiName } from '../types';
-
-const FETCH_TASK_DETAIL_KEY = 'fetchTaskDetail';
-const FETCH_TASK_LIST_KEY = 'fetchTaskList';
-const FETCH_TASK_GROUP_LIST_KEY = 'fetchTaskGroupList';
 
 const log = debug('lobe-task:executor');
 
@@ -36,14 +31,6 @@ const getCurrentTaskId = (): string | undefined => {
   } catch {
     return undefined;
   }
-};
-
-const refreshTaskUI = async (taskId?: string, agentId?: string) => {
-  const promises: Promise<any>[] = [];
-  if (taskId) promises.push(mutate([FETCH_TASK_DETAIL_KEY, taskId]));
-  promises.push(mutate([FETCH_TASK_LIST_KEY, agentId]));
-  promises.push(mutate([FETCH_TASK_GROUP_LIST_KEY, agentId]));
-  await Promise.all(promises);
 };
 
 class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
@@ -262,30 +249,21 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
   };
 
   updateTaskStatus = async (
-    params: { identifier?: string; status: string },
-    ctx?: BuiltinToolContext,
+    params: { error?: string; identifier?: string; status: TaskStatus },
+    _ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
     try {
       log('[TaskExecutor] updateTaskStatus - params:', params);
 
-      const id = params.identifier || getCurrentTaskId();
-      if (!id) {
-        return {
-          content: 'No task identifier provided and no current task context.',
-          error: { message: 'No task identifier', type: 'NoTaskContext' },
-          success: false,
-        };
-      }
-
-      await taskService.updateStatus(
-        id,
-        params.status as 'backlog' | 'canceled' | 'completed' | 'failed' | 'paused' | 'running',
-      );
-
-      await refreshTaskUI(id, ctx?.agentId);
+      const id = await getTaskStoreState().updateTaskStatus(params.identifier, params.status, {
+        error: params.error,
+      });
 
       return {
-        content: `Task ${id} status updated to ${params.status}.`,
+        content:
+          params.status === 'failed' && params.error
+            ? `Task ${id} status updated to failed. Error: ${params.error}`
+            : `Task ${id} status updated to ${params.status}.`,
         state: { status: params.status, success: true },
         success: true,
       };

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -12,7 +12,6 @@ import type { BuiltinToolContext, BuiltinToolResult, TaskStatus } from '@lobecha
 import { BaseExecutor } from '@lobechat/types';
 import debug from 'debug';
 
-import { taskService } from '@/services/task';
 import { getTaskStoreState } from '@/store/task';
 
 import { normalizeListTasksParams } from '../listTasks';
@@ -20,18 +19,6 @@ import { TaskIdentifier } from '../manifest';
 import { TaskApiName } from '../types';
 
 const log = debug('lobe-task:executor');
-
-/**
- * Resolve the current task identifier from store state.
- * Used as fallback when LLM omits the identifier parameter.
- */
-const getCurrentTaskId = (): string | undefined => {
-  try {
-    return getTaskStoreState().activeTaskId;
-  } catch {
-    return undefined;
-  }
-};
 
 class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
   readonly identifier = TaskIdentifier;
@@ -268,25 +255,7 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
     try {
       log('[TaskExecutor] viewTask - params:', params);
 
-      const id = params.identifier || getCurrentTaskId();
-      if (!id) {
-        return {
-          content: 'No task identifier provided and no current task context.',
-          error: { message: 'No task identifier', type: 'NoTaskContext' },
-          success: false,
-        };
-      }
-
-      const result = await taskService.getDetail(id);
-      const detail = result.data;
-
-      if (!detail) {
-        return {
-          content: `Task not found: ${id}`,
-          error: { message: `Task not found: ${id}`, type: 'TaskNotFound' },
-          success: false,
-        };
-      }
+      const detail = await getTaskStoreState().fetchTaskDetail(params.identifier);
 
       return {
         content: formatTaskDetail(detail),

--- a/packages/builtin-tool-task/src/index.ts
+++ b/packages/builtin-tool-task/src/index.ts
@@ -1,2 +1,3 @@
+export { UNFINISHED_TASK_STATUSES } from './constants';
 export { TaskIdentifier, TaskManifest } from './manifest';
 export { TaskApiName } from './types';

--- a/packages/builtin-tool-task/src/index.ts
+++ b/packages/builtin-tool-task/src/index.ts
@@ -1,4 +1,8 @@
 export { TASK_STATUSES, UNFINISHED_TASK_STATUSES } from './constants';
-export { DEFAULT_LIST_TASK_LIMIT, normalizeListTasksParams } from './listTasks';
+export {
+  DEFAULT_LIST_TASK_LIMIT,
+  normalizeListTasksParams,
+  normalizeOptionalFilterValues,
+} from './listTasks';
 export { TaskIdentifier, TaskManifest } from './manifest';
 export { TaskApiName } from './types';

--- a/packages/builtin-tool-task/src/index.ts
+++ b/packages/builtin-tool-task/src/index.ts
@@ -1,3 +1,4 @@
-export { UNFINISHED_TASK_STATUSES } from './constants';
+export { TASK_STATUSES, UNFINISHED_TASK_STATUSES } from './constants';
+export { DEFAULT_LIST_TASK_LIMIT, normalizeListTasksParams } from './listTasks';
 export { TaskIdentifier, TaskManifest } from './manifest';
 export { TaskApiName } from './types';

--- a/packages/builtin-tool-task/src/listTasks.ts
+++ b/packages/builtin-tool-task/src/listTasks.ts
@@ -37,6 +37,9 @@ interface NormalizeListTasksOptions {
   currentAgentId?: string;
 }
 
+export const normalizeOptionalFilterValues = <T>(values?: T[]) =>
+  values?.length ? values : undefined;
+
 const hasExplicitFilter = (params: ListTasksParams): boolean =>
   Boolean(
     params.parentIdentifier ||
@@ -57,8 +60,11 @@ export const normalizeListTasksParams = (
 } => {
   const { currentAgentId } = options;
   const isDefaultScope = !hasExplicitFilter(params);
+  const priorities = normalizeOptionalFilterValues(params.priorities);
+  const statuses =
+    normalizeOptionalFilterValues(params.statuses) ??
+    (isDefaultScope ? [...UNFINISHED_TASK_STATUSES] : undefined);
 
-  const statuses = params.statuses ?? (isDefaultScope ? [...UNFINISHED_TASK_STATUSES] : undefined);
   const assigneeAgentId = params.assigneeAgentId ?? (isDefaultScope ? currentAgentId : undefined);
 
   return {
@@ -67,7 +73,7 @@ export const normalizeListTasksParams = (
       isDefaultScope,
       isForCurrentAgent: isDefaultScope && Boolean(currentAgentId),
       parentIdentifier: params.parentIdentifier,
-      priorities: params.priorities,
+      priorities,
       statuses,
     },
     query: {
@@ -76,7 +82,7 @@ export const normalizeListTasksParams = (
       offset: params.offset ?? 0,
       parentIdentifier: params.parentIdentifier,
       parentTaskId: isDefaultScope ? null : undefined,
-      priorities: params.priorities,
+      priorities,
       statuses,
     },
   };

--- a/packages/builtin-tool-task/src/listTasks.ts
+++ b/packages/builtin-tool-task/src/listTasks.ts
@@ -1,0 +1,83 @@
+import type { TaskStatus } from '@lobechat/types';
+
+import { UNFINISHED_TASK_STATUSES } from './constants';
+
+export const DEFAULT_LIST_TASK_LIMIT = 20;
+const MAX_LIST_TASK_LIMIT = 100;
+
+export interface ListTasksParams {
+  assigneeAgentId?: string;
+  limit?: number;
+  offset?: number;
+  parentIdentifier?: string;
+  priorities?: number[];
+  statuses?: TaskStatus[];
+}
+
+export interface TaskListQuery {
+  assigneeAgentId?: string;
+  limit: number;
+  offset: number;
+  parentTaskId?: string | null;
+  priorities?: number[];
+  statuses?: TaskStatus[];
+}
+
+export interface TaskListDisplayFilters {
+  assigneeAgentId?: string;
+  isDefaultScope: boolean;
+  isForCurrentAgent?: boolean;
+  parentIdentifier?: string;
+  priorities?: number[];
+  statuses?: TaskStatus[];
+}
+
+interface NormalizeListTasksOptions {
+  currentAgentId?: string;
+  parentTaskId?: string;
+}
+
+const hasExplicitFilter = (params: ListTasksParams): boolean =>
+  Boolean(
+    params.parentIdentifier ||
+    params.statuses?.length ||
+    params.priorities?.length ||
+    params.assigneeAgentId,
+  );
+
+/**
+ * Normalize tool-facing listTasks params into concrete query args and display filters.
+ */
+export const normalizeListTasksParams = (
+  params: ListTasksParams,
+  options: NormalizeListTasksOptions = {},
+): {
+  displayFilters: TaskListDisplayFilters;
+  query: TaskListQuery;
+} => {
+  const { currentAgentId, parentTaskId } = options;
+  const isDefaultScope = !hasExplicitFilter(params);
+
+  const statuses = params.statuses ?? (isDefaultScope ? [...UNFINISHED_TASK_STATUSES] : undefined);
+  const assigneeAgentId = params.assigneeAgentId ?? (isDefaultScope ? currentAgentId : undefined);
+  const resolvedParentTaskId = parentTaskId ?? (isDefaultScope ? null : undefined);
+
+  return {
+    displayFilters: {
+      assigneeAgentId,
+      isDefaultScope,
+      isForCurrentAgent: isDefaultScope && Boolean(currentAgentId),
+      parentIdentifier: params.parentIdentifier,
+      priorities: params.priorities,
+      statuses,
+    },
+    query: {
+      assigneeAgentId,
+      limit: Math.min(params.limit ?? DEFAULT_LIST_TASK_LIMIT, MAX_LIST_TASK_LIMIT),
+      offset: params.offset ?? 0,
+      parentTaskId: resolvedParentTaskId,
+      priorities: params.priorities,
+      statuses,
+    },
+  };
+};

--- a/packages/builtin-tool-task/src/listTasks.ts
+++ b/packages/builtin-tool-task/src/listTasks.ts
@@ -18,6 +18,7 @@ export interface TaskListQuery {
   assigneeAgentId?: string;
   limit: number;
   offset: number;
+  parentIdentifier?: string;
   parentTaskId?: string | null;
   priorities?: number[];
   statuses?: TaskStatus[];
@@ -34,7 +35,6 @@ export interface TaskListDisplayFilters {
 
 interface NormalizeListTasksOptions {
   currentAgentId?: string;
-  parentTaskId?: string;
 }
 
 const hasExplicitFilter = (params: ListTasksParams): boolean =>
@@ -55,12 +55,11 @@ export const normalizeListTasksParams = (
   displayFilters: TaskListDisplayFilters;
   query: TaskListQuery;
 } => {
-  const { currentAgentId, parentTaskId } = options;
+  const { currentAgentId } = options;
   const isDefaultScope = !hasExplicitFilter(params);
 
   const statuses = params.statuses ?? (isDefaultScope ? [...UNFINISHED_TASK_STATUSES] : undefined);
   const assigneeAgentId = params.assigneeAgentId ?? (isDefaultScope ? currentAgentId : undefined);
-  const resolvedParentTaskId = parentTaskId ?? (isDefaultScope ? null : undefined);
 
   return {
     displayFilters: {
@@ -75,7 +74,8 @@ export const normalizeListTasksParams = (
       assigneeAgentId,
       limit: Math.min(params.limit ?? DEFAULT_LIST_TASK_LIMIT, MAX_LIST_TASK_LIMIT),
       offset: params.offset ?? 0,
-      parentTaskId: resolvedParentTaskId,
+      parentIdentifier: params.parentIdentifier,
+      parentTaskId: isDefaultScope ? null : undefined,
       priorities: params.priorities,
       statuses,
     },

--- a/packages/builtin-tool-task/src/manifest.ts
+++ b/packages/builtin-tool-task/src/manifest.ts
@@ -1,5 +1,6 @@
 import type { BuiltinToolManifest } from '@lobechat/types';
 
+import { UNFINISHED_TASK_STATUSES } from './constants';
 import { systemPrompt } from './systemRole';
 import { TaskApiName } from './types';
 
@@ -71,19 +72,34 @@ export const TaskManifest: BuiltinToolManifest = {
     },
     {
       description:
-        'List tasks with optional filters. Without filters, lists subtasks of the current task.',
+        'List tasks. Without any filters, returns top-level unfinished tasks of the current agent. Use parentIdentifier to drill into subtasks, or explicit filters to override defaults.',
       name: TaskApiName.listTasks,
       parameters: {
         properties: {
-          parentIdentifier: {
+          assigneeAgentId: {
             description:
-              'List subtasks of a specific parent task. Defaults to the current task if omitted.',
+              'Restrict to tasks assigned to this agent. Defaults to the current agent when omitted.',
             type: 'string',
           },
-          status: {
-            description: 'Filter by status.',
-            enum: ['backlog', 'running', 'paused', 'completed', 'failed', 'canceled'],
+          limit: { description: 'Max 1-100. Default 20.', type: 'number' },
+          offset: { description: 'Pagination offset.', type: 'number' },
+          parentIdentifier: {
+            description:
+              'List subtasks of this parent (e.g. "TASK-1"). When provided, disables the top-level default.',
             type: 'string',
+          },
+          priorities: {
+            description: 'Filter by priority values. 0=none, 1=urgent, 2=high, 3=normal, 4=low.',
+            items: { enum: [0, 1, 2, 3, 4], type: 'number' },
+            type: 'array',
+          },
+          statuses: {
+            description: `Filter by statuses. Defaults to [${UNFINISHED_TASK_STATUSES.map((s) => `"${s}"`).join(',')}] (unfinished) when no filters provided.`,
+            items: {
+              enum: ['backlog', 'running', 'paused', 'completed', 'failed', 'canceled'],
+              type: 'string',
+            },
+            type: 'array',
           },
         },
         required: [],

--- a/packages/builtin-tool-task/src/manifest.ts
+++ b/packages/builtin-tool-task/src/manifest.ts
@@ -124,13 +124,19 @@ export const TaskManifest: BuiltinToolManifest = {
     },
     {
       description:
-        "Edit a task's name, instruction, priority, or dependencies. Use addDependency/removeDependency to manage execution order.",
+        "Edit a task's fields (name, description, instruction, priority), dependencies (batched), or review config. Status changes go through updateTaskStatus.",
       name: TaskApiName.editTask,
       parameters: {
         properties: {
-          addDependency: {
+          addDependencies: {
             description:
-              'Add a dependency — this task will block until the specified task completes. Provide the identifier (e.g. "TASK-2").',
+              'Identifiers of tasks this task should block on (e.g. ["TASK-2", "TASK-3"]).',
+            items: { type: 'string' },
+            type: 'array',
+          },
+          description: {
+            description:
+              'Human-readable description (displayed in UI). Separate from instruction, which guides the agent.',
             type: 'string',
           },
           identifier: {
@@ -149,9 +155,10 @@ export const TaskManifest: BuiltinToolManifest = {
             description: 'Updated priority level: 0=none, 1=urgent, 2=high, 3=normal, 4=low.',
             type: 'number',
           },
-          removeDependency: {
-            description: 'Remove a dependency. Provide the identifier of the dependency to remove.',
-            type: 'string',
+          removeDependencies: {
+            description: 'Identifiers of existing dependencies to remove.',
+            items: { type: 'string' },
+            type: 'array',
           },
           review: {
             description: 'Update review config.',

--- a/packages/builtin-tool-task/src/manifest.ts
+++ b/packages/builtin-tool-task/src/manifest.ts
@@ -140,18 +140,23 @@ export const TaskManifest: BuiltinToolManifest = {
     },
     {
       description:
-        "Update a task's status. Use to mark tasks as completed, canceled, or change lifecycle state. Defaults to the current task if no identifier provided.",
+        "Update a task's status. Use to mark tasks as completed, canceled, paused, resumed, or failed. If identifier is omitted, this only works when there is a current task context.",
       name: TaskApiName.updateTaskStatus,
       parameters: {
         properties: {
+          error: {
+            description: 'Failure reason to store on the task. Only valid when status is "failed".',
+            type: 'string',
+          },
           identifier: {
             description:
-              'The task identifier (e.g. "TASK-1"). Defaults to the current task if omitted.',
+              'The task identifier (e.g. "TASK-1"). If omitted, the current task is used only when a current task context exists.',
             type: 'string',
           },
           status: {
-            description: 'New status for the task.',
-            enum: ['backlog', 'running', 'paused', 'completed', 'failed', 'canceled'],
+            description:
+              'New status for the task. Use error only when setting the status to failed.',
+            enum: [...TASK_STATUSES],
             type: 'string',
           },
         },

--- a/packages/builtin-tool-task/src/manifest.ts
+++ b/packages/builtin-tool-task/src/manifest.ts
@@ -11,7 +11,7 @@ export const TaskManifest: BuiltinToolManifest = {
     // ==================== Task CRUD ====================
     {
       description:
-        'Create a new task. Optionally attach it as a subtask by specifying parentIdentifier. Review config is inherited from parent task by default.',
+        'Create a new task. Optionally attach it as a subtask by specifying parentIdentifier.',
       name: TaskApiName.createTask,
       parameters: {
         properties: {
@@ -36,34 +36,6 @@ export const TaskManifest: BuiltinToolManifest = {
             description:
               'Sort order within parent task. Lower values appear first. Use to control display order (e.g. chapter 1=0, chapter 2=1, etc.).',
             type: 'number',
-          },
-          review: {
-            description:
-              'Review config. If omitted, inherits from parent task. Set to configure LLM-as-Judge auto-review.',
-            properties: {
-              autoRetry: {
-                description: 'Auto-retry on failure. Default true.',
-                type: 'boolean',
-              },
-              criteria: {
-                description: 'Review criteria with name and threshold (0-100).',
-                items: {
-                  properties: {
-                    name: { description: 'Criterion name, e.g. "内容准确性"', type: 'string' },
-                    threshold: { description: 'Pass threshold (0-100)', type: 'number' },
-                  },
-                  required: ['name', 'threshold'],
-                  type: 'object',
-                },
-                type: 'array',
-              },
-              enabled: { description: 'Enable review. Default false.', type: 'boolean' },
-              maxIterations: {
-                description: 'Max review iterations. Default 3.',
-                type: 'number',
-              },
-            },
-            type: 'object',
           },
         },
         required: ['name', 'instruction'],
@@ -124,7 +96,7 @@ export const TaskManifest: BuiltinToolManifest = {
     },
     {
       description:
-        "Edit a task's fields (name, description, instruction, priority), dependencies (batched), or review config. Status changes go through updateTaskStatus.",
+        "Edit a task's fields (name, description, instruction, priority) or dependencies (batched). Status changes go through updateTaskStatus.",
       name: TaskApiName.editTask,
       parameters: {
         properties: {
@@ -159,26 +131,6 @@ export const TaskManifest: BuiltinToolManifest = {
             description: 'Identifiers of existing dependencies to remove.',
             items: { type: 'string' },
             type: 'array',
-          },
-          review: {
-            description: 'Update review config.',
-            properties: {
-              autoRetry: { type: 'boolean' },
-              criteria: {
-                items: {
-                  properties: {
-                    name: { type: 'string' },
-                    threshold: { type: 'number' },
-                  },
-                  required: ['name', 'threshold'],
-                  type: 'object',
-                },
-                type: 'array',
-              },
-              enabled: { type: 'boolean' },
-              maxIterations: { type: 'number' },
-            },
-            type: 'object',
           },
         },
         required: ['identifier'],
@@ -225,7 +177,7 @@ export const TaskManifest: BuiltinToolManifest = {
   identifier: TaskIdentifier,
   meta: {
     avatar: '\uD83D\uDCCB',
-    description: 'Create, list, edit, delete tasks with dependencies and review config',
+    description: 'Create, list, edit, delete tasks with dependencies',
     title: 'Task Tools',
   },
   systemRole: systemPrompt,

--- a/packages/builtin-tool-task/src/manifest.ts
+++ b/packages/builtin-tool-task/src/manifest.ts
@@ -1,6 +1,7 @@
 import type { BuiltinToolManifest } from '@lobechat/types';
 
-import { UNFINISHED_TASK_STATUSES } from './constants';
+import { TASK_STATUSES, UNFINISHED_TASK_STATUSES } from './constants';
+import { DEFAULT_LIST_TASK_LIMIT } from './listTasks';
 import { systemPrompt } from './systemRole';
 import { TaskApiName } from './types';
 
@@ -44,20 +45,20 @@ export const TaskManifest: BuiltinToolManifest = {
     },
     {
       description:
-        'List tasks. Without any filters, returns top-level unfinished tasks of the current agent. Use parentIdentifier to drill into subtasks, or explicit filters to override defaults.',
+        'List tasks. Without any filters, returns top-level unfinished tasks of the current agent. If you provide any filter, omitted filters are not applied implicitly.',
       name: TaskApiName.listTasks,
       parameters: {
         properties: {
           assigneeAgentId: {
             description:
-              'Restrict to tasks assigned to this agent. Defaults to the current agent when omitted.',
+              'Restrict to tasks assigned to this agent. When omitted, no assignee filter is applied unless listTasks is called without any filters, which defaults to the current agent.',
             type: 'string',
           },
-          limit: { description: 'Max 1-100. Default 20.', type: 'number' },
+          limit: { description: `Max 1-100. Default ${DEFAULT_LIST_TASK_LIMIT}.`, type: 'number' },
           offset: { description: 'Pagination offset.', type: 'number' },
           parentIdentifier: {
             description:
-              'List subtasks of this parent (e.g. "TASK-1"). When provided, disables the top-level default.',
+              'List subtasks of this parent (e.g. "TASK-1"). When omitted, no parent filter is applied unless listTasks is called without any filters, which defaults to top-level tasks.',
             type: 'string',
           },
           priorities: {
@@ -66,9 +67,9 @@ export const TaskManifest: BuiltinToolManifest = {
             type: 'array',
           },
           statuses: {
-            description: `Filter by statuses. Defaults to [${UNFINISHED_TASK_STATUSES.map((s) => `"${s}"`).join(',')}] (unfinished) when no filters provided.`,
+            description: `Filter by statuses. When omitted, no status filter is applied unless listTasks is called without any filters, which defaults to [${UNFINISHED_TASK_STATUSES.map((s) => `"${s}"`).join(', ')}].`,
             items: {
-              enum: ['backlog', 'running', 'paused', 'completed', 'failed', 'canceled'],
+              enum: [...TASK_STATUSES],
               type: 'string',
             },
             type: 'array',

--- a/packages/builtin-tool-task/src/manifest.ts
+++ b/packages/builtin-tool-task/src/manifest.ts
@@ -81,13 +81,13 @@ export const TaskManifest: BuiltinToolManifest = {
     },
     {
       description:
-        'View details of a specific task. If no identifier is provided, returns the current task.',
+        'View details of a specific task. If identifier is omitted, this only works when there is a current task context.',
       name: TaskApiName.viewTask,
       parameters: {
         properties: {
           identifier: {
             description:
-              'The task identifier to view (e.g. "TASK-1"). Defaults to the current task if omitted.',
+              'The task identifier to view (e.g. "TASK-1"). If omitted, the current task is used only when a current task context exists.',
             type: 'string',
           },
         },

--- a/packages/builtin-tool-task/src/manifest.ts
+++ b/packages/builtin-tool-task/src/manifest.ts
@@ -25,7 +25,7 @@ export const TaskManifest: BuiltinToolManifest = {
           },
           parentIdentifier: {
             description:
-              'Identifier of the parent task (e.g. "TASK-1"). If provided, the new task becomes a subtask. Defaults to the current task if omitted.',
+              'Identifier of the parent task (e.g. "TASK-1"). If provided, the new task becomes a subtask.',
             type: 'string',
           },
           priority: {

--- a/packages/builtin-tool-task/src/manifest.ts
+++ b/packages/builtin-tool-task/src/manifest.ts
@@ -200,12 +200,13 @@ export const TaskManifest: BuiltinToolManifest = {
       },
     },
     {
-      description: 'Delete a task by identifier.',
+      description:
+        'Permanently delete a task by identifier. Subtasks are NOT cascaded — they become top-level tasks after deletion. Dependencies, topics, pinned documents, comments, and briefs attached to the task are cascade-deleted. This action is irreversible.',
       name: TaskApiName.deleteTask,
       parameters: {
         properties: {
           identifier: {
-            description: 'The identifier of the task to delete.',
+            description: 'The identifier of the task to delete (e.g. "TASK-1").',
             type: 'string',
           },
         },

--- a/packages/builtin-tool-task/src/systemRole.ts
+++ b/packages/builtin-tool-task/src/systemRole.ts
@@ -1,8 +1,8 @@
 export const systemPrompt = `You have access to Task management tools. Use them to:
 
 - **createTask**: Create a new task. Use parentIdentifier to make it a subtask. Review config is inherited from parent by default, or specify custom review criteria
-- **listTasks**: List tasks, optionally filtered by parent or status
-- **viewTask**: View details of a specific task (defaults to your current task)
+- **listTasks**: List tasks. Defaults to top-level unfinished tasks of the current agent. Use filters (parentIdentifier, statuses, priorities) to narrow down
+- **viewTask**: View details of a specific task by identifier
 - **editTask**: Modify a task's name, instruction, priority, dependencies (addDependency/removeDependency), or review config
 - **updateTaskStatus**: Change a task's status (e.g. mark as completed when done, or cancel if no longer needed)
 - **deleteTask**: Delete a task

--- a/packages/builtin-tool-task/src/systemRole.ts
+++ b/packages/builtin-tool-task/src/systemRole.ts
@@ -5,7 +5,7 @@ export const systemPrompt = `You have access to Task management tools. Use them 
 - **viewTask**: View details of a specific task by identifier
 - **editTask**: Modify a task's name, instruction, priority, dependencies (addDependency/removeDependency), or review config
 - **updateTaskStatus**: Change a task's status (e.g. mark as completed when done, or cancel if no longer needed)
-- **deleteTask**: Delete a task
+- **deleteTask**: Delete a task. Subtasks become top-level (not cascaded); dependencies/topics/comments cascade-delete; irreversible
 
 When planning work:
 1. Create tasks for each major piece of work (use parentIdentifier to organize as subtasks)

--- a/packages/builtin-tool-task/src/systemRole.ts
+++ b/packages/builtin-tool-task/src/systemRole.ts
@@ -1,6 +1,6 @@
 export const systemPrompt = `You have access to Task management tools. Use them to:
 
-- **createTask**: Create a new task. Use parentIdentifier to make it a subtask. Review config is inherited from parent by default, or specify custom review criteria
+- **createTask**: Create a new task. Use parentIdentifier to make it a subtask. Review config is inherited when parentIdentifier is provided, or specify custom review criteria
 - **listTasks**: List tasks. Defaults to top-level unfinished tasks of the current agent. Use filters (parentIdentifier, statuses, priorities) to narrow down
 - **viewTask**: View details of a specific task by identifier
 - **editTask**: Modify a task's name, instruction, priority, dependencies (addDependency/removeDependency), or review config

--- a/packages/builtin-tool-task/src/systemRole.ts
+++ b/packages/builtin-tool-task/src/systemRole.ts
@@ -1,14 +1,13 @@
 export const systemPrompt = `You have access to Task management tools. Use them to:
 
-- **createTask**: Create a new task. Use parentIdentifier to make it a subtask. Review config is inherited when parentIdentifier is provided, or specify custom review criteria
+- **createTask**: Create a new task. Use parentIdentifier to make it a subtask
 - **listTasks**: List tasks. Defaults to top-level unfinished tasks of the current agent. Use filters (parentIdentifier, statuses, priorities) to narrow down
 - **viewTask**: View details of a specific task by identifier
-- **editTask**: Modify a task's fields (name, description, instruction, priority), dependencies (addDependencies/removeDependencies, batch), or review config. For status changes use updateTaskStatus
+- **editTask**: Modify a task's fields (name, description, instruction, priority) or dependencies (addDependencies/removeDependencies, batch). For status changes use updateTaskStatus
 - **updateTaskStatus**: Change a task's status (e.g. mark as completed when done, or cancel if no longer needed)
 - **deleteTask**: Delete a task. Subtasks become top-level (not cascaded); dependencies/topics/comments cascade-delete; irreversible
 
 When planning work:
 1. Create tasks for each major piece of work (use parentIdentifier to organize as subtasks)
-2. Use editTask with addDependency to control execution order
-3. Configure review criteria on tasks that need quality gates
-4. Use updateTaskStatus to mark the current task as completed when you finish all work`;
+2. Use editTask with addDependencies to control execution order
+3. Use updateTaskStatus to mark the current task as completed when you finish all work`;

--- a/packages/builtin-tool-task/src/systemRole.ts
+++ b/packages/builtin-tool-task/src/systemRole.ts
@@ -4,7 +4,7 @@ export const systemPrompt = `You have access to Task management tools. Use them 
 - **listTasks**: List tasks. With no filters, defaults to top-level unfinished tasks of the current agent. If you provide any filter, omitted filters are not applied implicitly
 - **viewTask**: View details of a specific task by identifier
 - **editTask**: Modify a task's fields (name, description, instruction, priority) or dependencies (addDependencies/removeDependencies, batch). For status changes use updateTaskStatus
-- **updateTaskStatus**: Change a task's status (e.g. mark as completed when done, or cancel if no longer needed)
+- **updateTaskStatus**: Change a task's status. If you mark a task as failed, include an error message explaining why. Omitting identifier only works when there is a current task context
 - **deleteTask**: Delete a task. Subtasks become top-level (not cascaded); dependencies/topics/comments cascade-delete; irreversible
 
 When planning work:

--- a/packages/builtin-tool-task/src/systemRole.ts
+++ b/packages/builtin-tool-task/src/systemRole.ts
@@ -1,7 +1,7 @@
 export const systemPrompt = `You have access to Task management tools. Use them to:
 
 - **createTask**: Create a new task. Use parentIdentifier to make it a subtask
-- **listTasks**: List tasks. Defaults to top-level unfinished tasks of the current agent. Use filters (parentIdentifier, statuses, priorities) to narrow down
+- **listTasks**: List tasks. With no filters, defaults to top-level unfinished tasks of the current agent. If you provide any filter, omitted filters are not applied implicitly
 - **viewTask**: View details of a specific task by identifier
 - **editTask**: Modify a task's fields (name, description, instruction, priority) or dependencies (addDependencies/removeDependencies, batch). For status changes use updateTaskStatus
 - **updateTaskStatus**: Change a task's status (e.g. mark as completed when done, or cancel if no longer needed)

--- a/packages/builtin-tool-task/src/systemRole.ts
+++ b/packages/builtin-tool-task/src/systemRole.ts
@@ -3,7 +3,7 @@ export const systemPrompt = `You have access to Task management tools. Use them 
 - **createTask**: Create a new task. Use parentIdentifier to make it a subtask. Review config is inherited when parentIdentifier is provided, or specify custom review criteria
 - **listTasks**: List tasks. Defaults to top-level unfinished tasks of the current agent. Use filters (parentIdentifier, statuses, priorities) to narrow down
 - **viewTask**: View details of a specific task by identifier
-- **editTask**: Modify a task's name, instruction, priority, dependencies (addDependency/removeDependency), or review config
+- **editTask**: Modify a task's fields (name, description, instruction, priority), dependencies (addDependencies/removeDependencies, batch), or review config. For status changes use updateTaskStatus
 - **updateTaskStatus**: Change a task's status (e.g. mark as completed when done, or cancel if no longer needed)
 - **deleteTask**: Delete a task. Subtasks become top-level (not cascaded); dependencies/topics/comments cascade-delete; irreversible
 

--- a/packages/builtin-tool-task/src/systemRole.ts
+++ b/packages/builtin-tool-task/src/systemRole.ts
@@ -2,7 +2,7 @@ export const systemPrompt = `You have access to Task management tools. Use them 
 
 - **createTask**: Create a new task. Use parentIdentifier to make it a subtask
 - **listTasks**: List tasks. With no filters, defaults to top-level unfinished tasks of the current agent. If you provide any filter, omitted filters are not applied implicitly
-- **viewTask**: View details of a specific task by identifier
+- **viewTask**: View details of a specific task. Omitting identifier only works when there is a current task context
 - **editTask**: Modify a task's fields (name, description, instruction, priority) or dependencies (addDependencies/removeDependencies, batch). For status changes use updateTaskStatus
 - **updateTaskStatus**: Change a task's status. If you mark a task as failed, include an error message explaining why. Omitting identifier only works when there is a current task context
 - **deleteTask**: Delete a task. Subtasks become top-level (not cascaded); dependencies/topics/comments cascade-delete; irreversible

--- a/packages/builtin-tool-task/src/types.ts
+++ b/packages/builtin-tool-task/src/types.ts
@@ -5,7 +5,7 @@ export const TaskApiName = {
   /** Delete a task */
   deleteTask: 'deleteTask',
 
-  /** Edit a task's name, instruction, priority, dependencies, or review config */
+  /** Edit a task's name, description, instruction, priority, or dependencies */
   editTask: 'editTask',
 
   /** List tasks with optional filters */

--- a/packages/builtin-tools/src/index.ts
+++ b/packages/builtin-tools/src/index.ts
@@ -43,6 +43,7 @@ export const defaultToolIds = [
   TopicReferenceManifest.identifier,
   AgentDocumentsManifest.identifier,
   GTDManifest.identifier,
+  TaskManifest.identifier,
 ];
 
 /**
@@ -239,7 +240,7 @@ export const builtinTools: LobeBuiltinTool[] = [
     type: 'builtin',
   },
   {
-    discoverable: false,
+    discoverable: true,
     hidden: true,
     identifier: TaskManifest.identifier,
     manifest: TaskManifest,
@@ -254,14 +255,14 @@ export const builtinTools: LobeBuiltinTool[] = [
   },
 ];
 
-/**
- * Non-hidden builtin tools that are NOT in RECOMMENDED_SKILLS.
- * These tools default to uninstalled and must be explicitly installed by the user from the Skill Store.
- */
 const recommendedBuiltinIds = new Set(
   RECOMMENDED_SKILLS.filter((s) => s.type === RecommendedSkillType.Builtin).map((s) => s.id),
 );
 
+/**
+ * Non-hidden builtin tools that are NOT in RECOMMENDED_SKILLS.
+ * These tools default to uninstalled and must be explicitly installed by the user from the Skill Store.
+ */
 export const defaultUninstalledBuiltinTools = builtinTools
   .filter((t) => !t.hidden && !recommendedBuiltinIds.has(t.identifier))
   .map((t) => t.identifier);

--- a/packages/context-engine/src/engine/messages/MessagesEngine.ts
+++ b/packages/context-engine/src/engine/messages/MessagesEngine.ts
@@ -48,6 +48,7 @@ import {
   SkillContextProvider,
   SystemDateProvider,
   SystemRoleInjector,
+  TaskManagerContextInjector,
   ToolDiscoveryProvider,
   ToolSystemRoleProvider,
   TopicReferenceContextInjector,
@@ -336,6 +337,11 @@ export class MessagesEngine {
                 xml: stepContext?.stepPageEditor?.xml || initialContext.pageEditor.xml,
               }
             : undefined),
+      }),
+      // Task Manager page context (inject current tasks list/detail to last user message)
+      new TaskManagerContextInjector({
+        contextPrompt: initialContext?.taskManager?.contextPrompt,
+        enabled: !!initialContext?.taskManager?.contextPrompt,
       }),
       // GTD Todo (at end of last user message)
       new GTDTodoInjector({ enabled: !!isGTDTodoEnabled, todos: gtd?.todos }),

--- a/packages/context-engine/src/providers/TaskManagerContextInjector.ts
+++ b/packages/context-engine/src/providers/TaskManagerContextInjector.ts
@@ -1,0 +1,64 @@
+import debug from 'debug';
+
+import { BaseLastUserContentProvider } from '../base/BaseLastUserContentProvider';
+import type { PipelineContext, ProcessorOptions } from '../types';
+
+declare module '../types' {
+  interface PipelineContextMetadataOverrides {
+    taskManagerContextInjected?: boolean;
+  }
+}
+
+const log = debug('context-engine:provider:TaskManagerContextInjector');
+
+export interface TaskManagerContextInjectorConfig {
+  contextPrompt?: string;
+  enabled?: boolean;
+}
+
+/**
+ * Appends Task Manager page context (list or detail) to the last user message.
+ */
+export class TaskManagerContextInjector extends BaseLastUserContentProvider {
+  readonly name = 'TaskManagerContextInjector';
+
+  constructor(
+    private config: TaskManagerContextInjectorConfig,
+    options: ProcessorOptions = {},
+  ) {
+    super(options);
+  }
+
+  protected async doProcess(context: PipelineContext): Promise<PipelineContext> {
+    log('doProcess: enabled=%s hasPrompt=%s', this.config.enabled, !!this.config.contextPrompt);
+
+    const clonedContext = this.cloneContext(context);
+
+    if (!this.config.enabled || !this.config.contextPrompt) {
+      log('No Task Manager context, skipping injection');
+      return this.markAsExecuted(clonedContext);
+    }
+
+    const lastUserIndex = this.findLastUserMessageIndex(clonedContext.messages);
+
+    log('Last user message index:', lastUserIndex);
+
+    if (lastUserIndex === -1) {
+      log('No user messages found, skipping injection');
+      return this.markAsExecuted(clonedContext);
+    }
+
+    const hasExistingWrapper = this.hasExistingSystemContext(clonedContext);
+    const contentToAppend = hasExistingWrapper
+      ? this.createContextBlock(this.config.contextPrompt, 'task_manager_context')
+      : this.wrapWithSystemContext(this.config.contextPrompt, 'task_manager_context');
+
+    this.appendToLastUserMessage(clonedContext, contentToAppend);
+
+    clonedContext.metadata.taskManagerContextInjected = true;
+
+    log('Task Manager context appended to last user message');
+
+    return this.markAsExecuted(clonedContext);
+  }
+}

--- a/packages/context-engine/src/providers/index.ts
+++ b/packages/context-engine/src/providers/index.ts
@@ -37,6 +37,7 @@ export {
 export { SkillContextProvider } from './SkillContextProvider';
 export { SystemDateProvider } from './SystemDateProvider';
 export { SystemRoleInjector } from './SystemRoleInjector';
+export { TaskManagerContextInjector } from './TaskManagerContextInjector';
 export { ToolDiscoveryProvider } from './ToolDiscoveryProvider';
 export { ToolSystemRoleProvider } from './ToolSystemRole';
 export { TopicReferenceContextInjector } from './TopicReferenceContextInjector';
@@ -98,6 +99,7 @@ export type { SelectedToolInjectorConfig } from './SelectedToolInjector';
 export type { SkillContextProviderConfig, SkillMeta } from './SkillContextProvider';
 export type { SystemDateProviderConfig } from './SystemDateProvider';
 export type { SystemRoleInjectorConfig } from './SystemRoleInjector';
+export type { TaskManagerContextInjectorConfig } from './TaskManagerContextInjector';
 export type { ToolDiscoveryMeta, ToolDiscoveryProviderConfig } from './ToolDiscoveryProvider';
 export type { ToolSystemRoleConfig } from './ToolSystemRole';
 export type {

--- a/packages/database/src/models/__tests__/task.test.ts
+++ b/packages/database/src/models/__tests__/task.test.ts
@@ -231,15 +231,28 @@ describe('TaskModel', () => {
       expect(tasks).toHaveLength(2);
     });
 
-    it('should filter by status', async () => {
+    it('should filter by statuses', async () => {
       const model = new TaskModel(serverDB, userId);
-      const task = await model.create({ instruction: 'Task 1' });
-      await model.updateStatus(task.id, 'running', { startedAt: new Date() });
-      await model.create({ instruction: 'Task 2' });
+      const t1 = await model.create({ instruction: 'Task 1' });
+      await model.updateStatus(t1.id, 'running', { startedAt: new Date() });
+      const t2 = await model.create({ instruction: 'Task 2' });
+      await model.updateStatus(t2.id, 'paused');
+      await model.create({ instruction: 'Task 3' }); // backlog
 
-      const { tasks } = await model.list({ status: 'running' });
-      expect(tasks).toHaveLength(1);
-      expect(tasks[0].status).toBe('running');
+      const { tasks } = await model.list({ statuses: ['running', 'paused'] });
+      expect(tasks).toHaveLength(2);
+      expect(tasks.map((t) => t.status).sort()).toEqual(['paused', 'running']);
+    });
+
+    it('should filter by priorities', async () => {
+      const model = new TaskModel(serverDB, userId);
+      await model.create({ instruction: 'Urgent task', priority: 1 });
+      await model.create({ instruction: 'High task', priority: 2 });
+      await model.create({ instruction: 'Low task', priority: 4 });
+
+      const { tasks } = await model.list({ priorities: [1, 2] });
+      expect(tasks).toHaveLength(2);
+      expect(tasks.map((t) => t.priority).sort()).toEqual([1, 2]);
     });
 
     it('should filter root tasks only', async () => {

--- a/packages/database/src/models/__tests__/topics/topic.query.test.ts
+++ b/packages/database/src/models/__tests__/topics/topic.query.test.ts
@@ -207,6 +207,24 @@ describe('TopicModel - Query', () => {
       expect(ids).toContain('null-trigger');
       expect(ids).not.toContain('cron-topic');
     });
+
+    it('should include only topics with specified triggers via includeTriggers', async () => {
+      await serverDB.insert(topics).values([
+        { id: 'normal-topic', sessionId, userId, title: 'Normal' },
+        { id: 'task-topic', sessionId, userId, title: 'Task', trigger: 'task_manager' },
+        { id: 'run-topic', sessionId, userId, title: 'Run', trigger: 'run_task' },
+        { id: 'null-trigger', sessionId, userId, title: 'Null Trigger' },
+      ]);
+
+      const result = await topicModel.query({
+        containerId: sessionId,
+        includeTriggers: ['task_manager'],
+      });
+
+      // Only topics whose trigger is exactly 'task_manager' should be returned
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].id).toBe('task-topic');
+    });
   });
 
   describe('query with agentId filter', () => {

--- a/packages/database/src/models/task.ts
+++ b/packages/database/src/models/task.ts
@@ -219,13 +219,22 @@ export class TaskModel {
     limit?: number;
     offset?: number;
     parentTaskId?: string | null;
-    status?: string;
+    priorities?: number[];
+    statuses?: string[];
   }): Promise<{ tasks: TaskItem[]; total: number }> {
-    const { status, parentTaskId, assigneeAgentId, limit = 50, offset = 0 } = options || {};
+    const {
+      statuses,
+      priorities,
+      parentTaskId,
+      assigneeAgentId,
+      limit = 50,
+      offset = 0,
+    } = options || {};
 
     const conditions = [eq(tasks.createdByUserId, this.userId)];
 
-    if (status) conditions.push(eq(tasks.status, status));
+    if (statuses?.length) conditions.push(inArray(tasks.status, statuses));
+    if (priorities?.length) conditions.push(inArray(tasks.priority, priorities));
     if (assigneeAgentId) conditions.push(eq(tasks.assigneeAgentId, assigneeAgentId));
 
     if (parentTaskId === null) {

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -37,6 +37,11 @@ interface QueryTopicParams {
    */
   groupId?: string | null;
   /**
+   * Include only topics whose trigger matches one of these values.
+   * Mutually complementary with excludeTriggers.
+   */
+  includeTriggers?: string[];
+  /**
    * Whether this is an inbox agent query.
    * When true, also includes legacy inbox topics (sessionId IS NULL AND groupId IS NULL AND agentId IS NULL)
    */
@@ -64,6 +69,7 @@ export class TopicModel {
     containerId,
     current = 0,
     excludeTriggers,
+    includeTriggers,
     pageSize = 9999,
     groupId,
     isInbox,
@@ -73,6 +79,10 @@ export class TopicModel {
       excludeTriggers && excludeTriggers.length > 0
         ? or(isNull(topics.trigger), not(inArray(topics.trigger, excludeTriggers)))
         : undefined;
+    const includeTriggerCondition =
+      includeTriggers && includeTriggers.length > 0
+        ? inArray(topics.trigger, includeTriggers)
+        : undefined;
 
     // If groupId is provided, query topics by groupId directly
     if (groupId) {
@@ -80,6 +90,7 @@ export class TopicModel {
         eq(topics.userId, this.userId),
         eq(topics.groupId, groupId),
         excludeTriggerCondition,
+        includeTriggerCondition,
       );
 
       const [items, totalResult] = await Promise.all([
@@ -157,14 +168,28 @@ export class TopicModel {
             updatedAt: topics.updatedAt,
           })
           .from(topics)
-          .where(and(eq(topics.userId, this.userId), agentCondition, excludeTriggerCondition))
+          .where(
+            and(
+              eq(topics.userId, this.userId),
+              agentCondition,
+              excludeTriggerCondition,
+              includeTriggerCondition,
+            ),
+          )
           .orderBy(desc(topics.favorite), desc(topics.updatedAt))
           .limit(pageSize)
           .offset(offset),
         this.db
           .select({ count: count(topics.id) })
           .from(topics)
-          .where(and(eq(topics.userId, this.userId), agentCondition, excludeTriggerCondition)),
+          .where(
+            and(
+              eq(topics.userId, this.userId),
+              agentCondition,
+              excludeTriggerCondition,
+              includeTriggerCondition,
+            ),
+          ),
       ]);
 
       return { items, total: totalResult[0].count };
@@ -175,6 +200,7 @@ export class TopicModel {
       eq(topics.userId, this.userId),
       this.matchContainer(containerId),
       excludeTriggerCondition,
+      includeTriggerCondition,
     );
 
     const [items, totalResult] = await Promise.all([

--- a/packages/openapi/src/types/topic.type.ts
+++ b/packages/openapi/src/types/topic.type.ts
@@ -12,6 +12,7 @@ export interface TopicListQuery extends IPaginationQuery {
   agentId?: string | null;
   excludeTriggers?: string[];
   groupId?: string | null;
+  includeTriggers?: string[];
   isInbox?: boolean;
 }
 
@@ -20,6 +21,7 @@ export const TopicListQuerySchema = z
     agentId: z.string().nullish(),
     excludeTriggers: z.array(z.string()).optional(),
     groupId: z.string().nullish(),
+    includeTriggers: z.array(z.string()).optional(),
     isInbox: z
       .string()
       .optional()

--- a/packages/prompts/src/prompts/task/__snapshots__/buildTaskDetailPrompt.test.ts.snap
+++ b/packages/prompts/src/prompts/task/__snapshots__/buildTaskDetailPrompt.test.ts.snap
@@ -1,0 +1,56 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`buildTaskDetailPrompt > includes subtasks, dependencies, and review 1`] = `
+"<page_context>The user is currently viewing the detail page of task T-3. When the user says "this task" or refers ambiguously, it means T-3.</page_context>
+<task>
+<hint>This tag contains the complete context of the task the user is viewing. Do NOT call viewTask to re-fetch it.</hint>
+T-3 Chapter 3
+Status: ● running     Priority: high
+Instruction: 写第3章 评测方法论
+Description: 面向开发者
+Agent: agt_xxx
+Parent: T-1
+Dependencies: completion: T-2
+
+Subtasks:
+  T-3-1 ✓ completed Draft
+  T-3-2 ○ backlog Polish ← blocks: T-3-1
+
+Review (maxIterations: 3):
+  - Clarity [llm] ≥ 80%
+</task>"
+`;
+
+exports[`buildTaskDetailPrompt > renders minimal task with page_context header 1`] = `
+"<page_context>The user is currently viewing the detail page of task T-3. When the user says "this task" or refers ambiguously, it means T-3.</page_context>
+<task>
+<hint>This tag contains the complete context of the task the user is viewing. Do NOT call viewTask to re-fetch it.</hint>
+T-3 Chapter 3
+Status: ● running     Priority: high
+Instruction: 写第3章 评测方法论
+
+Review: (not configured)
+</task>"
+`;
+
+exports[`buildTaskDetailPrompt > renders workspace tree and activities timeline 1`] = `
+"<page_context>The user is currently viewing the detail page of task T-3. When the user says "this task" or refers ambiguously, it means T-3.</page_context>
+<task>
+<hint>This tag contains the complete context of the task the user is viewing. Do NOT call viewTask to re-fetch it.</hint>
+T-3 Chapter 3
+Status: ● running     Priority: high
+Instruction: 写第3章 评测方法论
+
+Review: (not configured)
+
+Workspace (2):
+  📁 Drafts (doc_root)
+  └── 📄 ch3.md (doc_ch3)  1200 chars
+
+Activities:
+  💬 3h ago Topic #1 Outline ✓ completed  tpc_001
+  📋 2h ago Brief [decision] 大纲通过 [normal] ✏️ approve  brief_001
+  💭 1h ago 👤 user 需要加评测章节
+  💭 30m ago 🤖 agent 已添加评测章节
+</task>"
+`;

--- a/packages/prompts/src/prompts/task/__snapshots__/buildTaskListPrompt.test.ts.snap
+++ b/packages/prompts/src/prompts/task/__snapshots__/buildTaskListPrompt.test.ts.snap
@@ -1,0 +1,40 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`buildTaskListPrompt > notes truncation when total exceeds shown count 1`] = `
+"<task_list>
+<hint>The user is currently viewing the tasks list page. These are the 3 task(s) displayed in the UI. Do NOT call listTasks to re-fetch them.</hint>
+Total: 120 (showing most recent 3)
+
+  T-1 ○ backlog  [normal]  Task 1  2h ago
+  T-2 ○ backlog  [normal]  Task 2  2h ago
+  T-3 ○ backlog  [normal]  Task 3  2h ago
+
+Only the most recent 3 tasks are shown above. Use the \`listTasks\` tool to query the full list of 120 tasks.
+</task_list>"
+`;
+
+exports[`buildTaskListPrompt > omits created-at suffix when tasks lack createdAt 1`] = `
+"<task_list>
+<hint>The user is currently viewing the tasks list page. These are the 1 task(s) displayed in the UI. Do NOT call listTasks to re-fetch them.</hint>
+Total: 1
+
+  T-1 ○ backlog  [-]  Untimed
+</task_list>"
+`;
+
+exports[`buildTaskListPrompt > renders a short list with total equal to shown count 1`] = `
+"<task_list>
+<hint>The user is currently viewing the tasks list page. These are the 2 task(s) displayed in the UI. Do NOT call listTasks to re-fetch them.</hint>
+Total: 2
+
+  T-1 ● running  [high]  Write chapter 1  3h ago
+  T-2 ○ backlog  [normal]  Review outline  1d ago
+</task_list>"
+`;
+
+exports[`buildTaskListPrompt > renders empty state when no tasks 1`] = `
+"<task_list>
+<hint>The user is currently viewing the tasks list page. These are the 0 task(s) displayed in the UI. Do NOT call listTasks to re-fetch them.</hint>
+(no tasks)
+</task_list>"
+`;

--- a/packages/prompts/src/prompts/task/buildTaskDetailPrompt.test.ts
+++ b/packages/prompts/src/prompts/task/buildTaskDetailPrompt.test.ts
@@ -1,0 +1,122 @@
+import type { TaskDetailData } from '@lobechat/types';
+import { describe, expect, it } from 'vitest';
+
+import { buildTaskDetailPrompt } from './buildTaskDetailPrompt';
+
+const NOW = new Date('2026-03-22T12:00:00Z');
+
+const baseTask: TaskDetailData = {
+  identifier: 'T-3',
+  instruction: '写第3章 评测方法论',
+  name: 'Chapter 3',
+  priority: 2,
+  status: 'running',
+};
+
+describe('buildTaskDetailPrompt', () => {
+  it('renders minimal task with page_context header', () => {
+    const result = buildTaskDetailPrompt({ task: baseTask }, NOW);
+
+    expect(result).toMatchSnapshot();
+    expect(result).toContain('<page_context>');
+    expect(result).toContain('T-3');
+    expect(result).toContain('<task>');
+    expect(result).not.toContain('<high_priority_instruction>');
+  });
+
+  it('includes subtasks, dependencies, and review', () => {
+    const result = buildTaskDetailPrompt(
+      {
+        task: {
+          ...baseTask,
+          description: '面向开发者',
+          agentId: 'agt_xxx',
+          parent: { identifier: 'T-1', name: 'Book' },
+          dependencies: [{ dependsOn: 'T-2', type: 'completion' }],
+          subtasks: [
+            { identifier: 'T-3-1', name: 'Draft', status: 'completed' },
+            { identifier: 'T-3-2', name: 'Polish', status: 'backlog', blockedBy: 'T-3-1' },
+          ],
+          review: {
+            enabled: true,
+            maxIterations: 3,
+            rubrics: [{ name: 'Clarity', type: 'llm', threshold: 0.8 }],
+          },
+        },
+      },
+      NOW,
+    );
+
+    expect(result).toMatchSnapshot();
+    expect(result).toContain('Parent: T-1');
+    expect(result).toContain('Dependencies: completion: T-2');
+    expect(result).toContain('Subtasks:');
+    expect(result).toContain('Review (maxIterations: 3)');
+  });
+
+  it('renders workspace tree and activities timeline', () => {
+    const result = buildTaskDetailPrompt(
+      {
+        task: {
+          ...baseTask,
+          workspace: [
+            {
+              documentId: 'doc_root',
+              fileType: 'custom/folder',
+              title: 'Drafts',
+              children: [
+                {
+                  documentId: 'doc_ch3',
+                  fileType: 'text/markdown',
+                  title: 'ch3.md',
+                  size: 1200,
+                },
+              ],
+            },
+          ],
+          activities: [
+            {
+              type: 'topic',
+              id: 'tpc_001',
+              seq: 1,
+              status: 'completed',
+              time: '2026-03-22T09:00:00Z',
+              title: 'Outline',
+            },
+            {
+              type: 'brief',
+              briefType: 'decision',
+              id: 'brief_001',
+              priority: 'normal',
+              resolvedAction: 'approve',
+              time: '2026-03-22T10:00:00Z',
+              title: '大纲通过',
+            },
+            {
+              type: 'comment',
+              content: '需要加评测章节',
+              time: '2026-03-22T11:00:00Z',
+            },
+            {
+              type: 'comment',
+              agentId: 'agt_xxx',
+              content: '已添加评测章节',
+              time: '2026-03-22T11:30:00Z',
+            },
+          ],
+        },
+      },
+      NOW,
+    );
+
+    expect(result).toMatchSnapshot();
+    expect(result).toContain('Workspace (2)');
+    expect(result).toContain('📁');
+    expect(result).toContain('📄');
+    expect(result).toContain('Activities:');
+    expect(result).toContain('💬');
+    expect(result).toContain('📋');
+    expect(result).toContain('👤 user');
+    expect(result).toContain('🤖 agent');
+  });
+});

--- a/packages/prompts/src/prompts/task/buildTaskDetailPrompt.ts
+++ b/packages/prompts/src/prompts/task/buildTaskDetailPrompt.ts
@@ -1,0 +1,127 @@
+import type { TaskDetailData, TaskDetailWorkspaceNode } from './index';
+import { briefIcon, priorityLabel, statusIcon, timeAgo } from './index';
+
+export interface BuildTaskDetailPromptInput {
+  task: TaskDetailData;
+}
+
+/**
+ * Task detail prompt for Task Manager conversational reference.
+ * Variant of `buildTaskRunPrompt` without `<high_priority_instruction>`.
+ */
+export const buildTaskDetailPrompt = (input: BuildTaskDetailPromptInput, now?: Date): string => {
+  const { task } = input;
+  const { activities, workspace } = task;
+
+  const lines: string[] = [
+    `<page_context>The user is currently viewing the detail page of task ${task.identifier}. When the user says "this task" or refers ambiguously, it means ${task.identifier}.</page_context>`,
+    '<task>',
+    `<hint>This tag contains the complete context of the task the user is viewing. Do NOT call viewTask to re-fetch it.</hint>`,
+    `${task.identifier} ${task.name || '(unnamed)'}`,
+    `Status: ${statusIcon(task.status)} ${task.status}     Priority: ${priorityLabel(task.priority)}`,
+    `Instruction: ${task.instruction}`,
+  ];
+  if (task.description) lines.push(`Description: ${task.description}`);
+  if (task.agentId) lines.push(`Agent: ${task.agentId}`);
+  if (task.parent) lines.push(`Parent: ${task.parent.identifier}`);
+  if (task.topicCount) lines.push(`Topics: ${task.topicCount}`);
+
+  if (task.dependencies && task.dependencies.length > 0) {
+    lines.push(
+      `Dependencies: ${task.dependencies.map((d) => `${d.type}: ${d.dependsOn}`).join(', ')}`,
+    );
+  }
+
+  if (task.subtasks && task.subtasks.length > 0) {
+    lines.push('');
+    lines.push('Subtasks:');
+    const renderSubtasks = (nodes: NonNullable<typeof task.subtasks>, indent: string) => {
+      for (const s of nodes) {
+        const dep = s.blockedBy ? ` ← blocks: ${s.blockedBy}` : '';
+        lines.push(
+          `${indent}${s.identifier} ${statusIcon(s.status)} ${s.status} ${s.name || '(unnamed)'}${dep}`,
+        );
+        if (s.children && s.children.length > 0) {
+          renderSubtasks(s.children, indent + '  ');
+        }
+      }
+    };
+    renderSubtasks(task.subtasks, '  ');
+  }
+
+  lines.push('');
+  if (task.review && Object.keys(task.review).length > 0) {
+    const review = task.review as {
+      maxIterations?: number;
+      rubrics?: Array<{ name: string; threshold?: number; type: string }>;
+    };
+    lines.push(`Review (maxIterations: ${review.maxIterations || 3}):`);
+    if (review.rubrics) {
+      for (const r of review.rubrics) {
+        lines.push(
+          `  - ${r.name} [${r.type}]${r.threshold ? ` ≥ ${Math.round(r.threshold * 100)}%` : ''}`,
+        );
+      }
+    }
+  } else {
+    lines.push('Review: (not configured)');
+  }
+
+  if (workspace && workspace.length > 0) {
+    const countNodes = (nodes: TaskDetailWorkspaceNode[]): number =>
+      nodes.reduce((sum, n) => sum + 1 + (n.children ? countNodes(n.children) : 0), 0);
+    const total = countNodes(workspace);
+    lines.push('');
+    lines.push(`Workspace (${total}):`);
+
+    const renderNodes = (nodes: TaskDetailWorkspaceNode[], indent: string, isChild: boolean) => {
+      for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        const isFolder = node.fileType === 'custom/folder';
+        const isLast = i === nodes.length - 1;
+        const icon = isFolder ? '📁' : '📄';
+        const connector = isChild ? (isLast ? '└── ' : '├── ') : '';
+        const source = node.sourceTaskIdentifier ? ` ← ${node.sourceTaskIdentifier}` : '';
+        const sizeStr = !isFolder && node.size ? `  ${node.size} chars` : '';
+        lines.push(
+          `${indent}${connector}${icon} ${node.title || 'Untitled'} (${node.documentId})${source}${sizeStr}`,
+        );
+        if (node.children) {
+          const childIndent = isChild ? indent + (isLast ? '    ' : '│   ') : indent;
+          renderNodes(node.children, childIndent, true);
+        }
+      }
+    };
+    renderNodes(workspace, '  ', false);
+  }
+
+  if (activities && activities.length > 0) {
+    lines.push('');
+    lines.push('Activities:');
+    for (const act of activities) {
+      const ago = act.time ? timeAgo(act.time, now) : '';
+      const idSuffix = act.id ? `  ${act.id}` : '';
+      if (act.type === 'topic') {
+        const status = act.status || 'completed';
+        lines.push(
+          `  💬 ${ago} Topic #${act.seq || '?'} ${act.title || 'Untitled'} ${statusIcon(status)} ${status}${idSuffix}`,
+        );
+      } else if (act.type === 'brief') {
+        const resolved = act.resolvedAction ? ` ✏️ ${act.resolvedAction}` : '';
+        const priStr = act.priority ? ` [${act.priority}]` : '';
+        lines.push(
+          `  ${briefIcon(act.briefType || '')} ${ago} Brief [${act.briefType}] ${act.title}${priStr}${resolved}${idSuffix}`,
+        );
+      } else if (act.type === 'comment') {
+        const author = act.agentId ? '🤖 agent' : '👤 user';
+        const content = act.content || '';
+        const truncated = content.length > 200 ? content.slice(0, 200) + '...' : content;
+        lines.push(`  💭 ${ago} ${author} ${truncated}`);
+      }
+    }
+  }
+
+  lines.push('</task>');
+
+  return lines.join('\n');
+};

--- a/packages/prompts/src/prompts/task/buildTaskListPrompt.test.ts
+++ b/packages/prompts/src/prompts/task/buildTaskListPrompt.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildTaskListPrompt } from './buildTaskListPrompt';
+
+const NOW = new Date('2026-03-22T12:00:00Z');
+
+describe('buildTaskListPrompt', () => {
+  it('renders empty state when no tasks', () => {
+    const result = buildTaskListPrompt({ tasks: [], total: 0 }, NOW);
+    expect(result).toMatchSnapshot();
+    expect(result).toContain('(no tasks)');
+  });
+
+  it('renders a short list with total equal to shown count', () => {
+    const result = buildTaskListPrompt(
+      {
+        tasks: [
+          {
+            identifier: 'T-1',
+            name: 'Write chapter 1',
+            priority: 2,
+            status: 'running',
+            createdAt: '2026-03-22T09:00:00Z',
+          },
+          {
+            identifier: 'T-2',
+            name: 'Review outline',
+            priority: 3,
+            status: 'backlog',
+            createdAt: '2026-03-21T12:00:00Z',
+          },
+        ],
+        total: 2,
+      },
+      NOW,
+    );
+
+    expect(result).toMatchSnapshot();
+    expect(result).toContain('Total: 2');
+    expect(result).not.toContain('most recent');
+  });
+
+  it('notes truncation when total exceeds shown count', () => {
+    const tasks = Array.from({ length: 3 }, (_, i) => ({
+      identifier: `T-${i + 1}`,
+      name: `Task ${i + 1}`,
+      priority: 3,
+      status: 'backlog',
+      createdAt: '2026-03-22T10:00:00Z',
+    }));
+
+    const result = buildTaskListPrompt({ tasks, total: 120 }, NOW);
+
+    expect(result).toMatchSnapshot();
+    expect(result).toContain('Total: 120 (showing most recent 3)');
+    expect(result).toContain('Only the most recent 3 tasks');
+    expect(result).toContain('`listTasks`');
+  });
+
+  it('omits created-at suffix when tasks lack createdAt', () => {
+    const result = buildTaskListPrompt(
+      {
+        tasks: [{ identifier: 'T-1', name: 'Untimed', priority: null, status: 'backlog' }],
+        total: 1,
+      },
+      NOW,
+    );
+
+    expect(result).toMatchSnapshot();
+    expect(result).not.toContain('ago');
+  });
+});

--- a/packages/prompts/src/prompts/task/buildTaskListPrompt.ts
+++ b/packages/prompts/src/prompts/task/buildTaskListPrompt.ts
@@ -1,0 +1,46 @@
+import type { TaskSummary } from './index';
+import { priorityLabel, statusIcon, timeAgo } from './index';
+
+export interface BuildTaskListPromptInput {
+  tasks: Array<TaskSummary & { createdAt?: string | Date }>;
+  total: number;
+}
+
+/**
+ * Task list prompt for Task Manager conversational reference.
+ */
+export const buildTaskListPrompt = (input: BuildTaskListPromptInput, now?: Date): string => {
+  const { tasks, total } = input;
+  const shown = tasks.length;
+
+  const lines: string[] = [
+    '<task_list>',
+    `<hint>The user is currently viewing the tasks list page. These are the ${shown} task(s) displayed in the UI. Do NOT call listTasks to re-fetch them.</hint>`,
+  ];
+
+  if (shown === 0) {
+    lines.push('(no tasks)');
+  } else {
+    const countLine =
+      total > shown ? `Total: ${total} (showing most recent ${shown})` : `Total: ${total}`;
+    lines.push(countLine);
+    lines.push('');
+    for (const t of tasks) {
+      const ago = t.createdAt
+        ? `  ${timeAgo(typeof t.createdAt === 'string' ? t.createdAt : t.createdAt.toISOString(), now)}`
+        : '';
+      lines.push(
+        `  ${t.identifier} ${statusIcon(t.status)} ${t.status}  [${priorityLabel(t.priority)}]  ${t.name || '(unnamed)'}${ago}`,
+      );
+    }
+    if (total > shown) {
+      lines.push('');
+      lines.push(
+        `Only the most recent ${shown} tasks are shown above. Use the \`listTasks\` tool to query the full list of ${total} tasks.`,
+      );
+    }
+  }
+  lines.push('</task_list>');
+
+  return lines.join('\n');
+};

--- a/packages/prompts/src/prompts/task/index.ts
+++ b/packages/prompts/src/prompts/task/index.ts
@@ -85,23 +85,39 @@ export const formatTaskCreated = (
   return lines.join('\n');
 };
 
+export interface TaskListFilters {
+  assigneeAgentId?: string;
+  parentIdentifier?: string;
+  priorities?: number[];
+  statuses?: string[];
+}
+
+const buildTaskListLabel = (filters: TaskListFilters): string => {
+  if (filters.parentIdentifier) return `subtasks of ${filters.parentIdentifier}`;
+
+  const hasExplicitFilter =
+    filters.statuses?.length || filters.priorities?.length || filters.assigneeAgentId;
+  if (!hasExplicitFilter) return 'top-level unfinished tasks';
+
+  const parts: string[] = [];
+  if (filters.statuses?.length) parts.push(`status=[${filters.statuses.join(',')}]`);
+  if (filters.priorities?.length) {
+    parts.push(`priority=[${filters.priorities.map((p) => priorityLabel(p)).join(',')}]`);
+  }
+  if (filters.assigneeAgentId) parts.push(`agent=${filters.assigneeAgentId}`);
+  return `tasks matching ${parts.join(', ')}`;
+};
+
 /**
  * Format task list response
  */
-export const formatTaskList = (
-  tasks: TaskSummary[],
-  parentLabel: string,
-  filter?: string,
-): string => {
+export const formatTaskList = (tasks: TaskSummary[], filters: TaskListFilters): string => {
+  const label = buildTaskListLabel(filters);
   if (tasks.length === 0) {
-    const filterNote = filter ? ` with status "${filter}"` : '';
-    return `No subtasks found under ${parentLabel}${filterNote}.`;
+    return `No ${label}.`;
   }
 
-  return [
-    `${tasks.length} task(s) under ${parentLabel}:`,
-    ...tasks.map((t) => `  ${formatTaskLine(t)}`),
-  ].join('\n');
+  return [`${tasks.length} ${label}:`, ...tasks.map((t) => `  ${formatTaskLine(t)}`)].join('\n');
 };
 
 /**

--- a/packages/prompts/src/prompts/task/index.ts
+++ b/packages/prompts/src/prompts/task/index.ts
@@ -573,4 +573,9 @@ export const buildTaskRunPrompt = (input: TaskRunPromptInput, now?: Date): strin
   return sections.join('\n\n');
 };
 
-export { priorityLabel, statusIcon };
+export { briefIcon, priorityLabel, statusIcon, timeAgo };
+
+export type { BuildTaskDetailPromptInput } from './buildTaskDetailPrompt';
+export { buildTaskDetailPrompt } from './buildTaskDetailPrompt';
+export type { BuildTaskListPromptInput } from './buildTaskListPrompt';
+export { buildTaskListPrompt } from './buildTaskListPrompt';

--- a/packages/prompts/src/prompts/task/index.ts
+++ b/packages/prompts/src/prompts/task/index.ts
@@ -250,6 +250,12 @@ export const formatTaskEdited = (identifier: string, changes: string[]): string 
   `Task ${identifier} updated:\n  ${changes.join('\n  ')}`;
 
 /**
+ * Format deleteTask response
+ */
+export const formatTaskDeleted = (identifier: string, name?: string | null): string =>
+  name ? `Task ${identifier} "${name}" has been deleted.` : `Task ${identifier} has been deleted.`;
+
+/**
  * Format dependency change response
  */
 export const formatDependencyAdded = (task: string, dependsOn: string): string =>

--- a/packages/prompts/src/prompts/task/index.ts
+++ b/packages/prompts/src/prompts/task/index.ts
@@ -1,4 +1,4 @@
-import type { TaskDetailData, TaskDetailWorkspaceNode } from '@lobechat/types';
+import type { TaskDetailData, TaskDetailWorkspaceNode, TaskStatus } from '@lobechat/types';
 
 // ── Formatting helpers for Task tool responses ──
 
@@ -87,17 +87,19 @@ export const formatTaskCreated = (
 
 export interface TaskListFilters {
   assigneeAgentId?: string;
+  isDefaultScope?: boolean;
+  isForCurrentAgent?: boolean;
   parentIdentifier?: string;
   priorities?: number[];
-  statuses?: string[];
+  statuses?: TaskStatus[];
 }
 
 const buildTaskListLabel = (filters: TaskListFilters): string => {
-  if (filters.parentIdentifier) return `subtasks of ${filters.parentIdentifier}`;
-
-  const hasExplicitFilter =
-    filters.statuses?.length || filters.priorities?.length || filters.assigneeAgentId;
-  if (!hasExplicitFilter) return 'top-level unfinished tasks';
+  if (filters.isDefaultScope) {
+    return filters.isForCurrentAgent
+      ? 'top-level unfinished tasks of the current agent'
+      : 'top-level unfinished tasks';
+  }
 
   const parts: string[] = [];
   if (filters.statuses?.length) parts.push(`status=[${filters.statuses.join(',')}]`);
@@ -105,7 +107,14 @@ const buildTaskListLabel = (filters: TaskListFilters): string => {
     parts.push(`priority=[${filters.priorities.map((p) => priorityLabel(p)).join(',')}]`);
   }
   if (filters.assigneeAgentId) parts.push(`agent=${filters.assigneeAgentId}`);
-  return `tasks matching ${parts.join(', ')}`;
+
+  if (filters.parentIdentifier) {
+    return parts.length > 0
+      ? `subtasks of ${filters.parentIdentifier} matching ${parts.join(', ')}`
+      : `subtasks of ${filters.parentIdentifier}`;
+  }
+
+  return parts.length > 0 ? `tasks matching ${parts.join(', ')}` : 'tasks';
 };
 
 /**

--- a/packages/types/src/aiChat.ts
+++ b/packages/types/src/aiChat.ts
@@ -68,6 +68,7 @@ export interface SendMessageServerParams {
   newTopic?: {
     title?: string;
     topicMessageIds?: string[];
+    trigger?: string;
   };
   newUserMessage: SendNewMessage;
   preloadMessages?: SendPreloadMessage[];
@@ -113,6 +114,7 @@ export const AiSendMessageServerSchema = z.object({
     .object({
       title: z.string().optional(),
       topicMessageIds: z.array(z.string()).optional(),
+      trigger: z.string().optional(),
     })
     .optional(),
   preloadMessages: z.array(SendPreloadMessageSchema).optional(),

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -201,4 +201,9 @@ export interface ConversationContext {
    * page-specific filtering. Only consumed during new-topic creation.
    */
   topicTrigger?: string;
+  /**
+   * Task Manager page the user is currently viewing. When set, streamingExecutor
+   * builds `RuntimeInitialContext.taskManager` from the task store.
+   */
+  viewedTask?: { type: 'list' } | { taskId: string; type: 'detail' };
 }

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -129,6 +129,13 @@ export interface ConversationContext {
    */
   isNew?: boolean;
   /**
+   * When true, sendMessage will NOT update the global `useChatStore.activeTopicId`
+   * after creating a new topic — the caller is responsible for tracking the new
+   * topic id (e.g. via `ConversationHooks.onTopicCreated`). Used by isolated
+   * panels (Task Manager) that maintain their own topic pointer.
+   */
+  isolatedTopic?: boolean;
+  /**
    * Whether the current agent is the Supervisor in group orchestration
    * - Used to mark assistant messages with metadata.isSupervisor
    * - conversation-flow will transform role to 'supervisor' for UI rendering
@@ -188,4 +195,10 @@ export interface ConversationContext {
    * When present, allows unauthenticated access to topic messages
    */
   topicShareId?: string;
+  /**
+   * Trigger value applied when sendMessage creates a new topic from this
+   * context (e.g. `'task_manager'`). Stamped on the topic row to support
+   * page-specific filtering. Only consumed during new-topic creation.
+   */
+  topicTrigger?: string;
 }

--- a/packages/types/src/stepContext.ts
+++ b/packages/types/src/stepContext.ts
@@ -221,4 +221,15 @@ export interface RuntimeInitialContext {
    * This constrains the available tools for the current runtime execution
    */
   selectedTools?: RuntimeSelectedTool[];
+  /**
+   * Task Manager page context, built from the tasks list/detail page the user
+   * is currently viewing. Injected into the last user message so the LLM can
+   * answer questions about the on-screen tasks without extra tool calls.
+   */
+  taskManager?: InitialTaskManagerContext;
+}
+
+export interface InitialTaskManagerContext {
+  /** Prebuilt prompt describing the tasks shown on the page. */
+  contextPrompt: string;
 }

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -126,6 +126,7 @@ export interface CreateTopicParams {
   messages?: string[];
   sessionId?: string | null;
   title: string;
+  trigger?: string;
 }
 
 export interface QueryTopicParams {
@@ -139,6 +140,10 @@ export interface QueryTopicParams {
    * Group ID to filter topics by
    */
   groupId?: string | null;
+  /**
+   * Include only topics whose trigger matches one of these values.
+   */
+  includeTriggers?: string[];
   /**
    * Whether this is an inbox agent query.
    * When true, also includes legacy inbox topics (sessionId IS NULL AND groupId IS NULL AND agentId IS NULL)

--- a/src/const/topic.ts
+++ b/src/const/topic.ts
@@ -1,0 +1,26 @@
+/**
+ * Well-known `topic.trigger` values used to segment the same agent's topics
+ * across different panels (Task Manager vs. main chat).
+ */
+export const TopicTrigger = {
+  Cron: 'cron',
+  Eval: 'eval',
+  RunTask: 'run_task',
+  TaskManager: 'task_manager',
+} as const;
+
+/**
+ * Triggers to exclude from the main chat sidebar so page-owned topics
+ * (cron jobs, evals, task manager) don't pollute the user's main history.
+ */
+export const MAIN_SIDEBAR_EXCLUDE_TRIGGERS: string[] = [
+  TopicTrigger.Cron,
+  TopicTrigger.Eval,
+  TopicTrigger.TaskManager,
+  TopicTrigger.RunTask,
+];
+
+/**
+ * Triggers the Task Manager panel fetches.
+ */
+export const TASK_MANAGER_INCLUDE_TRIGGERS: string[] = [TopicTrigger.TaskManager];

--- a/src/features/AgentTaskManager/Conversation.tsx
+++ b/src/features/AgentTaskManager/Conversation.tsx
@@ -25,9 +25,9 @@ import { useChatStore } from '@/store/chat';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 import { useTaskChatStore } from '@/store/taskChat';
 
-import TaskManagerToolbar from './TaskManagerToolbar';
+import Toolbar from './Toolbar';
 
-const log = debug('lobe-render:agent-tasks:TaskManagerConversation');
+const log = debug('lobe-render:agent-task-manager:Conversation');
 
 const Search = actionMap['search'];
 
@@ -48,9 +48,9 @@ const Welcome = memo(() => {
   );
 });
 
-Welcome.displayName = 'TaskManagerWelcome';
+Welcome.displayName = 'Welcome';
 
-const TaskManagerConversation = memo(() => {
+const Conversation = memo(() => {
   const activeAgentId = useChatStore((s) => s.activeAgentId);
   const taskTopicId = useTaskChatStore((s) => s.activeTopicId);
 
@@ -110,7 +110,7 @@ const TaskManagerConversation = memo(() => {
     >
       <DragUploadZone style={{ flex: 1, height: '100%' }} onUploadFiles={handleUploadFiles}>
         <Flexbox flex={1} height={'100%'} style={{ overflow: 'hidden' }}>
-          <TaskManagerToolbar />
+          <Toolbar />
           <Flexbox flex={1} style={{ overflow: 'hidden' }}>
             <ChatList welcome={<Welcome />} />
           </Flexbox>
@@ -129,6 +129,6 @@ const TaskManagerConversation = memo(() => {
   );
 });
 
-TaskManagerConversation.displayName = 'TaskManagerConversation';
+Conversation.displayName = 'Conversation';
 
-export default TaskManagerConversation;
+export default Conversation;

--- a/src/features/AgentTaskManager/Conversation.tsx
+++ b/src/features/AgentTaskManager/Conversation.tsx
@@ -5,6 +5,7 @@ import { Flexbox, Text } from '@lobehub/ui';
 import debug from 'debug';
 import { memo, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useMatch } from 'react-router-dom';
 
 import DragUploadZone, { useUploadFiles } from '@/components/DragUploadZone';
 import { TopicTrigger } from '@/const/topic';
@@ -66,6 +67,10 @@ const Conversation = memo(() => {
     useTaskChatStore.getState().switchTopic(null);
   }, [activeAgentId]);
 
+  const detailMatch = useMatch('/agent/:aid/tasks/:taskId');
+  const isListRoute = !!useMatch('/agent/:aid/tasks');
+  const viewedTaskId = detailMatch?.params.taskId;
+
   const context = useMemo<ConversationContext>(
     () => ({
       agentId: activeAgentId,
@@ -73,8 +78,13 @@ const Conversation = memo(() => {
       scope: 'main',
       topicId: taskTopicId,
       topicTrigger: TopicTrigger.TaskManager,
+      viewedTask: viewedTaskId
+        ? { taskId: viewedTaskId, type: 'detail' }
+        : isListRoute
+          ? { type: 'list' }
+          : undefined,
     }),
-    [activeAgentId, taskTopicId],
+    [activeAgentId, taskTopicId, viewedTaskId, isListRoute],
   );
 
   const chatKey = messageMapKey(context);

--- a/src/features/AgentTaskManager/Toolbar.tsx
+++ b/src/features/AgentTaskManager/Toolbar.tsx
@@ -76,6 +76,11 @@ const Toolbar = memo(() => {
                       topicTitle={topic.title}
                       onClose={() => setTopicPopoverOpen(false)}
                       onTopicChange={(id) => switchTopic(id)}
+                      onDelete={(deletedId) => {
+                        const store = useTaskChatStore.getState();
+                        void store.refreshTopics();
+                        if (store.activeTopicId === deletedId) store.switchTopic(null);
+                      }}
                     />
                   ))}
                 </Flexbox>

--- a/src/features/AgentTaskManager/Toolbar.tsx
+++ b/src/features/AgentTaskManager/Toolbar.tsx
@@ -11,7 +11,7 @@ import TopicItem from '@/features/PageEditor/Copilot/TopicSelector/TopicItem';
 import { useGlobalStore } from '@/store/global';
 import { useTaskChatStore } from '@/store/taskChat';
 
-const TaskManagerToolbar = memo(() => {
+const Toolbar = memo(() => {
   const { t } = useTranslation('topic');
   const [topicPopoverOpen, setTopicPopoverOpen] = useState(false);
   const agentId = useConversationStore(conversationSelectors.agentId);
@@ -111,6 +111,6 @@ const TaskManagerToolbar = memo(() => {
   );
 });
 
-TaskManagerToolbar.displayName = 'TaskManagerToolbar';
+Toolbar.displayName = 'Toolbar';
 
-export default TaskManagerToolbar;
+export default Toolbar;

--- a/src/features/AgentTaskManager/index.tsx
+++ b/src/features/AgentTaskManager/index.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 
 import RightPanel from '@/features/RightPanel';
 
-import TaskManagerConversation from './TaskManagerConversation';
+import Conversation from './Conversation';
 
 /**
  * Tasks page right-side chat panel.
@@ -15,14 +15,14 @@ import TaskManagerConversation from './TaskManagerConversation';
  * The parent `_layout` sets `runtimePluginOverrides.forceActivated` on the
  * chat store so `lobe-task` is auto-activated for every LLM step here.
  */
-const TasksChatPanel = memo(() => {
+const AgentTaskManager = memo(() => {
   return (
     <RightPanel defaultWidth={420} maxWidth={720} minWidth={320}>
-      <TaskManagerConversation />
+      <Conversation />
     </RightPanel>
   );
 });
 
-TasksChatPanel.displayName = 'TasksChatPanel';
+AgentTaskManager.displayName = 'AgentTaskManager';
 
-export default TasksChatPanel;
+export default AgentTaskManager;

--- a/src/features/AgentTaskManager/index.tsx
+++ b/src/features/AgentTaskManager/index.tsx
@@ -12,8 +12,8 @@ import Conversation from './Conversation';
  * still read from `useChatStore.dbMessagesMap` via a distinct `messageMapKey`
  * derived from the isolated topic id.
  *
- * The parent `_layout` sets `runtimePluginOverrides.forceActivated` on the
- * chat store so `lobe-task` is auto-activated for every LLM step here.
+ * The parent `_layout` sets `scenarioEnabledToolIds` on the chat store so
+ * `lobe-task` is available for every LLM step here.
  */
 const AgentTaskManager = memo(() => {
   return (

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx
@@ -12,13 +12,13 @@ const TaskDetailRunPauseAction = memo(() => {
   const canRun = useTaskStore(taskDetailSelectors.canRunActiveTask);
   const canPause = useTaskStore(taskDetailSelectors.canPauseActiveTask);
   const runTask = useTaskStore((s) => s.runTask);
-  const pauseTask = useTaskStore((s) => s.pauseTask);
+  const updateTaskStatus = useTaskStore((s) => s.updateTaskStatus);
 
   const handleRunOrPause = useCallback(() => {
     if (!taskId) return;
     if (canRun) runTask(taskId);
-    else if (canPause) pauseTask(taskId);
-  }, [taskId, canRun, canPause, runTask, pauseTask]);
+    else if (canPause) updateTaskStatus(taskId, 'paused');
+  }, [taskId, canRun, canPause, runTask, updateTaskStatus]);
 
   if (!canRun && !canPause) return null;
 

--- a/src/features/AgentTasks/AgentTaskDetail/TaskInstruction.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskInstruction.tsx
@@ -30,7 +30,9 @@ const TaskInstruction = memo(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       const markdown = String(editor.getDocument('markdown') ?? '');
-      updateTask(taskId, { instruction: markdown });
+      updateTask(taskId, { instruction: markdown }).catch((e) => {
+        console.error('[TaskInstruction] Failed to save:', e);
+      });
     }, DEBOUNCE_MS);
   }, [editor, taskId, updateTask]);
 

--- a/src/features/AgentTasks/TaskManagerConversation.tsx
+++ b/src/features/AgentTasks/TaskManagerConversation.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { type ConversationContext } from '@lobechat/types';
+import { Flexbox, Text } from '@lobehub/ui';
+import debug from 'debug';
+import { memo, useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import DragUploadZone, { useUploadFiles } from '@/components/DragUploadZone';
+import { TopicTrigger } from '@/const/topic';
+import { actionMap } from '@/features/ChatInput/ActionBar/config';
+import { ActionBarContext } from '@/features/ChatInput/ActionBar/context';
+import CompactModelSelector from '@/features/ChatInput/CompactModelSelector';
+import {
+  COMPACT_ACTION_BAR_CONTEXT,
+  COMPACT_ACTION_BAR_STYLE,
+  COMPACT_SEND_BUTTON_PROPS,
+} from '@/features/ChatInput/compactPreset';
+import { ChatInput, ChatList, ConversationProvider } from '@/features/Conversation';
+import { type ConversationHooks } from '@/features/Conversation/types';
+import { useOperationState } from '@/hooks/useOperationState';
+import { useAgentStore } from '@/store/agent';
+import { agentByIdSelectors } from '@/store/agent/selectors';
+import { useChatStore } from '@/store/chat';
+import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+import { useTaskChatStore } from '@/store/taskChat';
+
+import TaskManagerToolbar from './TaskManagerToolbar';
+
+const log = debug('lobe-render:agent-tasks:TaskManagerConversation');
+
+const Search = actionMap['search'];
+
+const EMPTY_LEFT_ACTIONS: [] = [];
+
+const HOOKS: ConversationHooks = {
+  onTopicCreated: (topicId: string) => useTaskChatStore.getState().onTopicCreated(topicId),
+};
+
+const Welcome = memo(() => {
+  const { t } = useTranslation('topic');
+  return (
+    <Flexbox align={'center'} flex={1} justify={'center'} padding={24}>
+      <Text style={{ fontSize: 15 }} type={'secondary'}>
+        {t('taskManager.welcome')}
+      </Text>
+    </Flexbox>
+  );
+});
+
+Welcome.displayName = 'TaskManagerWelcome';
+
+const TaskManagerConversation = memo(() => {
+  const activeAgentId = useChatStore((s) => s.activeAgentId);
+  const taskTopicId = useTaskChatStore((s) => s.activeTopicId);
+
+  const model = useAgentStore((s) => agentByIdSelectors.getAgentModelById(activeAgentId)(s));
+  const provider = useAgentStore((s) =>
+    agentByIdSelectors.getAgentModelProviderById(activeAgentId)(s),
+  );
+  const { handleUploadFiles } = useUploadFiles({ model, provider });
+
+  // Reset task topic when the route agent changes so a stale topicId from
+  // the previous agent does not leak into this agent's messageMapKey.
+  useEffect(() => {
+    useTaskChatStore.getState().switchTopic(null);
+  }, [activeAgentId]);
+
+  const context = useMemo<ConversationContext>(
+    () => ({
+      agentId: activeAgentId,
+      isolatedTopic: true,
+      scope: 'main',
+      topicId: taskTopicId,
+      topicTrigger: TopicTrigger.TaskManager,
+    }),
+    [activeAgentId, taskTopicId],
+  );
+
+  const chatKey = messageMapKey(context);
+  const replaceMessages = useChatStore((s) => s.replaceMessages);
+  const messages = useChatStore((s) => s.dbMessagesMap[chatKey]);
+  log('contextKey %s: %o', chatKey, messages);
+
+  const operationState = useOperationState(context);
+
+  const leftContent = useMemo(
+    () => (
+      <ActionBarContext value={COMPACT_ACTION_BAR_CONTEXT}>
+        <Flexbox horizontal align={'center'} gap={2}>
+          <Search />
+        </Flexbox>
+      </ActionBarContext>
+    ),
+    [],
+  );
+
+  const modelSelector = useMemo(() => <CompactModelSelector />, []);
+
+  return (
+    <ConversationProvider
+      context={context}
+      hasInitMessages={!!messages}
+      hooks={HOOKS}
+      messages={messages}
+      operationState={operationState}
+      onMessagesChange={(msgs, ctx) => {
+        replaceMessages(msgs, { context: ctx });
+      }}
+    >
+      <DragUploadZone style={{ flex: 1, height: '100%' }} onUploadFiles={handleUploadFiles}>
+        <Flexbox flex={1} height={'100%'} style={{ overflow: 'hidden' }}>
+          <TaskManagerToolbar />
+          <Flexbox flex={1} style={{ overflow: 'hidden' }}>
+            <ChatList welcome={<Welcome />} />
+          </Flexbox>
+          <ChatInput
+            actionBarStyle={COMPACT_ACTION_BAR_STYLE}
+            allowExpand={false}
+            leftActions={EMPTY_LEFT_ACTIONS}
+            leftContent={leftContent}
+            sendAreaPrefix={modelSelector}
+            sendButtonProps={COMPACT_SEND_BUTTON_PROPS}
+            showRuntimeConfig={false}
+          />
+        </Flexbox>
+      </DragUploadZone>
+    </ConversationProvider>
+  );
+});
+
+TaskManagerConversation.displayName = 'TaskManagerConversation';
+
+export default TaskManagerConversation;

--- a/src/features/AgentTasks/TaskManagerConversation.tsx
+++ b/src/features/AgentTasks/TaskManagerConversation.tsx
@@ -10,7 +10,6 @@ import DragUploadZone, { useUploadFiles } from '@/components/DragUploadZone';
 import { TopicTrigger } from '@/const/topic';
 import { actionMap } from '@/features/ChatInput/ActionBar/config';
 import { ActionBarContext } from '@/features/ChatInput/ActionBar/context';
-import CompactModelSelector from '@/features/ChatInput/CompactModelSelector';
 import {
   COMPACT_ACTION_BAR_CONTEXT,
   COMPACT_ACTION_BAR_STYLE,
@@ -18,6 +17,7 @@ import {
 } from '@/features/ChatInput/compactPreset';
 import { ChatInput, ChatList, ConversationProvider } from '@/features/Conversation';
 import { type ConversationHooks } from '@/features/Conversation/types';
+import CopilotModelSelect from '@/features/PageEditor/Copilot/CopilotModelSelect';
 import { useOperationState } from '@/hooks/useOperationState';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
@@ -95,7 +95,7 @@ const TaskManagerConversation = memo(() => {
     [],
   );
 
-  const modelSelector = useMemo(() => <CompactModelSelector />, []);
+  const modelSelector = useMemo(() => <CopilotModelSelect />, []);
 
   return (
     <ConversationProvider

--- a/src/features/AgentTasks/TaskManagerToolbar.tsx
+++ b/src/features/AgentTasks/TaskManagerToolbar.tsx
@@ -1,0 +1,116 @@
+import { ActionIcon, Flexbox, Popover, Text } from '@lobehub/ui';
+import { Clock3Icon, PanelRightCloseIcon, PlusIcon } from 'lucide-react';
+import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
+import { TASK_MANAGER_INCLUDE_TRIGGERS } from '@/const/topic';
+import { conversationSelectors, useConversationStore } from '@/features/Conversation';
+import NavHeader from '@/features/NavHeader';
+import TopicItem from '@/features/PageEditor/Copilot/TopicSelector/TopicItem';
+import { useGlobalStore } from '@/store/global';
+import { useTaskChatStore } from '@/store/taskChat';
+
+const TaskManagerToolbar = memo(() => {
+  const { t } = useTranslation('topic');
+  const [topicPopoverOpen, setTopicPopoverOpen] = useState(false);
+  const agentId = useConversationStore(conversationSelectors.agentId);
+
+  useTaskChatStore((s) => s.useFetchTopics)(agentId, TASK_MANAGER_INCLUDE_TRIGGERS);
+
+  const [activeTopicId, switchTopic] = useTaskChatStore((s) => [s.activeTopicId, s.switchTopic]);
+  const topics = useTaskChatStore((s) => s.topics);
+
+  const toggleRightPanel = useGlobalStore((s) => s.toggleRightPanel);
+
+  const isLoadingTopics = topics === undefined;
+  const topicTitle = topics?.find((topic) => topic.id === activeTopicId)?.title || t('title');
+  const hasTopics = !!topics && topics.length > 0;
+
+  const handleCreate = () => {
+    switchTopic(null);
+  };
+
+  return (
+    <NavHeader
+      showTogglePanelButton={false}
+      left={
+        <Text
+          style={{ fontSize: 13, fontWeight: 500, marginLeft: 8 }}
+          type={'secondary'}
+          ellipsis={{
+            tooltipWhenOverflow: true,
+          }}
+        >
+          {topicTitle}
+        </Text>
+      }
+      right={
+        <>
+          <ActionIcon
+            icon={PlusIcon}
+            size={DESKTOP_HEADER_ICON_SIZE}
+            title={t('actions.addNewTopic')}
+            onClick={handleCreate}
+          />
+          <Popover
+            open={isLoadingTopics ? false : topicPopoverOpen}
+            placement="bottomRight"
+            trigger="click"
+            content={
+              hasTopics ? (
+                <Flexbox
+                  gap={4}
+                  padding={8}
+                  style={{
+                    maxHeight: '50vh',
+                    overflowY: 'auto',
+                    width: '100%',
+                  }}
+                >
+                  {topics!.map((topic) => (
+                    <TopicItem
+                      active={topic.id === activeTopicId}
+                      key={topic.id}
+                      topicId={topic.id}
+                      topicTitle={topic.title}
+                      onClose={() => setTopicPopoverOpen(false)}
+                      onTopicChange={(id) => switchTopic(id)}
+                    />
+                  ))}
+                </Flexbox>
+              ) : (
+                <Flexbox padding={16}>
+                  <Text type={'secondary'}>{t('temp')}</Text>
+                </Flexbox>
+              )
+            }
+            styles={{
+              content: {
+                padding: 0,
+                width: 240,
+              },
+            }}
+            onOpenChange={setTopicPopoverOpen}
+          >
+            <ActionIcon
+              disabled={isLoadingTopics}
+              icon={Clock3Icon}
+              loading={isLoadingTopics}
+              size={DESKTOP_HEADER_ICON_SIZE}
+            />
+          </Popover>
+          <ActionIcon
+            icon={PanelRightCloseIcon}
+            size={DESKTOP_HEADER_ICON_SIZE}
+            onClick={() => toggleRightPanel()}
+          />
+        </>
+      }
+    />
+  );
+});
+
+TaskManagerToolbar.displayName = 'TaskManagerToolbar';
+
+export default TaskManagerToolbar;

--- a/src/features/AgentTasks/TasksChatPanel.tsx
+++ b/src/features/AgentTasks/TasksChatPanel.tsx
@@ -1,26 +1,24 @@
 import { memo } from 'react';
 
 import RightPanel from '@/features/RightPanel';
-import ConversationArea from '@/routes/(main)/agent/features/Conversation/ConversationArea';
+
+import TaskManagerConversation from './TaskManagerConversation';
 
 /**
  * Tasks page right-side chat panel.
  *
- * Renders the main conversation (same agentId + activeTopicId as `/agent/:aid`)
- * inside a DraggablePanel, so users can chat with the agent while viewing
- * task list / task detail on the left.
+ * Holds its own `activeTopicId` in `useTaskChatStore` so switching a task
+ * topic here does not mutate the main chat's `activeTopicId`. Messages are
+ * still read from `useChatStore.dbMessagesMap` via a distinct `messageMapKey`
+ * derived from the isolated topic id.
  *
- * Context reuse: ConversationArea internally calls `useAgentContext()` which
- * reads `activeAgentId` / `activeTopicId` from chat store — the same values
- * the main chat page uses. No isolation scope.
- *
- * Tool activation: the parent `_layout` sets `runtimePluginOverrides.forceActivated`
- * on the chat store so `lobe-task` is auto-activated for every LLM step on tasks pages.
+ * The parent `_layout` sets `runtimePluginOverrides.forceActivated` on the
+ * chat store so `lobe-task` is auto-activated for every LLM step here.
  */
 const TasksChatPanel = memo(() => {
   return (
     <RightPanel defaultWidth={420} maxWidth={720} minWidth={320}>
-      <ConversationArea />
+      <TaskManagerConversation />
     </RightPanel>
   );
 });

--- a/src/features/AgentTasks/TasksChatPanel.tsx
+++ b/src/features/AgentTasks/TasksChatPanel.tsx
@@ -1,0 +1,30 @@
+import { memo } from 'react';
+
+import RightPanel from '@/features/RightPanel';
+import ConversationArea from '@/routes/(main)/agent/features/Conversation/ConversationArea';
+
+/**
+ * Tasks page right-side chat panel.
+ *
+ * Renders the main conversation (same agentId + activeTopicId as `/agent/:aid`)
+ * inside a DraggablePanel, so users can chat with the agent while viewing
+ * task list / task detail on the left.
+ *
+ * Context reuse: ConversationArea internally calls `useAgentContext()` which
+ * reads `activeAgentId` / `activeTopicId` from chat store — the same values
+ * the main chat page uses. No isolation scope.
+ *
+ * Tool activation: the parent `_layout` sets `runtimePluginOverrides.forceActivated`
+ * on the chat store so `lobe-task` is auto-activated for every LLM step on tasks pages.
+ */
+const TasksChatPanel = memo(() => {
+  return (
+    <RightPanel defaultWidth={420} maxWidth={720} minWidth={320}>
+      <ConversationArea />
+    </RightPanel>
+  );
+});
+
+TasksChatPanel.displayName = 'TasksChatPanel';
+
+export default TasksChatPanel;

--- a/src/features/AgentTasks/features/TaskStatusTag.tsx
+++ b/src/features/AgentTasks/features/TaskStatusTag.tsx
@@ -21,16 +21,47 @@ import { useTaskStore } from '@/store/task';
 interface StatusMeta {
   color: string;
   icon: LucideIcon;
+  label: string;
   labelKey: string;
 }
 
 const STATUS_META: Record<TaskStatus, StatusMeta> = {
-  backlog: { color: cssVar.colorTextQuaternary, icon: CircleDashed, labelKey: 'status.backlog' },
-  canceled: { color: cssVar.colorTextSecondary, icon: CircleSlash, labelKey: 'status.canceled' },
-  completed: { color: cssVar.colorSuccess, icon: CircleCheck, labelKey: 'status.completed' },
-  failed: { color: cssVar.colorError, icon: CircleX, labelKey: 'status.failed' },
-  paused: { color: cssVar.colorWarning, icon: CirclePause, labelKey: 'status.paused' },
-  running: { color: cssVar.colorInfo, icon: CircleDot, labelKey: 'status.running' },
+  backlog: {
+    color: cssVar.colorTextQuaternary,
+    icon: CircleDashed,
+    label: 'Backlog',
+    labelKey: 'status.backlog',
+  },
+  canceled: {
+    color: cssVar.colorTextSecondary,
+    icon: CircleSlash,
+    label: 'Canceled',
+    labelKey: 'status.canceled',
+  },
+  completed: {
+    color: cssVar.colorSuccess,
+    icon: CircleCheck,
+    label: 'Completed',
+    labelKey: 'status.completed',
+  },
+  failed: {
+    color: cssVar.colorError,
+    icon: CircleX,
+    label: 'Failed',
+    labelKey: 'status.failed',
+  },
+  paused: {
+    color: cssVar.colorWarning,
+    icon: CirclePause,
+    label: 'Paused',
+    labelKey: 'status.paused',
+  },
+  running: {
+    color: cssVar.colorInfo,
+    icon: CircleDot,
+    label: 'Running',
+    labelKey: 'status.running',
+  },
 };
 
 const USER_SELECTABLE_STATUSES: TaskStatus[] = ['backlog', 'completed', 'canceled'];
@@ -73,7 +104,7 @@ const TaskStatusTag = memo<TaskStatusTagProps>(
           return {
             icon: <Icon color={statusMeta.color} icon={statusMeta.icon} size={16} />,
             key,
-            label: t(`taskDetail.${statusMeta.labelKey}`, { defaultValue: '' }),
+            label: t(`taskDetail.${statusMeta.labelKey}`, { defaultValue: statusMeta.label }),
             onClick: ({ domEvent }) => {
               domEvent.stopPropagation();
               void handleStatusChange(key);
@@ -83,20 +114,20 @@ const TaskStatusTag = memo<TaskStatusTagProps>(
       [handleStatusChange, t],
     );
 
-    const triggerNode = children ? (
-      children
-    ) : loading ? (
-      <Icon spin color={cssVar.colorTextDescription} icon={Loader2Icon} size={size} />
-    ) : (
-      <Tooltip title={t(`taskDetail.${meta.labelKey}`, { defaultValue: '' })}>
-        <Icon
-          color={meta.color}
-          icon={meta.icon}
-          size={size}
-          onClick={(e) => e.stopPropagation()}
-        />
-      </Tooltip>
-    );
+    const triggerNode =
+      children ||
+      (loading ? (
+        <Icon spin color={cssVar.colorTextDescription} icon={Loader2Icon} size={size} />
+      ) : (
+        <Tooltip title={t(`taskDetail.${meta.labelKey}`, { defaultValue: meta.label })}>
+          <Icon
+            color={meta.color}
+            icon={meta.icon}
+            size={size}
+            onClick={(e) => e.stopPropagation()}
+          />
+        </Tooltip>
+      ));
 
     if (disableDropdown) return <>{triggerNode}</>;
 

--- a/src/features/AgentTasks/features/TaskStatusTag.tsx
+++ b/src/features/AgentTasks/features/TaskStatusTag.tsx
@@ -47,10 +47,7 @@ const TaskStatusTag = memo<TaskStatusTagProps>(
   ({ children, disableDropdown, size = 16, status, taskIdentifier }) => {
     const [loading, setLoading] = useState(false);
     const { t } = useTranslation('chat');
-    const cancelTask = useTaskStore((s) => s.cancelTask);
-    const completeTask = useTaskStore((s) => s.completeTask);
-    const refreshTaskList = useTaskStore((s) => s.refreshTaskList);
-    const resumeTask = useTaskStore((s) => s.resumeTask);
+    const updateTaskStatus = useTaskStore((s) => s.updateTaskStatus);
 
     const displayStatus = status ?? 'backlog';
     const meta = STATUS_META[displayStatus];
@@ -61,27 +58,12 @@ const TaskStatusTag = memo<TaskStatusTagProps>(
         setLoading(true);
 
         try {
-          switch (nextStatus) {
-            case 'backlog': {
-              await resumeTask(taskIdentifier);
-              break;
-            }
-            case 'canceled': {
-              await cancelTask(taskIdentifier);
-              break;
-            }
-            case 'completed': {
-              await completeTask(taskIdentifier);
-              break;
-            }
-          }
-
-          await refreshTaskList();
+          await updateTaskStatus(taskIdentifier, nextStatus);
         } finally {
           setLoading(false);
         }
       },
-      [cancelTask, completeTask, displayStatus, refreshTaskList, resumeTask, taskIdentifier],
+      [displayStatus, taskIdentifier, updateTaskStatus],
     );
 
     const menuItems = useMemo<MenuProps['items']>(

--- a/src/features/ChatInput/CompactModelSelector/index.tsx
+++ b/src/features/ChatInput/CompactModelSelector/index.tsx
@@ -36,7 +36,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-const CopilotModelSelector = memo(() => {
+const CompactModelSelector = memo(() => {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const agentId = useConversationStore(conversationSelectors.agentId);
 
@@ -95,6 +95,6 @@ const CopilotModelSelector = memo(() => {
   );
 });
 
-CopilotModelSelector.displayName = 'CopilotModelSelector';
+CompactModelSelector.displayName = 'CompactModelSelector';
 
-export default CopilotModelSelector;
+export default CompactModelSelector;

--- a/src/features/ChatInput/compactPreset.ts
+++ b/src/features/ChatInput/compactPreset.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared `<ChatInput/>` styling presets for compact right-side panels
+ * (Page Agent Copilot, Task Manager, ...) so they stay visually aligned.
+ */
+export const COMPACT_ACTION_SIZE = { blockSize: 28, size: 16 };
+export const COMPACT_ACTION_BAR_CONTEXT = { actionSize: COMPACT_ACTION_SIZE };
+export const COMPACT_ACTION_BAR_STYLE = { paddingLeft: 4, paddingRight: 4 };
+export const COMPACT_SEND_BUTTON_PROPS = { size: 28 };

--- a/src/features/Conversation/store/slices/message/action/sendMessage.ts
+++ b/src/features/Conversation/store/slices/message/action/sendMessage.ts
@@ -45,10 +45,15 @@ export const sendMessage = (
 
     // Forward to ChatStore.sendMessage with context and messages
     // Pass displayMessages to decouple sendMessage from store selectors
+    // `onTopicCreated` is invoked from inside ChatStore.sendMessage as soon as
+    // the backend reports a new topic id (only under isolatedTopic contexts),
+    // not here after the full streaming lifecycle — otherwise the isolated
+    // UI would not see the AI response while it is still streaming.
     const result = await chatStore.sendMessage({
       ...params,
       context,
       messages,
+      onTopicCreated: hooks.onTopicCreated,
     });
 
     // ===== Hook: onAfterMessageCreate =====

--- a/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
+++ b/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
@@ -72,7 +72,7 @@ describe('BriefCardActions', () => {
 
     // CommentInput replaces action buttons
     expect(screen.queryByText('Approve')).not.toBeInTheDocument();
-    expect(screen.getByText('Submit feedback')).toBeInTheDocument();
+    expect(screen.getByTitle('Submit feedback')).toBeInTheDocument();
     expect(screen.getByText('Cancel')).toBeInTheDocument();
   });
 

--- a/src/features/PageEditor/Copilot/Conversation.tsx
+++ b/src/features/PageEditor/Copilot/Conversation.tsx
@@ -5,7 +5,6 @@ import { memo, useCallback, useEffect, useMemo } from 'react';
 import DragUploadZone, { useUploadFiles } from '@/components/DragUploadZone';
 import { actionMap } from '@/features/ChatInput/ActionBar/config';
 import { ActionBarContext } from '@/features/ChatInput/ActionBar/context';
-import CompactModelSelector from '@/features/ChatInput/CompactModelSelector';
 import {
   COMPACT_ACTION_BAR_CONTEXT,
   COMPACT_ACTION_BAR_STYLE,
@@ -22,6 +21,7 @@ import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 
 import AgentSelectorAction from './AgentSelector/AgentSelectorAction';
+import CopilotModelSelect from './CopilotModelSelect';
 import CopilotToolbar from './Toolbar';
 import Welcome from './Welcome';
 
@@ -83,7 +83,7 @@ const Conversation = memo(() => {
     [handleAgentChange],
   );
 
-  const modelSelector = useMemo(() => <CompactModelSelector />, []);
+  const modelSelector = useMemo(() => <CopilotModelSelect />, []);
 
   return (
     <DragUploadZone

--- a/src/features/PageEditor/Copilot/Conversation.tsx
+++ b/src/features/PageEditor/Copilot/Conversation.tsx
@@ -5,6 +5,12 @@ import { memo, useCallback, useEffect, useMemo } from 'react';
 import DragUploadZone, { useUploadFiles } from '@/components/DragUploadZone';
 import { actionMap } from '@/features/ChatInput/ActionBar/config';
 import { ActionBarContext } from '@/features/ChatInput/ActionBar/context';
+import CompactModelSelector from '@/features/ChatInput/CompactModelSelector';
+import {
+  COMPACT_ACTION_BAR_CONTEXT,
+  COMPACT_ACTION_BAR_STYLE,
+  COMPACT_SEND_BUTTON_PROPS,
+} from '@/features/ChatInput/compactPreset';
 import {
   ChatInput,
   ChatList,
@@ -16,18 +22,12 @@ import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 
 import AgentSelectorAction from './AgentSelector/AgentSelectorAction';
-import CopilotModelSelector from './CopilotModelSelector';
 import CopilotToolbar from './Toolbar';
 import Welcome from './Welcome';
 
 const Search = actionMap['search'];
 
 const EMPTY_LEFT_ACTIONS: [] = [];
-
-const COMPACT_ACTION_SIZE = { blockSize: 28, size: 16 };
-const COMPACT_CONTEXT_VALUE = { actionSize: COMPACT_ACTION_SIZE };
-const COMPACT_ACTION_BAR_STYLE = { paddingLeft: 4, paddingRight: 4 };
-const COMPACT_SEND_BUTTON_PROPS = { size: 28 };
 
 const Conversation = memo(() => {
   const [setActiveAgentId, useFetchAgentConfig] = useAgentStore((s) => [
@@ -73,7 +73,7 @@ const Conversation = memo(() => {
 
   const leftContent = useMemo(
     () => (
-      <ActionBarContext value={COMPACT_CONTEXT_VALUE}>
+      <ActionBarContext value={COMPACT_ACTION_BAR_CONTEXT}>
         <Flexbox horizontal align={'center'} gap={2}>
           <AgentSelectorAction onAgentChange={handleAgentChange} />
           <Search />
@@ -83,7 +83,7 @@ const Conversation = memo(() => {
     [handleAgentChange],
   );
 
-  const modelSelector = useMemo(() => <CopilotModelSelector />, []);
+  const modelSelector = useMemo(() => <CompactModelSelector />, []);
 
   return (
     <DragUploadZone

--- a/src/features/PageEditor/Copilot/CopilotModelSelect.tsx
+++ b/src/features/PageEditor/Copilot/CopilotModelSelect.tsx
@@ -36,7 +36,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-const CompactModelSelector = memo(() => {
+const CopilotModelSelect = memo(() => {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const agentId = useConversationStore(conversationSelectors.agentId);
 
@@ -95,6 +95,6 @@ const CompactModelSelector = memo(() => {
   );
 });
 
-CompactModelSelector.displayName = 'CompactModelSelector';
+CopilotModelSelect.displayName = 'CopilotModelSelect';
 
-export default CompactModelSelector;
+export default CopilotModelSelect;

--- a/src/features/PageEditor/Copilot/TopicSelector/TopicItem.tsx
+++ b/src/features/PageEditor/Copilot/TopicSelector/TopicItem.tsx
@@ -9,17 +9,19 @@ import { useDropdownMenu } from './useDropdownMenu';
 interface TopicItemProps {
   active: boolean;
   onClose: () => void;
+  onDelete?: (topicId: string) => void;
   onTopicChange: (topicId: string) => void;
   topicId: string;
   topicTitle: string;
 }
 
 const TopicItem = memo<TopicItemProps>(
-  ({ active, onClose, onTopicChange, topicId, topicTitle }) => {
+  ({ active, onClose, onDelete, onTopicChange, topicId, topicTitle }) => {
     const { t } = useTranslation('topic');
 
     const dropdownMenu = useDropdownMenu({
       onClose,
+      onDelete,
       topicId,
       topicTitle,
     });

--- a/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx
+++ b/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx
@@ -9,32 +9,19 @@ import { useChatStore } from '@/store/chat';
 
 interface UseDropdownMenuProps {
   onClose: () => void;
+  onDelete?: (topicId: string) => void;
   topicId: string;
   topicTitle: string;
 }
 
 export const useDropdownMenu = ({
   onClose,
+  onDelete,
   topicId,
 }: UseDropdownMenuProps): (() => MenuProps['items']) => {
   const { t } = useTranslation(['common', 'topic']);
   const { modal } = App.useApp();
   const removeTopic = useChatStore((s) => s.removeTopic);
-
-  const handleDelete = () => {
-    modal.confirm({
-      cancelText: t('cancel'),
-      centered: true,
-      content: t('actions.confirmRemoveTopic', { ns: 'topic' }),
-      okButtonProps: { danger: true },
-      okText: t('delete'),
-      onOk: async () => {
-        await removeTopic(topicId);
-        onClose();
-      },
-      title: t('delete'),
-    });
-  };
 
   return useCallback(
     () =>
@@ -44,9 +31,23 @@ export const useDropdownMenu = ({
           icon: <Icon icon={Trash2} />,
           key: 'delete',
           label: t('delete'),
-          onClick: handleDelete,
+          onClick: () => {
+            modal.confirm({
+              cancelText: t('cancel'),
+              centered: true,
+              content: t('actions.confirmRemoveTopic', { ns: 'topic' }),
+              okButtonProps: { danger: true },
+              okText: t('delete'),
+              onOk: async () => {
+                await removeTopic(topicId);
+                onDelete?.(topicId);
+                onClose();
+              },
+              title: t('delete'),
+            });
+          },
         },
       ].filter(Boolean) as MenuProps['items'],
-    [t, handleDelete],
+    [t, modal, removeTopic, topicId, onDelete, onClose],
   );
 };

--- a/src/helpers/toolEngineering/index.ts
+++ b/src/helpers/toolEngineering/index.ts
@@ -14,6 +14,7 @@ import { type ChatCompletionTool, type ToolManifest, type WorkingModel } from '@
 import { isToolAvailableInCurrentEnv } from '@/helpers/toolAvailability';
 import { getAgentStoreState } from '@/store/agent';
 import { agentChatConfigSelectors, agentSelectors } from '@/store/agent/selectors';
+import { getChatStoreState } from '@/store/chat';
 import { getToolStoreState } from '@/store/tool';
 import {
   klavisStoreSelectors,
@@ -125,6 +126,11 @@ export const createAgentToolsEngine = (
   const searchConfig = getSearchConfig(workingModel.model, workingModel.provider);
   const agentState = getAgentStoreState();
   const userPlugins = agentSelectors.currentAgentPlugins(agentState);
+  // Page-level force-activated tool ids (e.g. tasks page forces `lobe-task`).
+  // Set by page layouts via `useChatStore.setState({ runtimePluginOverrides })`,
+  // cleared on unmount. Only effective when the id is also in `defaultToolIds`
+  // or `pluginIds` — rules only apply to tools that reach the candidate pool.
+  const forceActivatedToolIds = getChatStoreState().runtimePluginOverrides?.forceActivated ?? [];
 
   return createToolsEngine({
     defaultToolIds,
@@ -152,6 +158,8 @@ export const createAgentToolsEngine = (
         ...Object.fromEntries(userPlugins.map((id) => [id, true])),
         // Always-on builtin tools
         ...Object.fromEntries(alwaysOnToolIds.map((id) => [id, true])),
+        // Page-level force-activated tools (e.g. tasks page forces `lobe-task`)
+        ...Object.fromEntries(forceActivatedToolIds.map((id) => [id, true])),
         // System-level rules (may override user selection for specific tools)
         [CloudSandboxManifest.identifier]:
           agentChatConfigSelectors.isCloudSandboxEnabled(agentState),

--- a/src/helpers/toolEngineering/index.ts
+++ b/src/helpers/toolEngineering/index.ts
@@ -126,11 +126,11 @@ export const createAgentToolsEngine = (
   const searchConfig = getSearchConfig(workingModel.model, workingModel.provider);
   const agentState = getAgentStoreState();
   const userPlugins = agentSelectors.currentAgentPlugins(agentState);
-  // Page-level force-activated tool ids (e.g. tasks page forces `lobe-task`).
-  // Set by page layouts via `useChatStore.setState({ runtimePluginOverrides })`,
+  // Page-level scenario-enabled tool ids (e.g. tasks page enables `lobe-task`).
+  // Set by page layouts via `useChatStore.setState({ scenarioEnabledToolIds })`,
   // cleared on unmount. Only effective when the id is also in `defaultToolIds`
   // or `pluginIds` — rules only apply to tools that reach the candidate pool.
-  const forceActivatedToolIds = getChatStoreState().runtimePluginOverrides?.forceActivated ?? [];
+  const scenarioEnabledToolIds = getChatStoreState().scenarioEnabledToolIds ?? [];
 
   return createToolsEngine({
     defaultToolIds,
@@ -158,8 +158,8 @@ export const createAgentToolsEngine = (
         ...Object.fromEntries(userPlugins.map((id) => [id, true])),
         // Always-on builtin tools
         ...Object.fromEntries(alwaysOnToolIds.map((id) => [id, true])),
-        // Page-level force-activated tools (e.g. tasks page forces `lobe-task`)
-        ...Object.fromEntries(forceActivatedToolIds.map((id) => [id, true])),
+        // Page-level scenario-enabled tools (e.g. tasks page enables `lobe-task`)
+        ...Object.fromEntries(scenarioEnabledToolIds.map((id) => [id, true])),
         // System-level rules (may override user selection for specific tools)
         [CloudSandboxManifest.identifier]:
           agentChatConfigSelectors.isCloudSandboxEnabled(agentState),

--- a/src/locales/default/topic.ts
+++ b/src/locales/default/topic.ts
@@ -38,6 +38,7 @@ export default {
   'loadMore': 'Load More',
   'searchPlaceholder': 'Search Topics...',
   'searchResultEmpty': 'No search results found.',
+  'taskManager.welcome': 'Ask me about your tasks',
   'temp': 'Temporary',
   'title': 'Topic',
 };

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/index.tsx
@@ -4,6 +4,7 @@ import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { MAIN_SIDEBAR_EXCLUDE_TRIGGERS } from '@/const/topic';
 import EmptyNavItem from '@/features/NavPanel/components/EmptyNavItem';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import { useFetchTopics } from '@/hooks/useFetchTopics';
@@ -18,7 +19,7 @@ import AllTopicsDrawer from '../AllTopicsDrawer';
 import ByTimeMode from '../TopicListContent/ByTimeMode';
 import FlatMode from '../TopicListContent/FlatMode';
 
-const fetchParams = { excludeTriggers: ['cron', 'eval'] };
+const fetchParams = { excludeTriggers: MAIN_SIDEBAR_EXCLUDE_TRIGGERS };
 
 const TopicList = memo(() => {
   const { t } = useTranslation('topic');

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/index.tsx
@@ -4,6 +4,7 @@ import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { MAIN_SIDEBAR_EXCLUDE_TRIGGERS } from '@/const/topic';
 import EmptyNavItem from '@/features/NavPanel/components/EmptyNavItem';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import { useFetchTopics } from '@/hooks/useFetchTopics';
@@ -18,6 +19,8 @@ import ByTimeMode from './ByTimeMode';
 import FlatMode from './FlatMode';
 import SearchResult from './SearchResult';
 
+const fetchParams = { excludeTriggers: MAIN_SIDEBAR_EXCLUDE_TRIGGERS };
+
 const TopicListContent = memo(() => {
   const { t } = useTranslation('topic');
   const router = useQueryRoute();
@@ -30,7 +33,7 @@ const TopicListContent = memo(() => {
 
   const [topicDisplayMode] = useUserStore((s) => [preferenceSelectors.topicDisplayMode(s)]);
 
-  useFetchTopics({ excludeTriggers: ['cron', 'eval'] });
+  useFetchTopics(fetchParams);
 
   if (isInSearchMode) return <SearchResult />;
 

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/index.tsx
@@ -5,6 +5,7 @@ import React, { memo, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
+import { MAIN_SIDEBAR_EXCLUDE_TRIGGERS } from '@/const/topic';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import { useFetchTopics } from '@/hooks/useFetchTopics';
 import { useChatStore } from '@/store/chat';
@@ -18,11 +19,13 @@ interface TopicProps {
   itemKey: string;
 }
 
+const fetchParams = { excludeTriggers: MAIN_SIDEBAR_EXCLUDE_TRIGGERS };
+
 const Topic = memo<TopicProps>(({ itemKey }) => {
   const { t } = useTranslation(['topic', 'common']);
   const [topicCount] = useChatStore((s) => [topicSelectors.currentTopicCount(s)]);
   const dropdownMenu = useTopicActionsDropdownMenu();
-  const { isRevalidating } = useFetchTopics({ excludeTriggers: ['cron', 'eval'] });
+  const { isRevalidating } = useFetchTopics(fetchParams);
 
   return (
     <AccordionItem

--- a/src/routes/(main)/agent/tasks/_layout/index.tsx
+++ b/src/routes/(main)/agent/tasks/_layout/index.tsx
@@ -5,7 +5,7 @@ import { Flexbox } from '@lobehub/ui';
 import { memo, useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 
-import TasksChatPanel from '@/features/AgentTasks/TasksChatPanel';
+import AgentTaskManager from '@/features/AgentTaskManager';
 import { useChatStore } from '@/store/chat';
 
 /**
@@ -35,7 +35,7 @@ const TasksLayout = memo(() => {
       <Flexbox flex={1} style={{ minWidth: 0 }}>
         <Outlet />
       </Flexbox>
-      <TasksChatPanel />
+      <AgentTaskManager />
     </Flexbox>
   );
 });

--- a/src/routes/(main)/agent/tasks/_layout/index.tsx
+++ b/src/routes/(main)/agent/tasks/_layout/index.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { TaskIdentifier } from '@lobechat/builtin-tool-task';
+import { Flexbox } from '@lobehub/ui';
+import { memo, useEffect } from 'react';
+import { Outlet } from 'react-router-dom';
+
+import TasksChatPanel from '@/features/AgentTasks/TasksChatPanel';
+import { useChatStore } from '@/store/chat';
+
+/**
+ * Tasks pages layout.
+ *
+ * - Horizontal split: task content on the left (list / detail), main-conversation
+ *   chat panel on the right. Right panel reuses the same agentId + activeTopicId
+ *   as the `/agent/:aid` page via `useAgentContext()` inside ConversationArea.
+ *
+ * - Force-activates `lobe-task` for every LLM step while the user is on any tasks
+ *   sub-page. Uses `runtimePluginOverrides.forceActivated` which streamingExecutor
+ *   merges into `stepContext.activatedToolIds`, so createAgentExecutors bypasses
+ *   enableChecker rules via `isExplicitActivation`.
+ */
+const TasksLayout = memo(() => {
+  useEffect(() => {
+    useChatStore.setState({
+      runtimePluginOverrides: { forceActivated: [TaskIdentifier] },
+    });
+    return () => {
+      useChatStore.setState({ runtimePluginOverrides: undefined });
+    };
+  }, []);
+
+  return (
+    <Flexbox horizontal flex={1} height={'100%'} width={'100%'}>
+      <Flexbox flex={1} style={{ minWidth: 0 }}>
+        <Outlet />
+      </Flexbox>
+      <TasksChatPanel />
+    </Flexbox>
+  );
+});
+
+TasksLayout.displayName = 'TasksLayout';
+
+export default TasksLayout;

--- a/src/routes/(main)/agent/tasks/_layout/index.tsx
+++ b/src/routes/(main)/agent/tasks/_layout/index.tsx
@@ -15,18 +15,16 @@ import { useChatStore } from '@/store/chat';
  *   chat panel on the right. Right panel reuses the same agentId + activeTopicId
  *   as the `/agent/:aid` page via `useAgentContext()` inside ConversationArea.
  *
- * - Force-activates `lobe-task` for every LLM step while the user is on any tasks
- *   sub-page. Uses `runtimePluginOverrides.forceActivated` which streamingExecutor
- *   merges into `stepContext.activatedToolIds`, so createAgentExecutors bypasses
- *   enableChecker rules via `isExplicitActivation`.
+ * - Enables `lobe-task` for every LLM step while the user is on any tasks
+ *   sub-page via the page-level `scenarioEnabledToolIds` chat state.
  */
 const TasksLayout = memo(() => {
   useEffect(() => {
     useChatStore.setState({
-      runtimePluginOverrides: { forceActivated: [TaskIdentifier] },
+      scenarioEnabledToolIds: [TaskIdentifier],
     });
     return () => {
-      useChatStore.setState({ runtimePluginOverrides: undefined });
+      useChatStore.setState({ scenarioEnabledToolIds: undefined });
     };
   }, []);
 

--- a/src/server/routers/lambda/aiChat.ts
+++ b/src/server/routers/lambda/aiChat.ts
@@ -87,6 +87,7 @@ export const aiChatRouter = router({
           messages: input.newTopic.topicMessageIds,
           sessionId,
           title: input.newTopic.title,
+          trigger: input.newTopic.trigger,
         });
         topicId = topicItem.id;
         isCreateNewTopic = true;

--- a/src/server/routers/lambda/task.ts
+++ b/src/server/routers/lambda/task.ts
@@ -61,7 +61,7 @@ const updateSchema = z.object({
   config: z.record(z.unknown()).optional(),
   context: z.record(z.unknown()).optional(),
   description: z.string().optional(),
-  heartbeatInterval: z.number().min(1).optional(),
+  heartbeatInterval: z.number().min(0).optional(),
   heartbeatTimeout: z.number().min(1).nullable().optional(),
   instruction: z.string().optional(),
   name: z.string().optional(),

--- a/src/server/routers/lambda/task.ts
+++ b/src/server/routers/lambda/task.ts
@@ -1258,12 +1258,19 @@ export const taskRouter = router({
       z.object({
         error: z.string().optional(),
         id: z.string(),
-        status: z.enum(['backlog', 'running', 'paused', 'completed', 'failed', 'canceled']),
+        status: z.enum(TASK_STATUSES),
       }),
     )
     .mutation(async ({ input, ctx }) => {
       const { id, status, error: errorMsg } = input;
       try {
+        if (errorMsg && status !== 'failed') {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Task error can only be provided when status is failed.',
+          });
+        }
+
         const model = ctx.taskModel;
         const resolved = await resolveOrThrow(model, id);
 

--- a/src/server/routers/lambda/task.ts
+++ b/src/server/routers/lambda/task.ts
@@ -72,7 +72,8 @@ const listSchema = z.object({
   limit: z.number().min(1).max(100).default(50),
   offset: z.number().min(0).default(0),
   parentTaskId: z.string().nullable().optional(),
-  status: z.string().optional(),
+  priorities: z.array(z.number().min(0).max(4)).min(1).max(5).optional(),
+  statuses: z.array(z.string()).min(1).max(10).optional(),
 });
 
 const groupListSchema = z.object({

--- a/src/server/routers/lambda/task.ts
+++ b/src/server/routers/lambda/task.ts
@@ -498,7 +498,7 @@ export const taskRouter = router({
       const model = ctx.taskModel;
       const task = await resolveOrThrow(model, input.id);
       await model.delete(task.id);
-      return { message: 'Task deleted', success: true };
+      return { data: task, message: 'Task deleted', success: true };
     } catch (error) {
       if (error instanceof TRPCError) throw error;
       console.error('[task:delete]', error);

--- a/src/server/routers/lambda/task.ts
+++ b/src/server/routers/lambda/task.ts
@@ -514,25 +514,7 @@ export const taskRouter = router({
 
   detail: taskProcedure.input(idInput).query(async ({ input, ctx }) => {
     try {
-      const model = ctx.taskModel;
-      let task = await resolveOrThrow(model, input.id);
-
-      // Auto-detect heartbeat timeout for running tasks
-      if (task.status === 'running' && task.heartbeatTimeout && task.lastHeartbeatAt) {
-        const elapsed = (Date.now() - new Date(task.lastHeartbeatAt).getTime()) / 1000;
-        if (elapsed > task.heartbeatTimeout) {
-          await model.updateStatus(task.id, 'paused', { error: 'Heartbeat timeout' });
-          await ctx.taskTopicModel.timeoutRunning(task.id);
-          task = await resolveOrThrow(model, input.id);
-        }
-      }
-
-      // Clear stale heartbeat timeout error if task is no longer running
-      if (task.status !== 'running' && task.error === 'Heartbeat timeout') {
-        await model.update(task.id, { error: null });
-      }
-
-      const detail = await ctx.taskService.getTaskDetail(task.identifier);
+      const detail = await ctx.taskService.getTaskDetail(input.id);
       if (!detail) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Task not found' });
       }

--- a/src/server/routers/lambda/task.ts
+++ b/src/server/routers/lambda/task.ts
@@ -72,6 +72,7 @@ const listSchema = z.object({
   assigneeAgentId: z.string().optional(),
   limit: z.number().min(1).max(100).default(50),
   offset: z.number().min(0).default(0),
+  parentIdentifier: z.string().optional(),
   parentTaskId: z.string().nullable().optional(),
   priorities: z.array(z.number().min(0).max(4)).min(1).max(5).optional(),
   statuses: z.array(z.enum(TASK_STATUSES)).min(1).max(10).optional(),
@@ -729,7 +730,25 @@ export const taskRouter = router({
   list: taskProcedure.input(listSchema).query(async ({ input, ctx }) => {
     try {
       const model = ctx.taskModel;
-      const result = await model.list(input);
+      const { parentIdentifier, ...query } = input;
+      let parentTaskId = query.parentTaskId;
+
+      if (parentIdentifier) {
+        const parent = await model.resolve(parentIdentifier);
+        if (!parent) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: `Parent task not found: ${parentIdentifier}`,
+          });
+        }
+
+        parentTaskId = parent.id;
+      }
+
+      const result = await model.list({
+        ...query,
+        parentTaskId,
+      });
 
       const assigneeIds = [
         ...new Set(result.tasks.map((t) => t.assigneeAgentId).filter((id): id is string => !!id)),
@@ -757,6 +776,7 @@ export const taskRouter = router({
 
       return { data, success: true, total: result.total };
     } catch (error) {
+      if (error instanceof TRPCError) throw error;
       console.error('[task:list]', error);
       throw new TRPCError({
         cause: error,

--- a/src/server/routers/lambda/task.ts
+++ b/src/server/routers/lambda/task.ts
@@ -1,6 +1,7 @@
 import { TaskIdentifier as TaskSkillIdentifier } from '@lobechat/builtin-skills';
 import { BriefIdentifier } from '@lobechat/builtin-tool-brief';
 import { NotebookIdentifier } from '@lobechat/builtin-tool-notebook';
+import { TASK_STATUSES } from '@lobechat/builtin-tool-task';
 import { buildTaskRunPrompt } from '@lobechat/prompts';
 import type {
   TaskListItem,
@@ -73,7 +74,7 @@ const listSchema = z.object({
   offset: z.number().min(0).default(0),
   parentTaskId: z.string().nullable().optional(),
   priorities: z.array(z.number().min(0).max(4)).min(1).max(5).optional(),
-  statuses: z.array(z.string()).min(1).max(10).optional(),
+  statuses: z.array(z.enum(TASK_STATUSES)).min(1).max(10).optional(),
 });
 
 const groupListSchema = z.object({

--- a/src/server/routers/lambda/task.ts
+++ b/src/server/routers/lambda/task.ts
@@ -74,8 +74,8 @@ const listSchema = z.object({
   offset: z.number().min(0).default(0),
   parentIdentifier: z.string().optional(),
   parentTaskId: z.string().nullable().optional(),
-  priorities: z.array(z.number().min(0).max(4)).min(1).max(5).optional(),
-  statuses: z.array(z.enum(TASK_STATUSES)).min(1).max(10).optional(),
+  priorities: z.array(z.number().min(0).max(4)).max(5).optional(),
+  statuses: z.array(z.enum(TASK_STATUSES)).max(10).optional(),
 });
 
 const groupListSchema = z.object({

--- a/src/server/routers/lambda/topic.ts
+++ b/src/server/routers/lambda/topic.ts
@@ -174,6 +174,7 @@ export const topicRouter = router({
           groupId: z.string().nullable().optional(),
           messages: z.array(z.string()).optional(),
           title: z.string(),
+          trigger: z.string().optional(),
         })
         .extend(basicContextSchema.shape),
     )
@@ -236,17 +237,23 @@ export const topicRouter = router({
         current: z.number().optional(),
         excludeTriggers: z.array(z.string()).optional(),
         groupId: z.string().nullable().optional(),
+        includeTriggers: z.array(z.string()).optional(),
         isInbox: z.boolean().optional(),
         pageSize: z.number().optional(),
         sessionId: z.string().nullable().optional(),
       }),
     )
     .query(async ({ input, ctx }) => {
-      const { sessionId, isInbox, groupId, excludeTriggers, ...rest } = input;
+      const { sessionId, isInbox, groupId, excludeTriggers, includeTriggers, ...rest } = input;
 
       // If groupId is provided, query by groupId directly
       if (groupId) {
-        const result = await ctx.topicModel.query({ excludeTriggers, groupId, ...rest });
+        const result = await ctx.topicModel.query({
+          excludeTriggers,
+          groupId,
+          includeTriggers,
+          ...rest,
+        });
         return { items: result.items, total: result.total };
       }
 
@@ -260,6 +267,7 @@ export const topicRouter = router({
         ...rest,
         agentId: effectiveAgentId,
         excludeTriggers,
+        includeTriggers,
         isInbox,
       });
 

--- a/src/server/services/task/index.test.ts
+++ b/src/server/services/task/index.test.ts
@@ -49,10 +49,13 @@ describe('TaskService', () => {
     getReviewConfig: vi.fn(),
     getTreePinnedDocuments: vi.fn(),
     resolve: vi.fn(),
+    update: vi.fn(),
+    updateStatus: vi.fn(),
   };
 
   const mockTaskTopicModel = {
     findWithHandoff: vi.fn(),
+    timeoutRunning: vi.fn(),
   };
 
   const mockBriefModel = {

--- a/src/server/services/task/index.ts
+++ b/src/server/services/task/index.ts
@@ -33,8 +33,25 @@ export class TaskService {
   }
 
   async getTaskDetail(taskIdOrIdentifier: string): Promise<TaskDetailData | null> {
-    const task = await this.taskModel.resolve(taskIdOrIdentifier);
+    let task = await this.taskModel.resolve(taskIdOrIdentifier);
     if (!task) return null;
+
+    // Auto-detect heartbeat timeout for running tasks before assembling detail.
+    if (task.status === 'running' && task.heartbeatTimeout && task.lastHeartbeatAt) {
+      const elapsed = (Date.now() - new Date(task.lastHeartbeatAt).getTime()) / 1000;
+      if (elapsed > task.heartbeatTimeout) {
+        await this.taskModel.updateStatus(task.id, 'paused', { error: 'Heartbeat timeout' });
+        await this.taskTopicModel.timeoutRunning(task.id);
+        task = await this.taskModel.resolve(taskIdOrIdentifier);
+        if (!task) return null;
+      }
+    }
+
+    // Clear stale heartbeat timeout error once the task is no longer running.
+    if (task.status !== 'running' && task.error === 'Heartbeat timeout') {
+      await this.taskModel.update(task.id, { error: null });
+      task = { ...task, error: null };
+    }
 
     const [allDescendants, dependencies, topics, briefs, comments, workspace] = await Promise.all([
       this.taskModel.findAllDescendants(task.id),

--- a/src/server/services/toolExecution/serverRuntimes/task.ts
+++ b/src/server/services/toolExecution/serverRuntimes/task.ts
@@ -1,4 +1,4 @@
-import { TaskIdentifier } from '@lobechat/builtin-tool-task';
+import { TaskIdentifier, UNFINISHED_TASK_STATUSES } from '@lobechat/builtin-tool-task';
 import {
   formatDependencyAdded,
   formatDependencyRemoved,
@@ -15,10 +15,12 @@ import { TaskService } from '@/server/services/task';
 import { type ServerRuntimeRegistration } from './types';
 
 const createTaskRuntime = ({
+  agentId,
   taskId,
   taskModel,
   taskService,
 }: {
+  agentId?: string;
   taskId?: string;
   taskModel: TaskModel;
   taskService: TaskService;
@@ -157,30 +159,51 @@ const createTaskRuntime = ({
     return { content: formatTaskEdited(task.identifier, changes), success: true };
   },
 
-  listTasks: async (args: { parentIdentifier?: string; status?: string }) => {
-    let parentId: string | undefined;
-    let parentLabel = 'current task';
-
+  listTasks: async (args: {
+    assigneeAgentId?: string;
+    limit?: number;
+    offset?: number;
+    parentIdentifier?: string;
+    priorities?: number[];
+    statuses?: string[];
+  }) => {
+    let parentTaskId: string | null | undefined;
     if (args.parentIdentifier) {
       const parent = await taskModel.resolve(args.parentIdentifier);
       if (!parent)
         return { content: `Parent task not found: ${args.parentIdentifier}`, success: false };
-      parentId = parent.id;
-      parentLabel = parent.identifier;
-    } else {
-      parentId = taskId;
+      parentTaskId = parent.id;
     }
 
-    if (!parentId) return { content: 'No task context available.', success: false };
+    const noFilters =
+      !args.parentIdentifier &&
+      !args.statuses?.length &&
+      !args.priorities?.length &&
+      !args.assigneeAgentId;
 
-    const subtasks = await taskModel.findSubtasks(parentId);
-    let filtered = subtasks;
-    if (args.status) {
-      filtered = subtasks.filter((t) => t.status === args.status);
-    }
+    const limit = Math.min(args.limit ?? 20, 100);
+
+    const resolvedStatuses =
+      args.statuses ?? (noFilters ? [...UNFINISHED_TASK_STATUSES] : undefined);
+    const resolvedAgentId = args.assigneeAgentId ?? (noFilters ? agentId : undefined);
+    const resolvedParentTaskId = parentTaskId ?? (noFilters ? null : undefined);
+
+    const result = await taskModel.list({
+      assigneeAgentId: resolvedAgentId,
+      limit,
+      offset: args.offset ?? 0,
+      parentTaskId: resolvedParentTaskId,
+      priorities: args.priorities,
+      statuses: resolvedStatuses,
+    });
 
     return {
-      content: formatTaskList(filtered, parentLabel, args.status),
+      content: formatTaskList(result.tasks, {
+        assigneeAgentId: args.assigneeAgentId,
+        parentIdentifier: args.parentIdentifier,
+        priorities: args.priorities,
+        statuses: args.statuses,
+      }),
       success: true,
     };
   },
@@ -234,7 +257,12 @@ export const taskRuntime: ServerRuntimeRegistration = {
     const taskModel = new TaskModel(context.serverDB, context.userId);
     const taskService = new TaskService(context.serverDB, context.userId);
 
-    return createTaskRuntime({ taskId: context.taskId, taskModel, taskService });
+    return createTaskRuntime({
+      agentId: context.agentId,
+      taskId: context.taskId,
+      taskModel,
+      taskService,
+    });
   },
   identifier: TaskIdentifier,
 };

--- a/src/server/services/toolExecution/serverRuntimes/task.ts
+++ b/src/server/services/toolExecution/serverRuntimes/task.ts
@@ -3,6 +3,7 @@ import {
   formatDependencyAdded,
   formatDependencyRemoved,
   formatTaskCreated,
+  formatTaskDeleted,
   formatTaskDetail,
   formatTaskEdited,
   formatTaskList,
@@ -89,7 +90,7 @@ const createTaskRuntime = ({
     await taskModel.delete(task.id);
 
     return {
-      content: `Task ${task.identifier} "${task.name || ''}" has been deleted.`,
+      content: formatTaskDeleted(task.identifier, task.name),
       success: true,
     };
   },

--- a/src/server/services/toolExecution/serverRuntimes/task.ts
+++ b/src/server/services/toolExecution/serverRuntimes/task.ts
@@ -49,11 +49,6 @@ const createTaskRuntime = ({
       parentTaskId = parent.id;
       parentLabel = parent.identifier;
       parentConfig = parent.config as Record<string, any>;
-    } else if (taskId) {
-      parentTaskId = taskId;
-      const current = await taskModel.findById(taskId);
-      parentLabel = current?.identifier || taskId;
-      parentConfig = current?.config as Record<string, any>;
     }
 
     // Build config: explicit review > inherited from parent
@@ -66,6 +61,7 @@ const createTaskRuntime = ({
 
     const task = await taskModel.create({
       ...(config && { config }),
+      assigneeAgentId: agentId,
       instruction: args.instruction,
       name: args.name,
       parentTaskId,

--- a/src/server/services/toolExecution/serverRuntimes/task.ts
+++ b/src/server/services/toolExecution/serverRuntimes/task.ts
@@ -32,16 +32,9 @@ const createTaskRuntime = ({
     parentIdentifier?: string;
     priority?: number;
     sortOrder?: number;
-    review?: {
-      autoRetry?: boolean;
-      criteria?: Array<{ name: string; threshold: number }>;
-      enabled?: boolean;
-      maxIterations?: number;
-    };
   }) => {
     let parentTaskId: string | undefined;
     let parentLabel: string | undefined;
-    let parentConfig: Record<string, any> | undefined;
 
     if (args.parentIdentifier) {
       const parent = await taskModel.resolve(args.parentIdentifier);
@@ -49,19 +42,9 @@ const createTaskRuntime = ({
         return { content: `Parent task not found: ${args.parentIdentifier}`, success: false };
       parentTaskId = parent.id;
       parentLabel = parent.identifier;
-      parentConfig = parent.config as Record<string, any>;
-    }
-
-    // Build config: explicit review > inherited from parent
-    let config: Record<string, any> | undefined;
-    if (args.review) {
-      config = { review: { enabled: true, ...args.review } };
-    } else if (parentConfig?.review) {
-      config = { review: parentConfig.review };
     }
 
     const task = await taskModel.create({
-      ...(config && { config }),
       assigneeAgentId: agentId,
       instruction: args.instruction,
       name: args.name,
@@ -103,12 +86,6 @@ const createTaskRuntime = ({
     name?: string;
     priority?: number;
     removeDependencies?: string[];
-    review?: {
-      autoRetry?: boolean;
-      criteria?: Array<{ name: string; threshold: number }>;
-      enabled?: boolean;
-      maxIterations?: number;
-    };
   }) => {
     const task = await taskModel.resolve(args.identifier);
     if (!task) return { content: `Task not found: ${args.identifier}`, success: false };
@@ -136,12 +113,6 @@ const createTaskRuntime = ({
 
     if (Object.keys(updateData).length > 0) {
       ops.push(taskModel.update(task.id, updateData));
-    }
-
-    // TODO [LOBE-7199]: align criteria/rubrics schema and switch to typed updateReviewConfig
-    if (args.review) {
-      ops.push(taskModel.updateTaskConfig(task.id, { review: { enabled: true, ...args.review } }));
-      changes.push('review config updated');
     }
 
     const applyDeps = async (

--- a/src/server/services/toolExecution/serverRuntimes/task.ts
+++ b/src/server/services/toolExecution/serverRuntimes/task.ts
@@ -1,4 +1,4 @@
-import { TaskIdentifier, UNFINISHED_TASK_STATUSES } from '@lobechat/builtin-tool-task';
+import { normalizeListTasksParams, TaskIdentifier } from '@lobechat/builtin-tool-task';
 import {
   formatDependencyAdded,
   formatDependencyRemoved,
@@ -9,6 +9,7 @@ import {
   formatTaskList,
   priorityLabel,
 } from '@lobechat/prompts';
+import type { TaskStatus } from '@lobechat/types';
 
 import { TaskModel } from '@/database/models/task';
 import { TaskService } from '@/server/services/task';
@@ -163,9 +164,9 @@ const createTaskRuntime = ({
     offset?: number;
     parentIdentifier?: string;
     priorities?: number[];
-    statuses?: string[];
+    statuses?: TaskStatus[];
   }) => {
-    let parentTaskId: string | null | undefined;
+    let parentTaskId: string | undefined;
     if (args.parentIdentifier) {
       const parent = await taskModel.resolve(args.parentIdentifier);
       if (!parent)
@@ -173,35 +174,15 @@ const createTaskRuntime = ({
       parentTaskId = parent.id;
     }
 
-    const noFilters =
-      !args.parentIdentifier &&
-      !args.statuses?.length &&
-      !args.priorities?.length &&
-      !args.assigneeAgentId;
-
-    const limit = Math.min(args.limit ?? 20, 100);
-
-    const resolvedStatuses =
-      args.statuses ?? (noFilters ? [...UNFINISHED_TASK_STATUSES] : undefined);
-    const resolvedAgentId = args.assigneeAgentId ?? (noFilters ? agentId : undefined);
-    const resolvedParentTaskId = parentTaskId ?? (noFilters ? null : undefined);
-
-    const result = await taskModel.list({
-      assigneeAgentId: resolvedAgentId,
-      limit,
-      offset: args.offset ?? 0,
-      parentTaskId: resolvedParentTaskId,
-      priorities: args.priorities,
-      statuses: resolvedStatuses,
+    const normalized = normalizeListTasksParams(args, {
+      currentAgentId: agentId,
+      parentTaskId,
     });
 
+    const result = await taskModel.list(normalized.query);
+
     return {
-      content: formatTaskList(result.tasks, {
-        assigneeAgentId: args.assigneeAgentId,
-        parentIdentifier: args.parentIdentifier,
-        priorities: args.priorities,
-        statuses: args.statuses,
-      }),
+      content: formatTaskList(result.tasks, normalized.displayFilters),
       success: true,
     };
   },

--- a/src/server/services/toolExecution/serverRuntimes/task.ts
+++ b/src/server/services/toolExecution/serverRuntimes/task.ts
@@ -12,6 +12,7 @@ import {
 import type { TaskStatus } from '@lobechat/types';
 
 import { TaskModel } from '@/database/models/task';
+import { taskRouter } from '@/server/routers/lambda/task';
 import { TaskService } from '@/server/services/task';
 
 import { type ServerRuntimeRegistration } from './types';
@@ -19,11 +20,13 @@ import { type ServerRuntimeRegistration } from './types';
 const createTaskRuntime = ({
   agentId,
   taskId,
+  taskCaller,
   taskModel,
   taskService,
 }: {
   agentId?: string;
   taskId?: string;
+  taskCaller: ReturnType<typeof taskRouter.createCaller>;
   taskModel: TaskModel;
   taskService: TaskService;
 }) => ({
@@ -187,7 +190,7 @@ const createTaskRuntime = ({
     };
   },
 
-  updateTaskStatus: async (args: { identifier?: string; status: string }) => {
+  updateTaskStatus: async (args: { error?: string; identifier?: string; status: TaskStatus }) => {
     const id = args.identifier || taskId;
     if (!id) {
       return {
@@ -196,16 +199,28 @@ const createTaskRuntime = ({
       };
     }
 
-    const task = await taskModel.resolve(id);
-    if (!task) return { content: `Task not found: ${id}`, success: false };
+    try {
+      const result = await taskCaller.updateStatus({
+        error: args.error,
+        id,
+        status: args.status,
+      });
 
-    const updated = await taskModel.updateStatus(task.id, args.status);
-    if (!updated) return { content: `Failed to update task ${task.identifier}`, success: false };
+      return {
+        content:
+          args.status === 'failed' && args.error
+            ? `Task ${result.data.identifier} status updated to failed. Error: ${args.error}`
+            : `Task ${result.data.identifier} status updated to ${args.status}.`,
+        success: true,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update task status';
 
-    return {
-      content: `Task ${task.identifier} status updated to ${args.status}.`,
-      success: true,
-    };
+      return {
+        content: `Failed to update task status: ${message}`,
+        success: false,
+      };
+    }
   },
 
   viewTask: async (args: { identifier?: string }) => {
@@ -235,9 +250,11 @@ export const taskRuntime: ServerRuntimeRegistration = {
 
     const taskModel = new TaskModel(context.serverDB, context.userId);
     const taskService = new TaskService(context.serverDB, context.userId);
+    const taskCaller = taskRouter.createCaller({ userId: context.userId });
 
     return createTaskRuntime({
       agentId: context.agentId,
+      taskCaller,
       taskId: context.taskId,
       taskModel,
       taskService,

--- a/src/server/services/toolExecution/serverRuntimes/task.ts
+++ b/src/server/services/toolExecution/serverRuntimes/task.ts
@@ -169,25 +169,25 @@ const createTaskRuntime = ({
     priorities?: number[];
     statuses?: TaskStatus[];
   }) => {
-    let parentTaskId: string | undefined;
-    if (args.parentIdentifier) {
-      const parent = await taskModel.resolve(args.parentIdentifier);
-      if (!parent)
-        return { content: `Parent task not found: ${args.parentIdentifier}`, success: false };
-      parentTaskId = parent.id;
-    }
-
     const normalized = normalizeListTasksParams(args, {
       currentAgentId: agentId,
-      parentTaskId,
     });
 
-    const result = await taskModel.list(normalized.query);
+    try {
+      const result = await taskCaller.list(normalized.query);
 
-    return {
-      content: formatTaskList(result.tasks, normalized.displayFilters),
-      success: true,
-    };
+      return {
+        content: formatTaskList(result.data, normalized.displayFilters),
+        success: true,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to list tasks';
+
+      return {
+        content: `Failed to list tasks: ${message}`,
+        success: false,
+      };
+    }
   },
 
   updateTaskStatus: async (args: { error?: string; identifier?: string; status: TaskStatus }) => {

--- a/src/server/services/toolExecution/serverRuntimes/task.ts
+++ b/src/server/services/toolExecution/serverRuntimes/task.ts
@@ -96,12 +96,13 @@ const createTaskRuntime = ({
   },
 
   editTask: async (args: {
-    addDependency?: string;
+    addDependencies?: string[];
+    description?: string;
     identifier: string;
     instruction?: string;
     name?: string;
     priority?: number;
-    removeDependency?: string;
+    removeDependencies?: string[];
     review?: {
       autoRetry?: boolean;
       criteria?: Array<{ name: string; threshold: number }>;
@@ -114,6 +115,7 @@ const createTaskRuntime = ({
 
     const updateData: Record<string, any> = {};
     const changes: string[] = [];
+    const ops: Promise<unknown>[] = [];
 
     if (args.name !== undefined) {
       updateData.name = args.name;
@@ -123,35 +125,63 @@ const createTaskRuntime = ({
       updateData.instruction = args.instruction;
       changes.push(`instruction updated`);
     }
+    if (args.description !== undefined) {
+      updateData.description = args.description;
+      changes.push('description updated');
+    }
     if (args.priority !== undefined) {
       updateData.priority = args.priority;
       changes.push(`priority → ${priorityLabel(args.priority)}`);
     }
+
+    if (Object.keys(updateData).length > 0) {
+      ops.push(taskModel.update(task.id, updateData));
+    }
+
+    // TODO [LOBE-7199]: align criteria/rubrics schema and switch to typed updateReviewConfig
     if (args.review) {
-      await taskModel.updateTaskConfig(task.id, { review: { enabled: true, ...args.review } });
+      ops.push(taskModel.updateTaskConfig(task.id, { review: { enabled: true, ...args.review } }));
       changes.push('review config updated');
     }
 
-    if (Object.keys(updateData).length > 0) {
-      await taskModel.update(task.id, updateData);
+    const applyDeps = async (
+      ids: string[],
+      apply: (depId: string) => Promise<unknown>,
+      onChange: (depIdentifier: string) => void,
+    ): Promise<string | undefined> => {
+      const resolved = await Promise.all(
+        ids.map((id) => taskModel.resolve(id).then((r) => ({ id, resolved: r }))),
+      );
+      const missing = resolved.find((r) => !r.resolved);
+      if (missing) return `Dependency task not found: ${missing.id}`;
+
+      await Promise.all(resolved.map(({ resolved: dep }) => apply(dep!.id)));
+      resolved.forEach(({ resolved: dep }) => onChange(dep!.identifier));
+    };
+
+    const depResults: Promise<string | undefined>[] = [];
+    if (args.addDependencies?.length) {
+      depResults.push(
+        applyDeps(
+          args.addDependencies,
+          (depId) => taskModel.addDependency(task.id, depId),
+          (depIdentifier) => changes.push(formatDependencyAdded(task.identifier, depIdentifier)),
+        ),
+      );
+    }
+    if (args.removeDependencies?.length) {
+      depResults.push(
+        applyDeps(
+          args.removeDependencies,
+          (depId) => taskModel.removeDependency(task.id, depId),
+          (depIdentifier) => changes.push(formatDependencyRemoved(task.identifier, depIdentifier)),
+        ),
+      );
     }
 
-    // Handle dependencies
-    if (args.addDependency) {
-      const dep = await taskModel.resolve(args.addDependency);
-      if (!dep)
-        return { content: `Dependency task not found: ${args.addDependency}`, success: false };
-      await taskModel.addDependency(task.id, dep.id);
-      changes.push(formatDependencyAdded(task.identifier, dep.identifier));
-    }
-
-    if (args.removeDependency) {
-      const dep = await taskModel.resolve(args.removeDependency);
-      if (!dep)
-        return { content: `Dependency task not found: ${args.removeDependency}`, success: false };
-      await taskModel.removeDependency(task.id, dep.id);
-      changes.push(formatDependencyRemoved(task.identifier, dep.identifier));
-    }
+    const [, depErrors] = await Promise.all([Promise.all(ops), Promise.all(depResults)]);
+    const firstDepError = depErrors.find((e) => e);
+    if (firstDepError) return { content: firstDepError, success: false };
 
     return { content: formatTaskEdited(task.identifier, changes), success: true };
   },

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -14,7 +14,8 @@ class TaskService {
     limit?: number;
     offset?: number;
     parentTaskId?: string | null;
-    status?: string;
+    priorities?: number[];
+    statuses?: string[];
   }) => lambdaClient.task.list.query(params);
 
   groupList = async (params: {

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -1,4 +1,4 @@
-import type { CheckpointConfig } from '@lobechat/types';
+import type { CheckpointConfig, TaskStatus } from '@lobechat/types';
 
 import { lambdaClient } from '@/libs/trpc/client';
 
@@ -13,9 +13,10 @@ class TaskService {
     assigneeAgentId?: string;
     limit?: number;
     offset?: number;
+    parentIdentifier?: string;
     parentTaskId?: string | null;
     priorities?: number[];
-    statuses?: string[];
+    statuses?: TaskStatus[];
   }) => lambdaClient.task.list.query(params);
 
   groupList = async (params: {

--- a/src/services/topic/index.ts
+++ b/src/services/topic/index.ts
@@ -39,6 +39,7 @@ export class TopicService {
       current: params.current,
       excludeTriggers: params.excludeTriggers,
       groupId: params.groupId,
+      includeTriggers: params.includeTriggers,
       isInbox: params.isInbox,
       pageSize: params.pageSize,
     }) as any;

--- a/src/spa/router/desktopRouter.config.desktop.tsx
+++ b/src/spa/router/desktopRouter.config.desktop.tsx
@@ -20,6 +20,7 @@ import AgentChannelPage from '@/routes/(main)/agent/channel';
 import AgentCronDetailPage from '@/routes/(main)/agent/cron/[cronId]';
 import AgentProfilePage from '@/routes/(main)/agent/profile';
 import AgentTasksPage from '@/routes/(main)/agent/tasks';
+import AgentTasksLayout from '@/routes/(main)/agent/tasks/_layout';
 import AgentTaskDetailPage from '@/routes/(main)/agent/tasks/[taskId]';
 import CommunityLayout from '@/routes/(main)/community/_layout';
 import CommunityDetailLayout from '@/routes/(main)/community/(detail)/_layout';
@@ -115,6 +116,7 @@ export const desktopRoutes: RouteObject[] = [
                     path: ':taskId',
                   },
                 ],
+                element: <AgentTasksLayout />,
                 path: 'tasks',
               },
             ],

--- a/src/spa/router/desktopRouter.config.tsx
+++ b/src/spa/router/desktopRouter.config.tsx
@@ -63,6 +63,10 @@ export const desktopRoutes: RouteObject[] = [
                     path: ':taskId',
                   },
                 ],
+                element: dynamicLayout(
+                  () => import('@/routes/(main)/agent/tasks/_layout'),
+                  'Desktop > Chat > Tasks > Layout',
+                ),
                 path: 'tasks',
               },
             ],

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -57,6 +57,15 @@ export interface SendMessageWithContextParams extends SendMessageParams {
    * Contains sessionId, topicId, and threadId
    */
   context: ConversationContext;
+  /**
+   * Called as soon as the backend reports a newly created topic id, so callers
+   * with an isolated topic scope (e.g. Task Manager) can switch their UI to the
+   * new topic while the AI response is still streaming.
+   *
+   * Only invoked when `context.isolatedTopic` is true; otherwise the store's
+   * own `switchTopic` handles the transition on the global chat store.
+   */
+  onTopicCreated?: (topicId: string) => void | Promise<void>;
 }
 
 /**
@@ -110,6 +119,7 @@ export class ConversationLifecycleActionImpl {
     messages: inputMessages,
     parentId: inputParentId,
     pageSelections,
+    onTopicCreated,
   }: SendMessageWithContextParams): Promise<SendMessageResult | undefined> => {
     let editorData = inputEditorData;
     const { internal_execAgentRuntime, mainInputEditor } = this.#get();
@@ -491,12 +501,18 @@ export class ConversationLifecycleActionImpl {
         action: 'sendMessage/serverResponse',
       });
 
-      if (data.isCreateNewTopic && data.topicId && !context.isolatedTopic) {
-        // clearNewKey: true ensures the _new key data is cleared after topic creation
-        await this.#get().switchTopic(data.topicId, {
-          clearNewKey: true,
-          skipRefreshMessage: true,
-        });
+      if (data.isCreateNewTopic && data.topicId) {
+        if (context.isolatedTopic) {
+          // Notify the isolated caller immediately so its UI re-subscribes to
+          // the new topic key and picks up the streaming AI response.
+          await onTopicCreated?.(data.topicId);
+        } else {
+          // clearNewKey: true ensures the _new key data is cleared after topic creation
+          await this.#get().switchTopic(data.topicId, {
+            clearNewKey: true,
+            skipRefreshMessage: true,
+          });
+        }
       }
     } catch (e) {
       console.error(e);

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -67,6 +67,8 @@ export interface SendMessageResult {
   assistantMessageId: string;
   /** The created thread ID (if a new thread was created) */
   createdThreadId?: string;
+  /** The created topic ID (if a new topic was created in this call) */
+  createdTopicId?: string;
   /** The created user message ID */
   userMessageId: string;
 }
@@ -422,6 +424,7 @@ export class ConversationLifecycleActionImpl {
             ? {
                 topicMessageIds: forceNewTopicFromExisting ? [] : messages.map((m) => m.id),
                 title: message.slice(0, 20) || t('defaultTitle', { ns: 'topic' }),
+                trigger: context.topicTrigger,
               }
             : undefined,
           agentId: operationContext.agentId,
@@ -442,17 +445,24 @@ export class ConversationLifecycleActionImpl {
 
       // refresh the total data
       if (data?.topics) {
-        const pageSize = systemStatusSelectors.topicPageSize(useGlobalStore.getState());
-        this.#get().internal_updateTopics(operationContext.agentId, {
-          groupId: operationContext.groupId,
-          items: data.topics.items,
-          pageSize,
-          total: data.topics.total,
-        });
         finalTopicId = data.topicId;
 
-        // Record the created topicId in metadata (not context)
-        this.#get().updateOperationMetadata(operationId, { createdTopicId: data.topicId });
+        // Skip writing the returned topic list into the main chat's topicDataMap
+        // when the caller owns an isolated topic scope (e.g. Task Manager panel).
+        // Otherwise the newly created isolated-trigger topic would flash in the
+        // main sidebar until the next SWR revalidation filters it out.
+        if (!context.isolatedTopic) {
+          const pageSize = systemStatusSelectors.topicPageSize(useGlobalStore.getState());
+          this.#get().internal_updateTopics(operationContext.agentId, {
+            groupId: operationContext.groupId,
+            items: data.topics.items,
+            pageSize,
+            total: data.topics.total,
+          });
+
+          // Record the created topicId in metadata (not context)
+          this.#get().updateOperationMetadata(operationId, { createdTopicId: data.topicId });
+        }
       } else if (operationContext.topicId) {
         // Optimistically update topic's updatedAt so sidebar re-groups immediately
         this.#get().internal_dispatchTopic({
@@ -481,7 +491,7 @@ export class ConversationLifecycleActionImpl {
         action: 'sendMessage/serverResponse',
       });
 
-      if (data.isCreateNewTopic && data.topicId) {
+      if (data.isCreateNewTopic && data.topicId && !context.isolatedTopic) {
         // clearNewKey: true ensures the _new key data is cleared after topic creation
         await this.#get().switchTopic(data.topicId, {
           clearNewKey: true,
@@ -666,6 +676,7 @@ export class ConversationLifecycleActionImpl {
     return {
       assistantMessageId: data.assistantMessageId,
       createdThreadId: data.createdThreadId,
+      createdTopicId: data.isCreateNewTopic ? data.topicId : undefined,
       userMessageId: data.userMessageId,
     };
   };

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -11,6 +11,7 @@ import { PageAgentIdentifier } from '@lobechat/builtin-tool-page-agent';
 import { manualModeExcludeToolIds } from '@lobechat/builtin-tools';
 import { isDesktop } from '@lobechat/const';
 import { generateToolsFromManifest, type ToolsEngine } from '@lobechat/context-engine';
+import { buildTaskDetailPrompt, buildTaskListPrompt } from '@lobechat/prompts';
 import {
   type ConversationContext,
   type RuntimeInitialContext,
@@ -28,6 +29,7 @@ import { getAgentStoreState } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { createAgentExecutors } from '@/store/chat/agents/createAgentExecutors';
 import { type ChatStore, useChatStore } from '@/store/chat/store';
+import { getTaskStoreState } from '@/store/task';
 import { pageAgentRuntime } from '@/store/tool/slices/builtin/executors/lobe-page-agent';
 import { type StoreSetter } from '@/store/types';
 import { toolInterventionSelectors } from '@/store/user/selectors';
@@ -309,6 +311,37 @@ export class StreamingExecutorActionImpl {
         // Page agent runtime may not be initialized (e.g., editor not set)
         // This is expected in some scenarios, so we just log and continue
         log('[internal_createAgentState] Failed to get page content context: %o', error);
+      }
+    }
+
+    const viewedTask = operation?.context.viewedTask;
+    if (viewedTask) {
+      try {
+        const taskState = getTaskStoreState();
+        let contextPrompt: string | undefined;
+
+        if (viewedTask.type === 'list') {
+          contextPrompt = buildTaskListPrompt({
+            tasks: taskState.tasks,
+            total: taskState.tasksTotal || taskState.tasks.length,
+          });
+        } else {
+          const detail = taskState.taskDetailMap[viewedTask.taskId];
+          if (detail) contextPrompt = buildTaskDetailPrompt({ task: detail });
+        }
+
+        if (contextPrompt) {
+          runtimeInitialContext = {
+            ...runtimeInitialContext,
+            taskManager: { contextPrompt },
+          };
+          log(
+            '[internal_createAgentState] injected taskManager context (route=%s)',
+            viewedTask.type,
+          );
+        }
+      } catch (error) {
+        log('[internal_createAgentState] Failed to build task manager context: %o', error);
       }
     }
 

--- a/src/store/chat/slices/aiChat/initialState.ts
+++ b/src/store/chat/slices/aiChat/initialState.ts
@@ -1,19 +1,6 @@
 import { type ChatInputEditor } from '@/features/ChatInput';
 import type { GatewayConnection } from '@/store/chat/slices/aiChat/actions/gateway';
 
-/**
- * Page-level runtime overrides for plugin/tool behavior.
- * Transient state, not persisted — cleared on reload or when pages unmount.
- */
-export interface RuntimePluginOverrides {
-  /**
-   * Force these tool ids to be activated for every step on the current page,
-   * bypassing enableChecker rules via `isExplicitActivation`.
-   * Merged into stepContext.activatedToolIds in streamingExecutor.
-   */
-  forceActivated?: string[];
-}
-
 export interface ChatAIChatState {
   /**
    * Active Agent Gateway WebSocket connections, keyed by operationId
@@ -30,10 +17,11 @@ export interface ChatAIChatState {
    */
   pendingClientToolExecutions: Record<string, boolean>;
   /**
-   * Page-level runtime plugin overrides. Set by page layouts (e.g. tasks page
-   * forcing `lobe-task` to be activated), cleared on unmount.
+   * Tool ids enabled by the current runtime scenario/page (for example the
+   * tasks page enabling `lobe-task` while its panel is mounted).
+   * Transient state, not persisted — cleared on reload or when pages unmount.
    */
-  runtimePluginOverrides?: RuntimePluginOverrides;
+  scenarioEnabledToolIds?: string[];
   searchWorkflowLoadingIds: string[];
   threadInputEditor: ChatInputEditor | null;
   /**
@@ -48,7 +36,7 @@ export const initialAiChatState: ChatAIChatState = {
   inputMessage: '',
   mainInputEditor: null,
   pendingClientToolExecutions: {},
-  runtimePluginOverrides: undefined,
+  scenarioEnabledToolIds: undefined,
   searchWorkflowLoadingIds: [],
   threadInputEditor: null,
   toolCallingStreamIds: {},

--- a/src/store/chat/slices/aiChat/initialState.ts
+++ b/src/store/chat/slices/aiChat/initialState.ts
@@ -1,6 +1,19 @@
 import { type ChatInputEditor } from '@/features/ChatInput';
 import type { GatewayConnection } from '@/store/chat/slices/aiChat/actions/gateway';
 
+/**
+ * Page-level runtime overrides for plugin/tool behavior.
+ * Transient state, not persisted — cleared on reload or when pages unmount.
+ */
+export interface RuntimePluginOverrides {
+  /**
+   * Force these tool ids to be activated for every step on the current page,
+   * bypassing enableChecker rules via `isExplicitActivation`.
+   * Merged into stepContext.activatedToolIds in streamingExecutor.
+   */
+  forceActivated?: string[];
+}
+
 export interface ChatAIChatState {
   /**
    * Active Agent Gateway WebSocket connections, keyed by operationId
@@ -16,6 +29,11 @@ export interface ChatAIChatState {
    * UI can render a distinct "running on device" state.
    */
   pendingClientToolExecutions: Record<string, boolean>;
+  /**
+   * Page-level runtime plugin overrides. Set by page layouts (e.g. tasks page
+   * forcing `lobe-task` to be activated), cleared on unmount.
+   */
+  runtimePluginOverrides?: RuntimePluginOverrides;
   searchWorkflowLoadingIds: string[];
   threadInputEditor: ChatInputEditor | null;
   /**
@@ -30,6 +48,7 @@ export const initialAiChatState: ChatAIChatState = {
   inputMessage: '',
   mainInputEditor: null,
   pendingClientToolExecutions: {},
+  runtimePluginOverrides: undefined,
   searchWorkflowLoadingIds: [],
   threadInputEditor: null,
   toolCallingStreamIds: {},

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -613,7 +613,11 @@ export class ChatTopicActionImpl {
     // Key format: [SWR_USE_FETCH_TOPIC, containerKey, { isInbox, pageSize }]
     const containerKey = topicMapKey({ agentId: activeAgentId, groupId: activeGroupId });
     await mutate(
-      (key) => Array.isArray(key) && key[0] === SWR_USE_FETCH_TOPIC && key[1] === containerKey,
+      (key) =>
+        Array.isArray(key) &&
+        key[0] === SWR_USE_FETCH_TOPIC &&
+        typeof key[1] === 'string' &&
+        key[1] === containerKey,
     );
   };
 

--- a/src/store/task/slices/config/action.ts
+++ b/src/store/task/slices/config/action.ts
@@ -97,6 +97,7 @@ export class TaskConfigSliceActionImpl {
     try {
       await taskService.updateConfig(id, modelConfig);
       this.#set({ taskSaveStatus: 'saved' }, false, 'updateTaskModelConfig/saved');
+      await this.#get().internal_refreshTaskDetail(id);
     } catch (error) {
       console.error('[TaskStore] Failed to update task model config:', error);
       this.#set({ taskSaveStatus: 'idle' }, false, 'updateTaskModelConfig/error');
@@ -104,14 +105,11 @@ export class TaskConfigSliceActionImpl {
     }
   };
 
-  // 配置周期执行间隔（heartbeatInterval 字段，单位：秒）
-  // TODO: 清除间隔需要后端 schema 支持 nullable（当前 z.number().min(1).optional() 不接受 null/0）
+  // Configure periodic execution interval (heartbeatInterval in seconds).
+  // Sending 0 disables periodic execution while keeping the API shape simple for the UI.
   updatePeriodicInterval = async (id: string, interval: number | null): Promise<void> => {
-    // 后端不支持 null/0，清除时跳过请求
-    if (!interval) return;
-
     try {
-      await taskService.update(id, { heartbeatInterval: interval });
+      await taskService.update(id, { heartbeatInterval: interval ?? 0 });
       await this.#get().internal_refreshTaskDetail(id);
     } catch (error) {
       console.error('[TaskStore] Failed to update periodic interval:', error);

--- a/src/store/task/slices/detail/action.test.ts
+++ b/src/store/task/slices/detail/action.test.ts
@@ -129,7 +129,7 @@ describe('TaskDetailSliceAction', () => {
   });
 
   describe('deleteTask', () => {
-    it('should remove from map and clear activeTaskId', async () => {
+    it('should remove from map, clear activeTaskId, and return deleted task data', async () => {
       useTaskStore.setState({
         activeTaskId: 'T-1',
         taskDetailMap: {
@@ -137,10 +137,15 @@ describe('TaskDetailSliceAction', () => {
         },
       });
 
-      vi.mocked(taskService.delete).mockResolvedValue({ success: true } as any);
+      vi.mocked(taskService.delete).mockResolvedValue({
+        data: { identifier: 'T-1', name: 'Test Task' },
+        success: true,
+      } as any);
 
-      await useTaskStore.getState().deleteTask('T-1');
+      const result = await useTaskStore.getState().deleteTask('T-1');
 
+      expect(result?.identifier).toBe('T-1');
+      expect(result?.name).toBe('Test Task');
       expect(useTaskStore.getState().taskDetailMap['T-1']).toBeUndefined();
       expect(useTaskStore.getState().activeTaskId).toBeUndefined();
     });
@@ -154,10 +159,27 @@ describe('TaskDetailSliceAction', () => {
 
       vi.mocked(taskService.delete).mockImplementation(async () => {
         expect(useTaskStore.getState().isDeletingTask).toBe(true);
-        return { success: true } as any;
+        return { data: { identifier: 'T-1' }, success: true } as any;
       });
 
       await useTaskStore.getState().deleteTask('T-1');
+      expect(useTaskStore.getState().isDeletingTask).toBe(false);
+    });
+
+    it('should rollback optimistic delete and propagate error on failure', async () => {
+      const snapshot = {
+        identifier: 'T-1',
+        instruction: 'Test',
+        name: 'Original',
+        status: 'backlog',
+      };
+      useTaskStore.setState({ taskDetailMap: { 'T-1': snapshot as any } });
+
+      vi.mocked(taskService.delete).mockRejectedValue(new Error('server down'));
+
+      await expect(useTaskStore.getState().deleteTask('T-1')).rejects.toThrow('server down');
+
+      expect(useTaskStore.getState().taskDetailMap['T-1']).toEqual(snapshot);
       expect(useTaskStore.getState().isDeletingTask).toBe(false);
     });
   });

--- a/src/store/task/slices/detail/action.test.ts
+++ b/src/store/task/slices/detail/action.test.ts
@@ -70,7 +70,7 @@ describe('TaskDetailSliceAction', () => {
         instruction: 'Do something',
         name: 'Test',
       });
-      expect(result).toBe('T-1');
+      expect(result?.identifier).toBe('T-1');
     });
 
     it('should set isCreatingTask during creation', async () => {
@@ -83,11 +83,12 @@ describe('TaskDetailSliceAction', () => {
       expect(useTaskStore.getState().isCreatingTask).toBe(false);
     });
 
-    it('should return null on error', async () => {
+    it('should throw on error and reset isCreatingTask', async () => {
       vi.mocked(taskService.create).mockRejectedValue(new Error('fail'));
 
-      const result = await useTaskStore.getState().createTask({ instruction: 'Test' });
-      expect(result).toBeNull();
+      await expect(useTaskStore.getState().createTask({ instruction: 'Test' })).rejects.toThrow(
+        'fail',
+      );
       expect(useTaskStore.getState().isCreatingTask).toBe(false);
     });
   });

--- a/src/store/task/slices/detail/action.test.ts
+++ b/src/store/task/slices/detail/action.test.ts
@@ -24,6 +24,12 @@ vi.mock('@/libs/swr', () => ({
   useClientDataSWR: vi.fn(),
 }));
 
+vi.mock('@/components/AntdStaticMethods', () => ({
+  message: { error: vi.fn(), success: vi.fn() },
+  modal: { confirm: vi.fn() },
+  notification: { error: vi.fn() },
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
   useTaskStore.setState({
@@ -111,8 +117,9 @@ describe('TaskDetailSliceAction', () => {
       expect(useTaskStore.getState().taskSaveStatus).toBe('saved');
     });
 
-    it('should refresh on error', async () => {
+    it('should propagate error, reset saveStatus, refresh, and toast on failure', async () => {
       const { mutate } = await import('@/libs/swr');
+      const { message } = await import('@/components/AntdStaticMethods');
       useTaskStore.setState({
         taskDetailMap: {
           'T-1': { identifier: 'T-1', instruction: 'Test', status: 'backlog' },
@@ -121,10 +128,13 @@ describe('TaskDetailSliceAction', () => {
 
       vi.mocked(taskService.update).mockRejectedValue(new Error('fail'));
 
-      await useTaskStore.getState().updateTask('T-1', { name: 'New' });
+      await expect(useTaskStore.getState().updateTask('T-1', { name: 'New' })).rejects.toThrow(
+        'fail',
+      );
 
       expect(useTaskStore.getState().taskSaveStatus).toBe('idle');
       expect(mutate).toHaveBeenCalledWith(['fetchTaskDetail', 'T-1']);
+      expect(message.error).toHaveBeenCalled();
     });
   });
 
@@ -204,6 +214,26 @@ describe('TaskDetailSliceAction', () => {
       await useTaskStore.getState().addDependency('T-1', 'T-2', 'blocks');
 
       expect(taskService.addDependency).toHaveBeenCalledWith('T-1', 'T-2', 'blocks');
+      expect(mutate).toHaveBeenCalledWith(['fetchTaskDetail', 'T-1']);
+    });
+
+    it('should propagate error from service', async () => {
+      vi.mocked(taskService.addDependency).mockRejectedValue(new Error('cycle detected'));
+
+      await expect(useTaskStore.getState().addDependency('T-1', 'T-2', 'blocks')).rejects.toThrow(
+        'cycle detected',
+      );
+    });
+  });
+
+  describe('removeDependency', () => {
+    it('should call service and refresh detail', async () => {
+      const { mutate } = await import('@/libs/swr');
+      vi.mocked(taskService.removeDependency).mockResolvedValue({ success: true } as any);
+
+      await useTaskStore.getState().removeDependency('T-1', 'T-2');
+
+      expect(taskService.removeDependency).toHaveBeenCalledWith('T-1', 'T-2');
       expect(mutate).toHaveBeenCalledWith(['fetchTaskDetail', 'T-1']);
     });
   });

--- a/src/store/task/slices/detail/action.ts
+++ b/src/store/task/slices/detail/action.ts
@@ -10,6 +10,7 @@ import type { TaskDetailDispatch } from './reducer';
 import { taskDetailReducer } from './reducer';
 
 type CreatedTask = NonNullable<Awaited<ReturnType<typeof taskService.create>>['data']>;
+type DeletedTask = NonNullable<Awaited<ReturnType<typeof taskService.delete>>['data']>;
 
 // config / heartbeatInterval / heartbeatTimeout are not exposed here:
 // - model/provider goes through configSlice.updateTaskModelConfig
@@ -79,21 +80,29 @@ export class TaskDetailSliceActionImpl {
     }
   };
 
-  deleteTask = async (id: string): Promise<void> => {
+  deleteTask = async (identifier: string): Promise<DeletedTask | null> => {
+    const snapshot = this.#get().taskDetailMap[identifier];
     this.#set({ isDeletingTask: true }, false, 'deleteTask/start');
     try {
-      this.internal_dispatchTaskDetail({ id, type: 'deleteTaskDetail' });
+      this.internal_dispatchTaskDetail({ id: identifier, type: 'deleteTaskDetail' });
 
-      await taskService.delete(id);
+      const result = await taskService.delete(identifier);
 
-      if (this.#get().activeTaskId === id) {
+      if (this.#get().activeTaskId === identifier) {
         this.#set({ activeTaskId: undefined }, false, 'deleteTask/clearActive');
       }
 
       await this.#get().refreshTaskList();
+      return result.data ?? null;
     } catch (error) {
-      console.error('[TaskStore] Failed to delete task:', error);
-      await this.internal_refreshTaskDetail(id);
+      if (snapshot) {
+        this.internal_dispatchTaskDetail({
+          id: identifier,
+          type: 'setTaskDetail',
+          value: snapshot,
+        });
+      }
+      throw error;
     } finally {
       this.#set({ isDeletingTask: false }, false, 'deleteTask/end');
     }

--- a/src/store/task/slices/detail/action.ts
+++ b/src/store/task/slices/detail/action.ts
@@ -1,6 +1,8 @@
 import type { TaskDetailData } from '@lobechat/types';
 import isEqual from 'fast-deep-equal';
+import { t } from 'i18next';
 
+import { message } from '@/components/AntdStaticMethods';
 import { mutate, useClientDataSWR } from '@/libs/swr';
 import { taskService } from '@/services/task';
 import type { StoreSetter } from '@/store/types';
@@ -142,10 +144,11 @@ export class TaskDetailSliceActionImpl {
       await taskService.update(id, data);
       this.#set({ taskSaveStatus: 'saved' }, false, 'updateTask/saved');
     } catch (error) {
-      console.error('[TaskStore] Failed to update task:', error);
       this.#set({ taskSaveStatus: 'idle' }, false, 'updateTask/error');
       // Revert by refreshing from server
       await this.internal_refreshTaskDetail(id);
+      message.error(t('taskDetail.updateFailed', { ns: 'chat' }));
+      throw error;
     }
   };
 

--- a/src/store/task/slices/detail/action.ts
+++ b/src/store/task/slices/detail/action.ts
@@ -170,7 +170,12 @@ export class TaskDetailSliceActionImpl {
       this.#set({ taskSaveStatus: 'idle' }, false, 'updateTask/error');
       // Revert by refreshing from server
       await this.internal_refreshTaskDetail(id);
-      message.error(t('taskDetail.updateFailed', { ns: 'chat' }));
+      message.error(
+        t('taskDetail.updateFailed', {
+          defaultValue: 'Failed to update task',
+          ns: 'chat',
+        }),
+      );
       throw error;
     }
   };

--- a/src/store/task/slices/detail/action.ts
+++ b/src/store/task/slices/detail/action.ts
@@ -64,6 +64,29 @@ export class TaskDetailSliceActionImpl {
     await this.internal_refreshTaskDetail(taskId);
   };
 
+  fetchTaskDetail = async (taskId?: string): Promise<TaskDetailData> => {
+    const resolvedId = taskId ?? this.#get().activeTaskId;
+
+    if (!resolvedId) {
+      throw new Error('No task identifier provided and no current task context.');
+    }
+
+    const result = await taskService.getDetail(resolvedId);
+    const detail = result.data;
+
+    if (!detail) {
+      throw new Error(`Task not found: ${resolvedId}`);
+    }
+
+    this.internal_dispatchTaskDetail({
+      id: detail.identifier,
+      type: 'setTaskDetail',
+      value: detail,
+    });
+
+    return detail;
+  };
+
   createTask = async (params: {
     assigneeAgentId?: string;
     description?: string;
@@ -156,19 +179,7 @@ export class TaskDetailSliceActionImpl {
     return useClientDataSWR(
       taskId ? [FETCH_TASK_DETAIL_KEY, taskId] : null,
       async ([, id]: [string, string]) => {
-        const result = await taskService.getDetail(id);
-        return result.data;
-      },
-      {
-        onSuccess: (data: TaskDetailData) => {
-          if (data && taskId) {
-            this.internal_dispatchTaskDetail({
-              id: taskId,
-              type: 'setTaskDetail',
-              value: data,
-            });
-          }
-        },
+        return this.fetchTaskDetail(id);
       },
     );
   };

--- a/src/store/task/slices/detail/action.ts
+++ b/src/store/task/slices/detail/action.ts
@@ -9,6 +9,8 @@ import type { TaskStore } from '../../store';
 import type { TaskDetailDispatch } from './reducer';
 import { taskDetailReducer } from './reducer';
 
+type CreatedTask = NonNullable<Awaited<ReturnType<typeof taskService.create>>['data']>;
+
 // config / heartbeatInterval / heartbeatTimeout are not exposed here:
 // - model/provider goes through configSlice.updateTaskModelConfig
 // - checkpoint goes through configSlice.updateCheckpoint
@@ -66,15 +68,12 @@ export class TaskDetailSliceActionImpl {
     name?: string;
     parentTaskId?: string;
     priority?: number;
-  }): Promise<string | null> => {
+  }): Promise<CreatedTask | null> => {
     this.#set({ isCreatingTask: true }, false, 'createTask/start');
     try {
       const result = await taskService.create(params);
       await this.#get().refreshTaskList();
-      return result.data?.identifier ?? null;
-    } catch (error) {
-      console.error('[TaskStore] Failed to create task:', error);
-      return null;
+      return result.data ?? null;
     } finally {
       this.#set({ isCreatingTask: false }, false, 'createTask/end');
     }

--- a/src/store/task/slices/lifecycle/action.test.ts
+++ b/src/store/task/slices/lifecycle/action.test.ts
@@ -62,11 +62,11 @@ describe('TaskLifecycleSliceAction', () => {
     });
   });
 
-  describe('pauseTask', () => {
+  describe('updateTaskStatus', () => {
     it('should call updateStatus with paused', async () => {
       vi.mocked(taskService.updateStatus).mockResolvedValue({ success: true } as any);
 
-      await useTaskStore.getState().pauseTask('T-1');
+      await useTaskStore.getState().updateTaskStatus('T-1', 'paused');
 
       expect(taskService.updateStatus).toHaveBeenCalledWith('T-1', 'paused');
     });
@@ -77,35 +77,29 @@ describe('TaskLifecycleSliceAction', () => {
         return { success: true } as any;
       });
 
-      await useTaskStore.getState().pauseTask('T-1');
+      await useTaskStore.getState().updateTaskStatus('T-1', 'paused');
     });
-  });
 
-  describe('cancelTask', () => {
     it('should call updateStatus with canceled', async () => {
       vi.mocked(taskService.updateStatus).mockResolvedValue({ success: true } as any);
 
-      await useTaskStore.getState().cancelTask('T-1');
+      await useTaskStore.getState().updateTaskStatus('T-1', 'canceled');
 
       expect(taskService.updateStatus).toHaveBeenCalledWith('T-1', 'canceled');
     });
-  });
 
-  describe('resumeTask', () => {
     it('should call updateStatus with backlog', async () => {
       vi.mocked(taskService.updateStatus).mockResolvedValue({ success: true } as any);
 
-      await useTaskStore.getState().resumeTask('T-1');
+      await useTaskStore.getState().updateTaskStatus('T-1', 'backlog');
 
       expect(taskService.updateStatus).toHaveBeenCalledWith('T-1', 'backlog');
     });
-  });
 
-  describe('completeTask', () => {
     it('should call updateStatus with completed', async () => {
       vi.mocked(taskService.updateStatus).mockResolvedValue({ success: true } as any);
 
-      await useTaskStore.getState().completeTask('T-1');
+      await useTaskStore.getState().updateTaskStatus('T-1', 'completed');
 
       expect(taskService.updateStatus).toHaveBeenCalledWith('T-1', 'completed');
     });

--- a/src/store/task/slices/lifecycle/action.test.ts
+++ b/src/store/task/slices/lifecycle/action.test.ts
@@ -68,7 +68,7 @@ describe('TaskLifecycleSliceAction', () => {
 
       await useTaskStore.getState().updateTaskStatus('T-1', 'paused');
 
-      expect(taskService.updateStatus).toHaveBeenCalledWith('T-1', 'paused');
+      expect(taskService.updateStatus).toHaveBeenCalledWith('T-1', 'paused', undefined);
     });
 
     it('should optimistically set status', async () => {
@@ -85,7 +85,7 @@ describe('TaskLifecycleSliceAction', () => {
 
       await useTaskStore.getState().updateTaskStatus('T-1', 'canceled');
 
-      expect(taskService.updateStatus).toHaveBeenCalledWith('T-1', 'canceled');
+      expect(taskService.updateStatus).toHaveBeenCalledWith('T-1', 'canceled', undefined);
     });
 
     it('should call updateStatus with backlog', async () => {
@@ -93,7 +93,7 @@ describe('TaskLifecycleSliceAction', () => {
 
       await useTaskStore.getState().updateTaskStatus('T-1', 'backlog');
 
-      expect(taskService.updateStatus).toHaveBeenCalledWith('T-1', 'backlog');
+      expect(taskService.updateStatus).toHaveBeenCalledWith('T-1', 'backlog', undefined);
     });
 
     it('should call updateStatus with completed', async () => {
@@ -101,7 +101,7 @@ describe('TaskLifecycleSliceAction', () => {
 
       await useTaskStore.getState().updateTaskStatus('T-1', 'completed');
 
-      expect(taskService.updateStatus).toHaveBeenCalledWith('T-1', 'completed');
+      expect(taskService.updateStatus).toHaveBeenCalledWith('T-1', 'completed', undefined);
     });
   });
 

--- a/src/store/task/slices/lifecycle/action.ts
+++ b/src/store/task/slices/lifecycle/action.ts
@@ -1,4 +1,4 @@
-import type { TaskDetailData } from '@lobechat/types';
+import type { TaskDetailData, TaskStatus } from '@lobechat/types';
 
 import { taskService } from '@/services/task';
 import type { StoreSetter } from '@/store/types';
@@ -20,32 +20,16 @@ export class TaskLifecycleSliceActionImpl {
     this.#get = get;
   }
 
-  cancelTask = async (id: string): Promise<void> => {
-    await this.#transitionStatus(id, 'canceled');
-  };
-
   cancelTopic = async (topicId: string): Promise<void> => {
     await taskService.cancelTopic(topicId);
     const { activeTaskId, internal_refreshTaskDetail } = this.#get();
     if (activeTaskId) await internal_refreshTaskDetail(activeTaskId);
   };
 
-  completeTask = async (id: string): Promise<void> => {
-    await this.#transitionStatus(id, 'completed');
-  };
-
   deleteTopic = async (topicId: string): Promise<void> => {
     await taskService.deleteTopic(topicId);
     const { activeTaskId, internal_refreshTaskDetail } = this.#get();
     if (activeTaskId) await internal_refreshTaskDetail(activeTaskId);
-  };
-
-  pauseTask = async (id: string): Promise<void> => {
-    await this.#transitionStatus(id, 'paused');
-  };
-
-  resumeTask = async (id: string): Promise<void> => {
-    await this.#transitionStatus(id, 'backlog');
   };
 
   runTask = async (
@@ -68,12 +52,35 @@ export class TaskLifecycleSliceActionImpl {
     }
   };
 
+  updateTaskStatus = async (
+    id: string | undefined,
+    status: TaskStatus,
+    options?: { error?: string },
+  ): Promise<string> => {
+    const { error } = options ?? {};
+    const resolvedId = id ?? this.#get().activeTaskId;
+
+    if (!resolvedId) {
+      throw new Error('No task identifier provided and no current task context.');
+    }
+
+    const extraUpdate: Partial<TaskDetailData> = { status };
+    if (status === 'failed' && error) {
+      extraUpdate.error = error;
+    }
+
+    await this.#transitionStatus(resolvedId, status, extraUpdate, error);
+
+    return resolvedId;
+  };
+
   // ── Private helper ──
 
   #transitionStatus = async (
     id: string,
-    status: Parameters<typeof taskService.updateStatus>[1],
+    status: TaskStatus,
     extraUpdate?: Partial<TaskDetailData>,
+    error?: string,
   ): Promise<void> => {
     this.#get().internal_dispatchTaskDetail({
       id,
@@ -83,7 +90,7 @@ export class TaskLifecycleSliceActionImpl {
     this.#set({ taskSaveStatus: 'saving' }, false, 'transitionStatus/saving');
 
     try {
-      await taskService.updateStatus(id, status);
+      await taskService.updateStatus(id, status, error);
       this.#set({ taskSaveStatus: 'saved' }, false, 'transitionStatus/saved');
       await this.#get().internal_refreshTaskDetail(id);
       await this.#get().refreshTaskList();
@@ -91,6 +98,7 @@ export class TaskLifecycleSliceActionImpl {
       console.error(`[TaskStore] Failed to transition task to ${status}:`, error);
       this.#set({ taskSaveStatus: 'idle' }, false, 'transitionStatus/error');
       await this.#get().internal_refreshTaskDetail(id);
+      throw error;
     }
   };
 }

--- a/src/store/task/slices/list/action.ts
+++ b/src/store/task/slices/list/action.ts
@@ -36,6 +36,9 @@ export class TaskListSliceActionImpl {
     await mutate([FETCH_TASK_GROUP_LIST_KEY, listAgentId]);
   };
 
+  fetchTaskList = async (params: Parameters<typeof taskService.list>[0]) =>
+    taskService.list(params);
+
   refreshTaskList = async (): Promise<void> => {
     const { listAgentId } = this.#get();
     await Promise.all([
@@ -88,7 +91,7 @@ export class TaskListSliceActionImpl {
     return useClientDataSWR(
       enabled && agentId ? [FETCH_TASK_LIST_KEY, agentId] : null,
       async ([, id]: [string, string]) => {
-        return taskService.list({ assigneeAgentId: id });
+        return this.fetchTaskList({ assigneeAgentId: id });
       },
       {
         fallbackData: { data: [], success: true, total: 0 },

--- a/src/store/task/slices/list/action.ts
+++ b/src/store/task/slices/list/action.ts
@@ -38,7 +38,10 @@ export class TaskListSliceActionImpl {
 
   refreshTaskList = async (): Promise<void> => {
     const { listAgentId } = this.#get();
-    await mutate([FETCH_TASK_LIST_KEY, listAgentId]);
+    await Promise.all([
+      mutate([FETCH_TASK_LIST_KEY, listAgentId]),
+      mutate([FETCH_TASK_GROUP_LIST_KEY, listAgentId]),
+    ]);
   };
 
   setListAgentId = (agentId?: string): void => {

--- a/src/store/taskChat/action.ts
+++ b/src/store/taskChat/action.ts
@@ -1,0 +1,83 @@
+import isEqual from 'fast-deep-equal';
+import { type SWRResponse } from 'swr';
+
+import { mutate, useClientDataSWRWithSync } from '@/libs/swr';
+import { topicService } from '@/services/topic';
+import { useChatStore } from '@/store/chat';
+import { type StoreSetter } from '@/store/types';
+import { type ChatTopic } from '@/types/topic';
+import { setNamespace } from '@/utils/storeDebug';
+
+import { type TaskChatStore } from './store';
+
+const n = setNamespace('taskChat');
+
+const SWR_USE_FETCH_TASK_TOPICS = 'SWR_USE_FETCH_TASK_TOPICS';
+
+type Setter = StoreSetter<TaskChatStore>;
+
+export const createTaskChatSlice = (set: Setter, get: () => TaskChatStore, _api?: unknown) =>
+  new TaskChatActionImpl(set, get, _api);
+
+export class TaskChatActionImpl {
+  readonly #get: () => TaskChatStore;
+  readonly #set: Setter;
+
+  constructor(set: Setter, get: () => TaskChatStore, _api?: unknown) {
+    void _api;
+    this.#set = set;
+    this.#get = get;
+  }
+
+  switchTopic = (id: string | null): void => {
+    if (this.#get().activeTopicId === id) return;
+    this.#set({ activeTopicId: id }, false, n('switchTopic'));
+  };
+
+  /**
+   * Called by `ConversationHooks.onTopicCreated` after the backend creates
+   * a new topic from this panel's sendMessage. Writes the new id into the
+   * isolated store and refreshes the local topic list.
+   */
+  onTopicCreated = async (topicId: string): Promise<void> => {
+    this.#set({ activeTopicId: topicId }, false, n('onTopicCreated'));
+    await this.refreshTopics();
+  };
+
+  refreshTopics = async (): Promise<void> => {
+    const { activeAgentId } = useChatStore.getState();
+    if (!activeAgentId) return;
+    await mutate(
+      (key) =>
+        Array.isArray(key) && key[0] === SWR_USE_FETCH_TASK_TOPICS && key[1] === activeAgentId,
+    );
+  };
+
+  useFetchTopics = (
+    agentId: string | undefined,
+    includeTriggers: string[],
+  ): SWRResponse<ChatTopic[]> => {
+    return useClientDataSWRWithSync<ChatTopic[]>(
+      agentId ? [SWR_USE_FETCH_TASK_TOPICS, agentId, includeTriggers.join(',')] : null,
+      async () => {
+        if (!agentId) return [];
+        const result = await topicService.getTopics({
+          agentId,
+          current: 0,
+          includeTriggers,
+          pageSize: 100,
+        });
+        return result.items;
+      },
+      {
+        onData: (topics) => {
+          if (!topics) return;
+          if (isEqual(topics, this.#get().topics)) return;
+          this.#set({ topics }, false, n('useFetchTopics(onData)'));
+        },
+      },
+    );
+  };
+}
+
+export type TaskChatAction = Pick<TaskChatActionImpl, keyof TaskChatActionImpl>;

--- a/src/store/taskChat/index.ts
+++ b/src/store/taskChat/index.ts
@@ -1,0 +1,1 @@
+export { getTaskChatStoreState, type TaskChatStore, useTaskChatStore } from './store';

--- a/src/store/taskChat/initialState.ts
+++ b/src/store/taskChat/initialState.ts
@@ -1,0 +1,25 @@
+import { type ChatTopic } from '@/types/topic';
+
+/**
+ * State for the Task Manager right-side panel.
+ *
+ * Isolated from the main `useChatStore` so that switching/creating a Task
+ * Manager topic does not mutate the main chat's `activeTopicId`.
+ *
+ * Messages are NOT duplicated here — they live in `useChatStore.dbMessagesMap`,
+ * keyed by `messageMapKey(context)`. As long as the Task Manager uses its own
+ * `activeTopicId` in the context it builds, the messages are naturally stored
+ * under a different key.
+ */
+export interface TaskChatState {
+  activeTopicId: string | null;
+  /**
+   * `undefined` means topics have not been fetched yet (loading state).
+   */
+  topics: ChatTopic[] | undefined;
+}
+
+export const initialState: TaskChatState = {
+  activeTopicId: null,
+  topics: undefined,
+};

--- a/src/store/taskChat/store.ts
+++ b/src/store/taskChat/store.ts
@@ -1,0 +1,39 @@
+import { shallow } from 'zustand/shallow';
+import { createWithEqualityFn } from 'zustand/traditional';
+import { type StateCreator } from 'zustand/vanilla';
+
+import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
+import { flattenActions } from '../utils/flattenActions';
+import { type ResetableStore, ResetableStoreAction } from '../utils/resetableStore';
+import { createTaskChatSlice, type TaskChatAction } from './action';
+import { initialState, type TaskChatState } from './initialState';
+
+export type TaskChatStore = TaskChatState & TaskChatAction & ResetableStore;
+
+type TaskChatStoreAction = TaskChatAction & ResetableStore;
+
+class TaskChatResetAction extends ResetableStoreAction<TaskChatStore> {
+  protected readonly resetActionName = 'resetTaskChatStore';
+}
+
+const createStore: StateCreator<TaskChatStore, [['zustand/devtools', never]]> = (
+  ...parameters: Parameters<StateCreator<TaskChatStore, [['zustand/devtools', never]]>>
+) => ({
+  ...initialState,
+  ...flattenActions<TaskChatStoreAction>([
+    createTaskChatSlice(...parameters),
+    new TaskChatResetAction(...parameters),
+  ]),
+});
+
+const devtools = createDevtools('taskChat');
+
+export const useTaskChatStore = createWithEqualityFn<TaskChatStore>()(
+  devtools(createStore),
+  shallow,
+);
+
+expose('taskChat', useTaskChatStore);
+
+export const getTaskChatStoreState = () => useTaskChatStore.getState();

--- a/src/store/tool/slices/builtin/executors/index.ts
+++ b/src/store/tool/slices/builtin/executors/index.ts
@@ -16,6 +16,7 @@ import { gtdExecutor } from '@lobechat/builtin-tool-gtd/executor';
 import { knowledgeBaseExecutor } from '@lobechat/builtin-tool-knowledge-base/executor';
 import { localSystemExecutor } from '@lobechat/builtin-tool-local-system/executor';
 import { memoryExecutor } from '@lobechat/builtin-tool-memory/executor';
+import { taskExecutor } from '@lobechat/builtin-tool-task/executor';
 
 import type { BuiltinToolContext, BuiltinToolResult, IBuiltinToolExecutor } from '../types';
 import { activatorExecutor } from './lobe-activator';
@@ -150,6 +151,7 @@ registerExecutors([
   pageAgentExecutor,
   skillStoreExecutor,
   skillsExecutor,
+  taskExecutor,
   activatorExecutor,
   topicReferenceExecutor,
   userInteractionExecutor,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Closes LOBE-7189
Closes LOBE-7190
Closes LOBE-7194
Closes LOBE-7195
Closes LOBE-7196
Closes LOBE-7197
Closes LOBE-7198

#### 🔀 Description of Change

- route task tool write/read paths through existing store actions or shared server services
- align web executor, server runtime, lambda, and manifest semantics for task tools
- centralize `listTasks` parent resolution and `viewTask` detail-loading semantics
- remove dead task review config from tool schema until the runtime path is ready again

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Static validation only:
- checked changed files with VSCode diagnostics
- verified client/server task tool paths after rebasing onto `LOBE-6597-with-ui`

#### 📝 Additional Information

- This branch was rebased onto `LOBE-6597-with-ui` before these tool polish commits were replayed.
- `LOBE-7193` (CLI verification) and `LOBE-7199` (review config re-introduction) are intentionally left out of this PR.
