### PR TITLE
♻️ refactor: createAgent uses `agentModel.create` directly

### DIFF
--- a/packages/database/src/models/session.ts
+++ b/packages/database/src/models/session.ts
@@ -212,6 +212,10 @@ export class SessionModel {
 
   // **************** Create *************** //
 
+  /**
+   * @deprecated Use AgentModel.create for creating agents directly.
+   * This method creates both a session and an agent, which is the legacy pattern.
+   */
   create = async ({
     id = idGenerator('sessions'),
     type = 'agent',

--- a/packages/database/src/schemas/agent.ts
+++ b/packages/database/src/schemas/agent.ts
@@ -83,6 +83,7 @@ export const agents = pgTable(
   ],
 );
 
+/** @deprecated Use CreateAgentSchema from @lobechat/types instead */
 export const insertAgentSchema = createInsertSchema(agents, {
   agencyConfig: z.custom<LobeAgentAgencyConfig>().nullable().optional(),
   // Override chatConfig type to use the proper schema

--- a/packages/types/src/agent/item.ts
+++ b/packages/types/src/agent/item.ts
@@ -1,10 +1,12 @@
 import type { LLMParams } from 'model-bank';
+import { z } from 'zod';
 
 import type { FileItem } from '../files';
 import type { KnowledgeBaseItem } from '../knowledgeBase';
 import type { FewShots } from '../llm';
 import type { LobeAgentAgencyConfig } from './agencyConfig';
 import type { LobeAgentChatConfig } from './chatConfig';
+import { AgentChatConfigSchema } from './chatConfig';
 import type { LobeAgentTTSConfig } from './tts';
 
 export interface LobeAgentConfig {
@@ -84,6 +86,35 @@ export interface LobeAgentConfig {
 export type LobeAgentConfigKeys =
   | keyof LobeAgentConfig
   | ['params', keyof LobeAgentConfig['params']];
+
+/**
+ * Zod schema for creating a new agent.
+ * Covers all user-configurable fields; system fields (id, userId, timestamps) are excluded.
+ */
+export const CreateAgentSchema = z.object({
+  agencyConfig: z.record(z.unknown()).optional(),
+  avatar: z.string().nullable().optional(),
+  backgroundColor: z.string().nullable().optional(),
+  chatConfig: AgentChatConfigSchema.optional(),
+  description: z.string().nullable().optional(),
+  editorData: z.unknown().optional(),
+  fewShots: z.unknown().optional(),
+  marketIdentifier: z.string().nullable().optional(),
+  model: z.string().nullable().optional(),
+  openingMessage: z.string().nullable().optional(),
+  openingQuestions: z.array(z.string()).optional(),
+  params: z.record(z.unknown()).optional(),
+  plugins: z.array(z.string()).optional(),
+  provider: z.string().nullable().optional(),
+  sessionGroupId: z.string().nullable().optional(),
+  systemRole: z.string().nullable().optional(),
+  tags: z.array(z.string()).optional(),
+  title: z.string().nullable().optional(),
+  tts: z.record(z.unknown()).optional(),
+  virtual: z.boolean().nullable().optional(),
+});
+
+export type CreateAgentConfig = z.infer<typeof CreateAgentSchema>;
 
 // Agent database item type (independent from schema)
 export interface AgentItem {

--- a/packages/types/src/agent/item.ts
+++ b/packages/types/src/agent/item.ts
@@ -5,8 +5,7 @@ import type { FileItem } from '../files';
 import type { KnowledgeBaseItem } from '../knowledgeBase';
 import type { FewShots } from '../llm';
 import type { LobeAgentAgencyConfig } from './agencyConfig';
-import type { LobeAgentChatConfig } from './chatConfig';
-import { AgentChatConfigSchema } from './chatConfig';
+import { AgentChatConfigSchema, type LobeAgentChatConfig } from './chatConfig';
 import type { LobeAgentTTSConfig } from './tts';
 
 export interface LobeAgentConfig {
@@ -92,7 +91,7 @@ export type LobeAgentConfigKeys =
  * Covers all user-configurable fields; system fields (id, userId, timestamps) are excluded.
  */
 export const CreateAgentSchema = z.object({
-  agencyConfig: z.record(z.unknown()).optional(),
+  agencyConfig: z.custom<LobeAgentAgencyConfig>().optional(),
   avatar: z.string().nullable().optional(),
   backgroundColor: z.string().nullable().optional(),
   chatConfig: AgentChatConfigSchema.optional(),
@@ -110,7 +109,7 @@ export const CreateAgentSchema = z.object({
   systemRole: z.string().nullable().optional(),
   tags: z.array(z.string()).optional(),
   title: z.string().nullable().optional(),
-  tts: z.record(z.unknown()).optional(),
+  tts: z.custom<LobeAgentTTSConfig>().optional(),
   virtual: z.boolean().nullable().optional(),
 });
 

--- a/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/AddAgent.tsx
+++ b/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/AddAgent.tsx
@@ -100,7 +100,7 @@ const AddAgent = memo<{ mobile?: boolean }>(({ mobile }) => {
     try {
       const result = await createAgentWithMarketIdentifier(true);
       message.success(t('assistants.addAgentSuccess'));
-      navigate(SESSION_CHAT_URL(result!.agentId || result!.sessionId, mobile));
+      navigate(SESSION_CHAT_URL(result!.agentId, mobile));
     } finally {
       setIsLoading(false);
     }

--- a/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/ForkAndChat.tsx
+++ b/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/ForkAndChat.tsx
@@ -118,7 +118,7 @@ const ForkAndChat = memo<{ mobile?: boolean }>(({ mobile }) => {
       message.success(t('fork.success'));
 
       // Step 6: Navigate to chat
-      navigate(SESSION_CHAT_URL(result!.agentId || result!.sessionId, mobile));
+      navigate(SESSION_CHAT_URL(result!.agentId, mobile));
     } catch (error: any) {
       console.error('Fork failed:', error);
       message.error(t('fork.failed'));

--- a/src/server/routers/lambda/agent.ts
+++ b/src/server/routers/lambda/agent.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_AGENT_CONFIG, INBOX_SESSION_ID } from '@lobechat/const';
-import { type KnowledgeItem } from '@lobechat/types';
+import { CreateAgentSchema, type KnowledgeItem } from '@lobechat/types';
 import { KnowledgeType } from '@lobechat/types';
 import { z } from 'zod';
 
@@ -9,7 +9,6 @@ import { FileModel } from '@/database/models/file';
 import { KnowledgeBaseModel } from '@/database/models/knowledgeBase';
 import { SessionModel } from '@/database/models/session';
 import { UserModel } from '@/database/models/user';
-import { insertAgentSchema } from '@/database/schemas';
 import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { AgentService } from '@/server/services/agent';
@@ -50,35 +49,14 @@ export const agentRouter = router({
   createAgent: agentProcedure
     .input(
       z.object({
-        config: insertAgentSchema
-          .omit({
-            chatConfig: true,
-            openingMessage: true,
-            openingQuestions: true,
-            tags: true,
-            tts: true,
-          })
-          .passthrough()
-          .partial()
-          .optional(),
+        config: CreateAgentSchema.optional(),
         groupId: z.string().optional(),
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const session = await ctx.sessionModel.create({
-        config: input.config as any,
-        session: { groupId: input.groupId },
-        type: 'agent',
-      });
+      const agent = await ctx.agentModel.create(input.config ?? {});
 
-      // Get the agent ID from the created session
-      const sessionWithAgent = await ctx.sessionModel.findByIdOrSlug(session.id);
-      const agentId = sessionWithAgent?.agent?.id;
-
-      return {
-        agentId,
-        sessionId: session.id,
-      };
+      return { agentId: agent.id };
     }),
 
   createAgentFiles: agentProcedure

--- a/src/server/routers/lambda/agent.ts
+++ b/src/server/routers/lambda/agent.ts
@@ -54,7 +54,10 @@ export const agentRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const agent = await ctx.agentModel.create(input.config ?? {});
+      const agent = await ctx.agentModel.create({
+        ...input.config,
+        sessionGroupId: input.groupId,
+      });
 
       return { agentId: agent.id };
     }),

--- a/src/server/routers/lambda/session.ts
+++ b/src/server/routers/lambda/session.ts
@@ -23,7 +23,14 @@ const sessionProcedure = authedProcedure.use(serverDatabase).use(async (opts) =>
   });
 });
 
+/**
+ * @deprecated Session router is legacy. Use agent router for agent CRUD operations.
+ * Session-based agent creation (createSession, batchCreateSessions) should migrate
+ * to agent.createAgent which uses agentModel.create directly.
+ * Session query/update methods are still used by mobile but should be migrated.
+ */
 export const sessionRouter = router({
+  /** @deprecated Use agent.createAgent instead */
   batchCreateSessions: sessionProcedure
     .input(
       z.array(
@@ -72,6 +79,7 @@ export const sessionRouter = router({
       return ctx.sessionModel.count(input);
     }),
 
+  /** @deprecated Use agent.createAgent instead */
   createSession: sessionProcedure
     .input(
       z.object({

--- a/src/services/agent.ts
+++ b/src/services/agent.ts
@@ -54,8 +54,7 @@ export interface CreateAgentParams {
 }
 
 export interface CreateAgentResult {
-  agentId?: string;
-  sessionId: string;
+  agentId: string;
 }
 
 export interface CreateAgentOnlyParams {

--- a/src/services/session/index.ts
+++ b/src/services/session/index.ts
@@ -13,12 +13,17 @@ import {
   type UpdateSessionParams,
 } from '@/types/session';
 
+/**
+ * @deprecated Session service is legacy. Use agentService for agent CRUD operations.
+ * Mobile still uses this, but should migrate to agentService.
+ */
 export class SessionService {
   hasSessions = async (): Promise<boolean> => {
     const result = await this.countSessions();
     return result === 0;
   };
 
+  /** @deprecated Use agentService.createAgent instead */
   createSession = async (
     type: LobeSessionType,
     data: Partial<LobeAgentSession>,

--- a/src/store/agent/slices/agent/action.ts
+++ b/src/store/agent/slices/agent/action.ts
@@ -93,7 +93,6 @@ export class AgentSliceActionImpl {
           agent_id: result.agentId,
           assistant_name: params.config?.title || 'Untitled Agent',
           assistant_tags: params.config?.tags || [],
-          session_id: result.sessionId,
           user_id: userId || 'anonymous',
         },
       });

--- a/src/store/session/slices/session/action.ts
+++ b/src/store/session/slices/session/action.ts
@@ -59,6 +59,7 @@ export class SessionActionImpl {
     this.#set({ allAgentsDrawerOpen: false }, false, n('closeAllAgentsDrawer'));
   };
 
+  /** @deprecated Use agentStore.createAgent instead */
   createSession = async (
     agent?: PartialDeep<LobeAgentSession>,
     isSwitchSession: boolean = true,


### PR DESCRIPTION
## Summary
- `createAgent` router was still going through `sessionModel.create`, a legacy path that doesn't pass all agent fields (like `agencyConfig`) to the agents table
- Switched to `agentModel.create` which directly inserts into the agents table with full field support
- Removed `sessionId` from `CreateAgentResult` since sessions are no longer created

## Test plan
- [ ] Create a new agent via the sidebar + menu
- [ ] Verify agent is created correctly with all config fields
- [ ] Verify agent profile page loads correctly after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)