### PR TITLE
♻️ refactor: add backgroundColor to TaskParticipant and rename name to title

### DIFF
--- a/packages/database/src/models/__tests__/agent.getAvatars.test.ts
+++ b/packages/database/src/models/__tests__/agent.getAvatars.test.ts
@@ -73,6 +73,50 @@ describe('AgentModel.getAgentAvatarsByIds', () => {
     expect(result[0].id).toBe('agent-mine');
   });
 
+  it('should fallback to LobeAI defaults for inbox agent without avatar/title', async () => {
+    await serverDB.insert(agents).values({
+      avatar: null,
+      backgroundColor: null,
+      id: 'agent-inbox',
+      slug: 'inbox',
+      title: null,
+      userId,
+    });
+
+    const model = new AgentModel(serverDB, userId);
+    const result = await model.getAgentAvatarsByIds(['agent-inbox']);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      avatar: '/avatars/lobe-ai.png',
+      backgroundColor: null,
+      id: 'agent-inbox',
+      title: 'LobeAI',
+    });
+  });
+
+  it('should not override inbox agent avatar/title when they are set', async () => {
+    await serverDB.insert(agents).values({
+      avatar: '🤖',
+      backgroundColor: '#123456',
+      id: 'agent-inbox-custom',
+      slug: 'inbox',
+      title: 'Custom Inbox',
+      userId,
+    });
+
+    const model = new AgentModel(serverDB, userId);
+    const result = await model.getAgentAvatarsByIds(['agent-inbox-custom']);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      avatar: '🤖',
+      backgroundColor: '#123456',
+      id: 'agent-inbox-custom',
+      title: 'Custom Inbox',
+    });
+  });
+
   it('should return only selected fields', async () => {
     await serverDB.insert(agents).values({
       avatar: '🤖',

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -1,5 +1,5 @@
 import { getAgentPersistConfig } from '@lobechat/builtin-agents';
-import { INBOX_SESSION_ID } from '@lobechat/const';
+import { DEFAULT_INBOX_AVATAR, INBOX_SESSION_ID } from '@lobechat/const';
 import { and, desc, eq, ilike, inArray, isNull, or, sql } from 'drizzle-orm';
 import type { PartialDeep } from 'type-fest';
 
@@ -93,7 +93,7 @@ export class AgentModel {
 
     return rows.map(({ slug, ...row }) => ({
       ...row,
-      avatar: row.avatar || (slug === INBOX_SESSION_ID ? '/avatars/lobe-ai.png' : null),
+      avatar: row.avatar || (slug === INBOX_SESSION_ID ? DEFAULT_INBOX_AVATAR : null),
       title: row.title || (slug === INBOX_SESSION_ID ? 'LobeAI' : null),
     }));
   };

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -75,19 +75,27 @@ export class AgentModel {
 
   /**
    * Get minimal agent info (avatar, title, backgroundColor) by IDs.
+   * For inbox agent (slug='inbox'), falls back to LobeAI defaults when avatar/title are missing.
    */
   getAgentAvatarsByIds = async (ids: string[]) => {
     if (ids.length === 0) return [];
 
-    return this.db
+    const rows = await this.db
       .select({
         avatar: agents.avatar,
         backgroundColor: agents.backgroundColor,
         id: agents.id,
+        slug: agents.slug,
         title: agents.title,
       })
       .from(agents)
       .where(and(eq(agents.userId, this.userId), inArray(agents.id, ids)));
+
+    return rows.map(({ slug, ...row }) => ({
+      ...row,
+      avatar: row.avatar || (slug === INBOX_SESSION_ID ? '/avatars/lobe-ai.png' : null),
+      title: row.title || (slug === INBOX_SESSION_ID ? 'LobeAI' : null),
+    }));
   };
 
   /**

--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -42,8 +42,9 @@ export interface TaskTopicHandoff {
 
 export interface TaskParticipant {
   avatar: string | null;
+  backgroundColor: string | null;
   id: string;
-  name: string;
+  title: string;
   type: 'user' | 'agent';
 }
 

--- a/src/server/routers/lambda/__tests__/integration/task.integration.test.ts
+++ b/src/server/routers/lambda/__tests__/integration/task.integration.test.ts
@@ -436,7 +436,13 @@ describe('Task Router Integration', () => {
 
       const assigned = list.data.find((t) => t.assigneeAgentId === testAgentId)!;
       expect(assigned.participants).toEqual([
-        { avatar: 'avatar.png', id: testAgentId, name: 'Agent One', type: 'agent' },
+        {
+          avatar: 'avatar.png',
+          backgroundColor: null,
+          id: testAgentId,
+          title: 'Agent One',
+          type: 'agent',
+        },
       ]);
 
       const unassigned = list.data.find((t) => !t.assigneeAgentId)!;

--- a/src/server/routers/lambda/task.ts
+++ b/src/server/routers/lambda/task.ts
@@ -743,8 +743,9 @@ export const taskRouter = router({
           if (agent) {
             participants.push({
               avatar: agent.avatar,
+              backgroundColor: agent.backgroundColor,
               id: agent.id,
-              name: agent.title ?? '',
+              title: agent.title ?? '',
               type: 'agent',
             });
           }


### PR DESCRIPTION
## Summary
- Add `backgroundColor` field to `TaskParticipant` interface
- Rename `name` → `title` in `TaskParticipant` to align with agent data model
- Add LobeAI fallback in `getAgentAvatarsByIds` for inbox agent (slug=`inbox`) when `avatar`/`title` are missing — defaults to `/avatars/lobe-ai.png` and `LobeAI`
- Add tests for inbox agent fallback behavior

## Test plan
- [x] Existing `getAgentAvatarsByIds` tests pass
- [x] New inbox fallback tests pass (null avatar/title → defaults, custom avatar/title → preserved)
- [ ] Verify task list UI renders agent avatars with background color

🤖 Generated with [Claude Code](https://claude.com/claude-code)