### PR TITLE
🐛 fix(builtin-tool-local-system): honor glob scope in local system tool

### DIFF
--- a/packages/builtin-tool-local-system/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-local-system/src/ExecutionRuntime/index.ts
@@ -128,6 +128,13 @@ export class LocalSystemExecutionRuntime extends ComputerRuntime {
         return { fullContent: params.fullContent, loc, path: params.path };
       }
 
+      case 'globLocalFiles': {
+        return {
+          pattern: params.pattern,
+          scope: params.directory,
+        };
+      }
+
       default: {
         return params;
       }

--- a/packages/builtin-tool-local-system/src/executor/index.test.ts
+++ b/packages/builtin-tool-local-system/src/executor/index.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { localSystemExecutor } from './index';
+
+const { globFilesMock } = vi.hoisted(() => ({
+  globFilesMock: vi.fn(),
+}));
+
+vi.mock('@/services/electron/localFileService', () => ({
+  localFileService: {
+    globFiles: globFilesMock,
+  },
+}));
+
+describe('LocalSystemExecutor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('globLocalFiles', () => {
+    it('should preserve scope and relative pattern when delegating glob search', async () => {
+      globFilesMock.mockResolvedValue({
+        files: ['/tmp/images/a.png'],
+        success: true,
+        total_files: 1,
+      });
+
+      await localSystemExecutor.globLocalFiles({
+        pattern: '**/*.{png,jpg,jpeg,gif,webp}',
+        scope: '/tmp/images',
+      });
+
+      expect(globFilesMock).toHaveBeenCalledWith({
+        pattern: '**/*.{png,jpg,jpeg,gif,webp}',
+        scope: '/tmp/images',
+      });
+    });
+  });
+});

--- a/packages/builtin-tool-local-system/src/executor/index.ts
+++ b/packages/builtin-tool-local-system/src/executor/index.ts
@@ -219,9 +219,9 @@ class LocalSystemExecutor extends BaseExecutor<typeof LocalSystemApiEnum> {
 
   globLocalFiles = async (params: GlobFilesParams): Promise<BuiltinToolResult> => {
     try {
-      const resolvedParams = resolveArgsWithScope(params, 'pattern');
       const result = await this.runtime.globFiles({
-        pattern: resolvedParams.pattern,
+        directory: params.scope,
+        pattern: params.pattern,
       });
       return this.toResult(result);
     } catch (error) {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The local system `globLocalFiles` tool previously dropped the user-provided `scope` when delegating to the desktop glob implementation. Relative glob patterns were effectively resolved without a search root, so searches could fall back to the process working directory instead of the intended folder.

This change maps IPC `scope` through `ComputerRuntime` using the normalized `directory` field and denormalizes it back to `scope` for `localFileService.globFiles`, while keeping the glob `pattern` unchanged. A regression test asserts the service receives `pattern` and `scope` together.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Ran: `bunx vitest run --config vitest.config.mts` in `packages/builtin-tool-local-system`.

#### 📸 Screenshots / Videos

N/A (non-UI)

#### 📝 Additional Information

None.

Made with [Cursor](https://cursor.com)