### PR TITLE
✨ feat: associate web crawl documents with agent documents

### DIFF
--- a/packages/builtin-tool-web-browsing/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-web-browsing/src/ExecutionRuntime/index.ts
@@ -7,14 +7,22 @@ import type {
   SearchQuery,
   SearchServiceImpl,
 } from '@lobechat/types';
+import type { CrawlSuccessResult } from '@lobechat/web-crawler';
 
 import { CRAWL_CONTENT_LIMITED_COUNT, SEARCH_ITEM_LIMITED_COUNT } from '../const';
 
+export interface WebBrowsingRuntimeOptions {
+  onCrawlComplete?: (results: CrawlSuccessResult[]) => Promise<void>;
+  searchService: SearchServiceImpl;
+}
+
 export class WebBrowsingExecutionRuntime {
+  private onCrawlComplete?: (results: CrawlSuccessResult[]) => Promise<void>;
   private searchService: SearchServiceImpl;
 
-  constructor(options: { searchService: SearchServiceImpl }) {
+  constructor(options: WebBrowsingRuntimeOptions) {
     this.searchService = options.searchService;
+    this.onCrawlComplete = options.onCrawlComplete;
   }
 
   async search(
@@ -65,6 +73,21 @@ export class WebBrowsingExecutionRuntime {
     });
 
     const { results } = response;
+
+    // Invoke onCrawlComplete callback with successful results
+    if (this.onCrawlComplete) {
+      const successResults = results
+        .filter((item) => !('errorMessage' in item.data) && item.data.content)
+        .map((item) => item.data as CrawlSuccessResult);
+
+      if (successResults.length > 0) {
+        try {
+          await this.onCrawlComplete(successResults);
+        } catch (error) {
+          console.error('[WebBrowsing] onCrawlComplete callback failed:', error);
+        }
+      }
+    }
 
     const content = results.map((item) =>
       'errorMessage' in item

--- a/packages/builtin-tool-web-browsing/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-web-browsing/src/ExecutionRuntime/index.ts
@@ -11,36 +11,34 @@ import type { CrawlSuccessResult } from '@lobechat/web-crawler';
 
 import { CRAWL_CONTENT_LIMITED_COUNT, SEARCH_ITEM_LIMITED_COUNT } from '../const';
 
-export interface WebBrowsingDocumentContext {
-  agentId?: string;
-  topicId?: string;
-}
-
 export interface WebBrowsingDocumentService {
-  associateDocument: (documentId: string, context: WebBrowsingDocumentContext) => Promise<void>;
-  createDocument: (
-    params: {
-      content: string;
-      description?: string;
-      title: string;
-      url: string;
-    },
-    context: WebBrowsingDocumentContext,
-  ) => Promise<{ id: string }>;
+  associateDocument: (documentId: string) => Promise<void>;
+  createDocument: (params: {
+    content: string;
+    description?: string;
+    title: string;
+    url: string;
+  }) => Promise<{ id: string }>;
 }
 
 export interface WebBrowsingRuntimeOptions {
+  agentId?: string;
   documentService?: WebBrowsingDocumentService;
   searchService: SearchServiceImpl;
+  topicId?: string;
 }
 
 export class WebBrowsingExecutionRuntime {
+  private agentId?: string;
   private documentService?: WebBrowsingDocumentService;
   private searchService: SearchServiceImpl;
+  private topicId?: string;
 
   constructor(options: WebBrowsingRuntimeOptions) {
     this.searchService = options.searchService;
     this.documentService = options.documentService;
+    this.agentId = options.agentId;
+    this.topicId = options.topicId;
   }
 
   async search(
@@ -81,17 +79,11 @@ export class WebBrowsingExecutionRuntime {
     }
   }
 
-  async crawlSinglePage(
-    args: CrawlSinglePageQuery,
-    context?: WebBrowsingDocumentContext,
-  ): Promise<BuiltinServerRuntimeOutput> {
-    return this.crawlMultiPages({ urls: [args.url] }, context);
+  async crawlSinglePage(args: CrawlSinglePageQuery): Promise<BuiltinServerRuntimeOutput> {
+    return this.crawlMultiPages({ urls: [args.url] });
   }
 
-  async crawlMultiPages(
-    args: CrawlMultiPagesQuery,
-    context?: WebBrowsingDocumentContext,
-  ): Promise<BuiltinServerRuntimeOutput> {
+  async crawlMultiPages(args: CrawlMultiPagesQuery): Promise<BuiltinServerRuntimeOutput> {
     const response = await this.searchService.crawlPages({
       urls: args.urls,
     });
@@ -99,7 +91,7 @@ export class WebBrowsingExecutionRuntime {
     const { results } = response;
 
     // Save crawled pages as documents and associate with agent
-    if (this.documentService && context) {
+    if (this.documentService) {
       await Promise.all(
         results.map(async (item) => {
           if ('errorMessage' in item.data) return;
@@ -108,17 +100,14 @@ export class WebBrowsingExecutionRuntime {
           if (!pageData.content) return;
 
           try {
-            const doc = await this.documentService!.createDocument(
-              {
-                content: pageData.content,
-                description: pageData.description || `Crawled from ${pageData.url}`,
-                title: pageData.title || pageData.url,
-                url: pageData.url,
-              },
-              context,
-            );
+            const doc = await this.documentService!.createDocument({
+              content: pageData.content,
+              description: pageData.description || `Crawled from ${pageData.url}`,
+              title: pageData.title || pageData.url,
+              url: pageData.url,
+            });
 
-            await this.documentService!.associateDocument(doc.id, context);
+            await this.documentService!.associateDocument(doc.id);
           } catch (error) {
             console.error('[WebBrowsing] Failed to save crawl result to agent document:', error);
           }

--- a/packages/builtin-tool-web-browsing/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-web-browsing/src/ExecutionRuntime/index.ts
@@ -11,18 +11,28 @@ import type { CrawlSuccessResult } from '@lobechat/web-crawler';
 
 import { CRAWL_CONTENT_LIMITED_COUNT, SEARCH_ITEM_LIMITED_COUNT } from '../const';
 
+export interface WebBrowsingDocumentService {
+  associateDocument: (documentId: string) => Promise<void>;
+  createDocument: (params: {
+    content: string;
+    description?: string;
+    title: string;
+    url: string;
+  }) => Promise<{ id: string }>;
+}
+
 export interface WebBrowsingRuntimeOptions {
-  onCrawlComplete?: (results: CrawlSuccessResult[]) => Promise<void>;
+  documentService?: WebBrowsingDocumentService;
   searchService: SearchServiceImpl;
 }
 
 export class WebBrowsingExecutionRuntime {
-  private onCrawlComplete?: (results: CrawlSuccessResult[]) => Promise<void>;
+  private documentService?: WebBrowsingDocumentService;
   private searchService: SearchServiceImpl;
 
   constructor(options: WebBrowsingRuntimeOptions) {
     this.searchService = options.searchService;
-    this.onCrawlComplete = options.onCrawlComplete;
+    this.documentService = options.documentService;
   }
 
   async search(
@@ -74,19 +84,29 @@ export class WebBrowsingExecutionRuntime {
 
     const { results } = response;
 
-    // Invoke onCrawlComplete callback with successful results
-    if (this.onCrawlComplete) {
-      const successResults = results
-        .filter((item) => !('errorMessage' in item.data) && item.data.content)
-        .map((item) => item.data as CrawlSuccessResult);
+    // Save crawled pages as documents and associate with agent
+    if (this.documentService) {
+      await Promise.all(
+        results.map(async (item) => {
+          if ('errorMessage' in item.data) return;
 
-      if (successResults.length > 0) {
-        try {
-          await this.onCrawlComplete(successResults);
-        } catch (error) {
-          console.error('[WebBrowsing] onCrawlComplete callback failed:', error);
-        }
-      }
+          const pageData = item.data as CrawlSuccessResult;
+          if (!pageData.content) return;
+
+          try {
+            const doc = await this.documentService!.createDocument({
+              content: pageData.content,
+              description: pageData.description || `Crawled from ${pageData.url}`,
+              title: pageData.title || pageData.url,
+              url: pageData.url,
+            });
+
+            await this.documentService!.associateDocument(doc.id);
+          } catch (error) {
+            console.error('[WebBrowsing] Failed to save crawl result to agent document:', error);
+          }
+        }),
+      );
     }
 
     const content = results.map((item) =>

--- a/packages/builtin-tool-web-browsing/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-web-browsing/src/ExecutionRuntime/index.ts
@@ -11,14 +11,22 @@ import type { CrawlSuccessResult } from '@lobechat/web-crawler';
 
 import { CRAWL_CONTENT_LIMITED_COUNT, SEARCH_ITEM_LIMITED_COUNT } from '../const';
 
+export interface WebBrowsingDocumentContext {
+  agentId?: string;
+  topicId?: string;
+}
+
 export interface WebBrowsingDocumentService {
-  associateDocument: (documentId: string) => Promise<void>;
-  createDocument: (params: {
-    content: string;
-    description?: string;
-    title: string;
-    url: string;
-  }) => Promise<{ id: string }>;
+  associateDocument: (documentId: string, context: WebBrowsingDocumentContext) => Promise<void>;
+  createDocument: (
+    params: {
+      content: string;
+      description?: string;
+      title: string;
+      url: string;
+    },
+    context: WebBrowsingDocumentContext,
+  ) => Promise<{ id: string }>;
 }
 
 export interface WebBrowsingRuntimeOptions {
@@ -73,11 +81,17 @@ export class WebBrowsingExecutionRuntime {
     }
   }
 
-  async crawlSinglePage(args: CrawlSinglePageQuery): Promise<BuiltinServerRuntimeOutput> {
-    return this.crawlMultiPages({ urls: [args.url] });
+  async crawlSinglePage(
+    args: CrawlSinglePageQuery,
+    context?: WebBrowsingDocumentContext,
+  ): Promise<BuiltinServerRuntimeOutput> {
+    return this.crawlMultiPages({ urls: [args.url] }, context);
   }
 
-  async crawlMultiPages(args: CrawlMultiPagesQuery): Promise<BuiltinServerRuntimeOutput> {
+  async crawlMultiPages(
+    args: CrawlMultiPagesQuery,
+    context?: WebBrowsingDocumentContext,
+  ): Promise<BuiltinServerRuntimeOutput> {
     const response = await this.searchService.crawlPages({
       urls: args.urls,
     });
@@ -85,7 +99,7 @@ export class WebBrowsingExecutionRuntime {
     const { results } = response;
 
     // Save crawled pages as documents and associate with agent
-    if (this.documentService) {
+    if (this.documentService && context) {
       await Promise.all(
         results.map(async (item) => {
           if ('errorMessage' in item.data) return;
@@ -94,14 +108,17 @@ export class WebBrowsingExecutionRuntime {
           if (!pageData.content) return;
 
           try {
-            const doc = await this.documentService!.createDocument({
-              content: pageData.content,
-              description: pageData.description || `Crawled from ${pageData.url}`,
-              title: pageData.title || pageData.url,
-              url: pageData.url,
-            });
+            const doc = await this.documentService!.createDocument(
+              {
+                content: pageData.content,
+                description: pageData.description || `Crawled from ${pageData.url}`,
+                title: pageData.title || pageData.url,
+                url: pageData.url,
+              },
+              context,
+            );
 
-            await this.documentService!.associateDocument(doc.id);
+            await this.documentService!.associateDocument(doc.id, context);
           } catch (error) {
             console.error('[WebBrowsing] Failed to save crawl result to agent document:', error);
           }

--- a/packages/database/src/models/__tests__/document.test.ts
+++ b/packages/database/src/models/__tests__/document.test.ts
@@ -55,6 +55,51 @@ const createTestDocument = async (model: DocumentModel, fModel: FileModel, conte
 };
 
 describe('DocumentModel', () => {
+  describe('findOrCreateFolder', () => {
+    it('should create a new folder when none exists', async () => {
+      const folder = await documentModel.findOrCreateFolder('bookmark');
+
+      expect(folder).toBeDefined();
+      expect(folder.fileType).toBe('custom/folder');
+      expect(folder.filename).toBe('bookmark');
+      expect(folder.title).toBe('bookmark');
+      expect(folder.source).toBe('');
+      expect(folder.sourceType).toBe('api');
+      expect(folder.totalCharCount).toBe(0);
+      expect(folder.content).toBe('');
+    });
+
+    it('should return existing folder on second call', async () => {
+      const first = await documentModel.findOrCreateFolder('bookmark');
+      const second = await documentModel.findOrCreateFolder('bookmark');
+
+      expect(second.id).toBe(first.id);
+    });
+
+    it('should isolate folders by user', async () => {
+      const folder1 = await documentModel.findOrCreateFolder('bookmark');
+      const folder2 = await documentModel2.findOrCreateFolder('bookmark');
+
+      expect(folder1.id).not.toBe(folder2.id);
+    });
+
+    it('should support parentId for nested folders', async () => {
+      const parent = await documentModel.findOrCreateFolder('root');
+      const child = await documentModel.findOrCreateFolder('sub', parent.id);
+
+      expect(child.parentId).toBe(parent.id);
+      expect(child.id).not.toBe(parent.id);
+    });
+
+    it('should distinguish folders with same name but different parentId', async () => {
+      const topLevel = await documentModel.findOrCreateFolder('notes');
+      const parent = await documentModel.findOrCreateFolder('root');
+      const nested = await documentModel.findOrCreateFolder('notes', parent.id);
+
+      expect(topLevel.id).not.toBe(nested.id);
+    });
+  });
+
   describe('create', () => {
     it('should create a new document', async () => {
       const { id: fileId } = await fileModel.create({

--- a/packages/database/src/models/agentDocuments/__tests__/agentDocument.test.ts
+++ b/packages/database/src/models/agentDocuments/__tests__/agentDocument.test.ts
@@ -39,6 +39,96 @@ beforeEach(async () => {
 });
 
 describe('AgentDocumentModel', () => {
+  describe('associate', () => {
+    it('should link an existing document to an agent and return the new id', async () => {
+      // Create a document in the documents table directly
+      const [doc] = await serverDB
+        .insert(documents)
+        .values({
+          content: 'crawled content',
+          fileType: 'article',
+          filename: 'page.html',
+          source: 'https://example.com',
+          sourceType: 'web',
+          title: 'Example Page',
+          totalCharCount: 15,
+          totalLineCount: 1,
+          userId,
+        })
+        .returning();
+
+      const result = await agentDocumentModel.associate({ agentId, documentId: doc!.id });
+
+      expect(result.id).toBeDefined();
+      expect(result.id).not.toBe('');
+
+      // Verify the agentDocuments row was created
+      const [row] = await serverDB
+        .select()
+        .from(agentDocuments)
+        .where(eq(agentDocuments.id, result.id));
+
+      expect(row).toBeDefined();
+      expect(row?.agentId).toBe(agentId);
+      expect(row?.documentId).toBe(doc!.id);
+      expect(row?.userId).toBe(userId);
+      expect(row?.policyLoad).toBe(PolicyLoad.PROGRESSIVE);
+    });
+
+    it('should be idempotent (onConflictDoNothing)', async () => {
+      const [doc] = await serverDB
+        .insert(documents)
+        .values({
+          content: 'content',
+          fileType: 'article',
+          filename: 'dup.html',
+          source: 'https://example.com/dup',
+          sourceType: 'web',
+          title: 'Dup Page',
+          totalCharCount: 7,
+          totalLineCount: 1,
+          userId,
+        })
+        .returning();
+
+      const first = await agentDocumentModel.associate({ agentId, documentId: doc!.id });
+      const second = await agentDocumentModel.associate({ agentId, documentId: doc!.id });
+
+      expect(first.id).toBeDefined();
+      // Second call should not throw, id may be undefined due to onConflictDoNothing
+      expect(second).toBeDefined();
+    });
+
+    it('should not create documents row — only the link', async () => {
+      const [doc] = await serverDB
+        .insert(documents)
+        .values({
+          content: 'existing',
+          fileType: 'article',
+          filename: 'existing.html',
+          source: 'https://example.com/existing',
+          sourceType: 'web',
+          title: 'Existing',
+          totalCharCount: 8,
+          totalLineCount: 1,
+          userId,
+        })
+        .returning();
+
+      const countBefore = await serverDB
+        .select()
+        .from(documents)
+        .where(eq(documents.userId, userId));
+      await agentDocumentModel.associate({ agentId, documentId: doc!.id });
+      const countAfter = await serverDB
+        .select()
+        .from(documents)
+        .where(eq(documents.userId, userId));
+
+      expect(countAfter.length).toBe(countBefore.length);
+    });
+  });
+
   describe('create', () => {
     it('should create an agent document with normalized policy and linked document row', async () => {
       const result = await agentDocumentModel.create(agentId, 'identity.md', 'line1\nline2', {

--- a/packages/database/src/models/agentDocuments/agentDocument.ts
+++ b/packages/database/src/models/agentDocuments/agentDocument.ts
@@ -85,6 +85,38 @@ export class AgentDocumentModel {
     };
   }
 
+  async associate(params: {
+    agentId: string;
+    documentId: string;
+    policyLoad?: PolicyLoad;
+  }): Promise<{ id: string }> {
+    const { agentId, documentId, policyLoad } = params;
+
+    const [result] = await this.db
+      .insert(agentDocuments)
+      .values({
+        accessPublic: 0,
+        accessSelf:
+          AgentAccess.EXECUTE |
+          AgentAccess.LIST |
+          AgentAccess.READ |
+          AgentAccess.WRITE |
+          AgentAccess.DELETE,
+        accessShared: 0,
+        agentId,
+        documentId,
+        policyLoad: policyLoad ?? PolicyLoad.PROGRESSIVE,
+        policyLoadFormat: DocumentLoadFormat.RAW,
+        policyLoadPosition: DocumentLoadPosition.BEFORE_FIRST_USER,
+        policyLoadRule: DocumentLoadRule.ALWAYS,
+        userId: this.userId,
+      })
+      .onConflictDoNothing()
+      .returning({ id: agentDocuments.id });
+
+    return { id: result?.id };
+  }
+
   async create(
     agentId: string,
     filename: string,

--- a/packages/database/src/models/agentDocuments/agentDocument.ts
+++ b/packages/database/src/models/agentDocuments/agentDocument.ts
@@ -92,6 +92,13 @@ export class AgentDocumentModel {
   }): Promise<{ id: string }> {
     const { agentId, documentId, policyLoad } = params;
 
+    // Verify the document belongs to the current user
+    const doc = await this.db.query.documents.findFirst({
+      where: and(eq(documents.id, documentId), eq(documents.userId, this.userId)),
+    });
+
+    if (!doc) return { id: '' };
+
     const [result] = await this.db
       .insert(agentDocuments)
       .values({

--- a/packages/database/src/models/document.ts
+++ b/packages/database/src/models/document.ts
@@ -1,7 +1,7 @@
 import { and, count, desc, eq, inArray } from 'drizzle-orm';
 
 import type { DocumentItem, NewDocument } from '../schemas';
-import { documents } from '../schemas';
+import { DOCUMENT_FOLDER_TYPE, documents } from '../schemas';
 import type { LobeChatDatabase } from '../type';
 
 export interface QueryDocumentParams {
@@ -19,6 +19,36 @@ export class DocumentModel {
     this.userId = userId;
     this.db = db;
   }
+
+  findOrCreateFolder = async (name: string, parentId?: string): Promise<DocumentItem> => {
+    const conditions = [
+      eq(documents.userId, this.userId),
+      eq(documents.fileType, DOCUMENT_FOLDER_TYPE),
+      eq(documents.filename, name),
+    ];
+
+    if (parentId) {
+      conditions.push(eq(documents.parentId, parentId));
+    }
+
+    const existing = await this.db.query.documents.findFirst({
+      where: and(...conditions),
+    });
+
+    if (existing) return existing;
+
+    return this.create({
+      content: '',
+      fileType: DOCUMENT_FOLDER_TYPE,
+      filename: name,
+      parentId,
+      source: '',
+      sourceType: 'api',
+      title: name,
+      totalCharCount: 0,
+      totalLineCount: 0,
+    });
+  };
 
   create = async (params: Omit<NewDocument, 'userId'>): Promise<DocumentItem> => {
     const result = (await this.db

--- a/packages/database/src/models/document.ts
+++ b/packages/database/src/models/document.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, inArray } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, isNull } from 'drizzle-orm';
 
 import type { DocumentItem, NewDocument } from '../schemas';
 import { DOCUMENT_FOLDER_TYPE, documents } from '../schemas';
@@ -21,18 +21,13 @@ export class DocumentModel {
   }
 
   findOrCreateFolder = async (name: string, parentId?: string): Promise<DocumentItem> => {
-    const conditions = [
-      eq(documents.userId, this.userId),
-      eq(documents.fileType, DOCUMENT_FOLDER_TYPE),
-      eq(documents.filename, name),
-    ];
-
-    if (parentId) {
-      conditions.push(eq(documents.parentId, parentId));
-    }
-
     const existing = await this.db.query.documents.findFirst({
-      where: and(...conditions),
+      where: and(
+        eq(documents.userId, this.userId),
+        eq(documents.fileType, DOCUMENT_FOLDER_TYPE),
+        eq(documents.filename, name),
+        parentId ? eq(documents.parentId, parentId) : isNull(documents.parentId),
+      ),
     });
 
     if (existing) return existing;

--- a/packages/database/src/models/recent.ts
+++ b/packages/database/src/models/recent.ts
@@ -1,6 +1,6 @@
 import { sql } from 'drizzle-orm';
 
-import { agents, documents, tasks, topics } from '../schemas';
+import { agents, DOCUMENT_FOLDER_TYPE, documents, tasks, topics } from '../schemas';
 import type { LobeChatDatabase } from '../type';
 
 export interface RecentDbItem {
@@ -56,7 +56,7 @@ export class RecentModel {
         WHERE ${documents.userId} = ${this.userId}
           AND ${documents.sourceType} != 'file'
           AND ${documents.knowledgeBaseId} IS NULL
-          AND ${documents.fileType} != 'custom/folder'
+          AND ${documents.fileType} != ${DOCUMENT_FOLDER_TYPE}
 
         UNION ALL
 

--- a/packages/database/src/repositories/knowledge/index.ts
+++ b/packages/database/src/repositories/knowledge/index.ts
@@ -4,7 +4,7 @@ import { and, eq, sql } from 'drizzle-orm';
 
 import { DocumentModel } from '../../models/document';
 import { FileModel } from '../../models/file';
-import { documents, files, knowledgeBaseFiles } from '../../schemas';
+import { DOCUMENT_FOLDER_TYPE, documents, files, knowledgeBaseFiles } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
 
 export interface KnowledgeItem {
@@ -313,7 +313,7 @@ export class KnowledgeRepo {
     const document = await this.documentModel.findById(id);
     if (!document) return;
 
-    if (document.fileType === 'custom/folder') {
+    if (document.fileType === DOCUMENT_FOLDER_TYPE) {
       const children = await this.db.query.documents.findMany({
         where: and(eq(documents.parentId, id), eq(documents.userId, this.userId)),
       });

--- a/packages/database/src/repositories/search/index.ts
+++ b/packages/database/src/repositories/search/index.ts
@@ -3,6 +3,7 @@ import { and, eq, ne, sql } from 'drizzle-orm';
 import {
   agents,
   chatGroups,
+  DOCUMENT_FOLDER_TYPE,
   documents,
   files,
   knowledgeBaseFiles,
@@ -554,7 +555,7 @@ export class SearchRepo {
   }
 
   /**
-   * Search folders (documents with file_type='custom/folder') (BM25)
+   * Search folders (documents with file_type=DOCUMENT_FOLDER_TYPE) (BM25)
    */
   private async searchFolders(query: string, limit: number): Promise<FolderSearchResult[]> {
     const bm25Query = sanitizeBm25Query(query);
@@ -575,7 +576,7 @@ export class SearchRepo {
       .where(
         and(
           eq(documents.userId, this.userId),
-          eq(documents.fileType, 'custom/folder'),
+          eq(documents.fileType, DOCUMENT_FOLDER_TYPE),
           sql`(${documents.title} @@@ ${bm25Query} OR ${documents.slug} @@@ ${bm25Query} OR ${documents.description} @@@ ${bm25Query})`,
         ),
       )

--- a/packages/database/src/schemas/file.ts
+++ b/packages/database/src/schemas/file.ts
@@ -22,6 +22,8 @@ import { accessedAt, createdAt, timestamps } from './_helpers';
 import { asyncTasks } from './asyncTask';
 import { users } from './user';
 
+export const DOCUMENT_FOLDER_TYPE = 'custom/folder';
+
 export const globalFiles = pgTable(
   'global_files',
   {

--- a/src/server/routers/lambda/agentDocument.ts
+++ b/src/server/routers/lambda/agentDocument.ts
@@ -231,6 +231,20 @@ export const agentDocumentRouter = router({
     }),
 
   /**
+   * Tool-oriented: associate an existing document with an agent
+   */
+  associateDocument: agentDocumentProcedure
+    .input(
+      z.object({
+        agentId: z.string(),
+        documentId: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      return ctx.agentDocumentService.associateDocument(input.agentId, input.documentId);
+    }),
+
+  /**
    * Tool-oriented: create document
    */
   createDocument: agentDocumentProcedure

--- a/src/server/services/agentDocuments.test.ts
+++ b/src/server/services/agentDocuments.test.ts
@@ -19,6 +19,7 @@ describe('AgentDocumentsService', () => {
   const userId = 'user-1';
 
   const mockModel = {
+    associate: vi.fn(),
     create: vi.fn(),
     findByAgent: vi.fn(),
     findByFilename: vi.fn(),
@@ -134,6 +135,18 @@ describe('AgentDocumentsService', () => {
 
       expect(mockModel.hasByAgent).toHaveBeenCalledWith('agent-1');
       expect(result).toBe(true);
+    });
+  });
+
+  describe('associateDocument', () => {
+    it('should delegate to agentDocumentModel.associate', async () => {
+      mockModel.associate.mockResolvedValue({ id: 'ad-1' });
+
+      const service = new AgentDocumentsService(db, userId);
+      const result = await service.associateDocument('agent-1', 'doc-1');
+
+      expect(mockModel.associate).toHaveBeenCalledWith({ agentId: 'agent-1', documentId: 'doc-1' });
+      expect(result).toEqual({ id: 'ad-1' });
     });
   });
 });

--- a/src/server/services/agentDocuments.ts
+++ b/src/server/services/agentDocuments.ts
@@ -208,6 +208,10 @@ export class AgentDocumentsService {
     });
   }
 
+  async associateDocument(agentId: string, documentId: string): Promise<{ id: string }> {
+    return this.agentDocumentModel.associate({ agentId, documentId });
+  }
+
   async createDocument(agentId: string, title: string, content: string) {
     return this.createWithUniqueFilename(agentId, title, content);
   }

--- a/src/server/services/toolExecution/serverRuntimes/webBrowsing.ts
+++ b/src/server/services/toolExecution/serverRuntimes/webBrowsing.ts
@@ -7,40 +7,34 @@ import { SearchService } from '@/server/services/search';
 
 import { type ServerRuntimeRegistration } from './types';
 
-/**
- * WebBrowsing Server Runtime
- * Per-request factory to support saving crawled content to agent documents
- */
 export const webBrowsingRuntime: ServerRuntimeRegistration = {
   factory: (context) => {
     const { userId, serverDB, agentId } = context;
+    const canSaveDocuments = userId && serverDB && agentId;
 
     return new WebBrowsingExecutionRuntime({
-      onCrawlComplete:
-        userId && serverDB && agentId
-          ? async (results) => {
-              const documentModel = new DocumentModel(serverDB, userId);
-              const agentDocumentsService = new AgentDocumentsService(serverDB, userId);
-
-              await Promise.all(
-                results.map(async (pageData) => {
-                  const doc = await documentModel.create({
-                    content: pageData.content || '',
-                    description: pageData.description || `Crawled from ${pageData.url}`,
-                    fileType: 'article',
-                    filename: pageData.title || pageData.url,
-                    source: pageData.url,
-                    sourceType: 'web',
-                    title: pageData.title || pageData.url,
-                    totalCharCount: pageData.content?.length || 0,
-                    totalLineCount: pageData.content?.split('\n').length || 0,
-                  });
-
-                  await agentDocumentsService.associateDocument(agentId, doc.id);
-                }),
-              );
-            }
-          : undefined,
+      documentService: canSaveDocuments
+        ? {
+            associateDocument: async (documentId) => {
+              const service = new AgentDocumentsService(serverDB, userId);
+              await service.associateDocument(agentId, documentId);
+            },
+            createDocument: async ({ content, description, title, url }) => {
+              const model = new DocumentModel(serverDB, userId);
+              return model.create({
+                content,
+                description,
+                fileType: 'article',
+                filename: title,
+                source: url,
+                sourceType: 'web',
+                title,
+                totalCharCount: content.length,
+                totalLineCount: content.split('\n').length,
+              });
+            },
+          }
+        : undefined,
       searchService: new SearchService(),
     });
   },

--- a/src/server/services/toolExecution/serverRuntimes/webBrowsing.ts
+++ b/src/server/services/toolExecution/serverRuntimes/webBrowsing.ts
@@ -56,8 +56,11 @@ export const webBrowsingRuntime: ServerRuntimeRegistration = {
 
                 // Associate with agent
                 await agentDocumentsService.associateDocument(agentId, doc.id);
-              } catch {
-                // Silently ignore document creation errors to not block the main flow
+              } catch (error) {
+                console.error(
+                  '[WebBrowsing] Failed to save crawl result to agent document:',
+                  error,
+                );
               }
             }),
           );

--- a/src/server/services/toolExecution/serverRuntimes/webBrowsing.ts
+++ b/src/server/services/toolExecution/serverRuntimes/webBrowsing.ts
@@ -1,20 +1,73 @@
 import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
 import { WebBrowsingExecutionRuntime } from '@lobechat/builtin-tool-web-browsing/executionRuntime';
+import { type CrawlMultiPagesQuery, type CrawlPluginState } from '@lobechat/types';
+import { type CrawlSuccessResult } from '@lobechat/web-crawler';
 
+import { DocumentModel } from '@/database/models/document';
+import { AgentDocumentsService } from '@/server/services/agentDocuments';
 import { SearchService } from '@/server/services/search';
 
 import { type ServerRuntimeRegistration } from './types';
 
-// Pre-instantiated (no per-request context needed)
-const runtime = new WebBrowsingExecutionRuntime({
-  searchService: new SearchService(),
-});
-
 /**
  * WebBrowsing Server Runtime
- * Pre-instantiated runtime (no per-request context needed)
+ * Per-request factory to support saving crawled content to agent documents
  */
 export const webBrowsingRuntime: ServerRuntimeRegistration = {
-  factory: () => runtime,
+  factory: (context) => {
+    const baseRuntime = new WebBrowsingExecutionRuntime({
+      searchService: new SearchService(),
+    });
+
+    // If we have userId, serverDB, and agentId, wrap crawl methods to save to agent documents
+    if (context.userId && context.serverDB && context.agentId) {
+      const agentDocumentsService = new AgentDocumentsService(context.serverDB, context.userId);
+      const documentModel = new DocumentModel(context.serverDB, context.userId);
+      const agentId = context.agentId;
+
+      const originalCrawlMultiPages = baseRuntime.crawlMultiPages.bind(baseRuntime);
+
+      baseRuntime.crawlMultiPages = async (params: CrawlMultiPagesQuery) => {
+        const result = await originalCrawlMultiPages(params);
+
+        if (result.success) {
+          const crawlState = result.state as CrawlPluginState;
+
+          await Promise.all(
+            crawlState.results.map(async (crawlResult) => {
+              if ('errorMessage' in crawlResult.data) return;
+
+              const pageData = crawlResult.data as CrawlSuccessResult;
+              if (!pageData.content) return;
+
+              try {
+                // Create document in documents table
+                const doc = await documentModel.create({
+                  content: pageData.content,
+                  description: pageData.description || `Crawled from ${pageData.url}`,
+                  fileType: 'article',
+                  filename: pageData.title || pageData.url,
+                  source: pageData.url,
+                  sourceType: 'web',
+                  title: pageData.title || pageData.url,
+                  totalCharCount: pageData.content.length,
+                  totalLineCount: pageData.content.split('\n').length,
+                });
+
+                // Associate with agent
+                await agentDocumentsService.associateDocument(agentId, doc.id);
+              } catch {
+                // Silently ignore document creation errors to not block the main flow
+              }
+            }),
+          );
+        }
+
+        return result;
+      };
+    }
+
+    return baseRuntime;
+  },
   identifier: WebBrowsingManifest.identifier,
 };

--- a/src/server/services/toolExecution/serverRuntimes/webBrowsing.ts
+++ b/src/server/services/toolExecution/serverRuntimes/webBrowsing.ts
@@ -1,7 +1,5 @@
 import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
 import { WebBrowsingExecutionRuntime } from '@lobechat/builtin-tool-web-browsing/executionRuntime';
-import { type CrawlMultiPagesQuery, type CrawlPluginState } from '@lobechat/types';
-import { type CrawlSuccessResult } from '@lobechat/web-crawler';
 
 import { DocumentModel } from '@/database/models/document';
 import { AgentDocumentsService } from '@/server/services/agentDocuments';
@@ -15,62 +13,36 @@ import { type ServerRuntimeRegistration } from './types';
  */
 export const webBrowsingRuntime: ServerRuntimeRegistration = {
   factory: (context) => {
-    const baseRuntime = new WebBrowsingExecutionRuntime({
+    const { userId, serverDB, agentId } = context;
+
+    return new WebBrowsingExecutionRuntime({
+      onCrawlComplete:
+        userId && serverDB && agentId
+          ? async (results) => {
+              const documentModel = new DocumentModel(serverDB, userId);
+              const agentDocumentsService = new AgentDocumentsService(serverDB, userId);
+
+              await Promise.all(
+                results.map(async (pageData) => {
+                  const doc = await documentModel.create({
+                    content: pageData.content || '',
+                    description: pageData.description || `Crawled from ${pageData.url}`,
+                    fileType: 'article',
+                    filename: pageData.title || pageData.url,
+                    source: pageData.url,
+                    sourceType: 'web',
+                    title: pageData.title || pageData.url,
+                    totalCharCount: pageData.content?.length || 0,
+                    totalLineCount: pageData.content?.split('\n').length || 0,
+                  });
+
+                  await agentDocumentsService.associateDocument(agentId, doc.id);
+                }),
+              );
+            }
+          : undefined,
       searchService: new SearchService(),
     });
-
-    // If we have userId, serverDB, and agentId, wrap crawl methods to save to agent documents
-    if (context.userId && context.serverDB && context.agentId) {
-      const agentDocumentsService = new AgentDocumentsService(context.serverDB, context.userId);
-      const documentModel = new DocumentModel(context.serverDB, context.userId);
-      const agentId = context.agentId;
-
-      const originalCrawlMultiPages = baseRuntime.crawlMultiPages.bind(baseRuntime);
-
-      baseRuntime.crawlMultiPages = async (params: CrawlMultiPagesQuery) => {
-        const result = await originalCrawlMultiPages(params);
-
-        if (result.success) {
-          const crawlState = result.state as CrawlPluginState;
-
-          await Promise.all(
-            crawlState.results.map(async (crawlResult) => {
-              if ('errorMessage' in crawlResult.data) return;
-
-              const pageData = crawlResult.data as CrawlSuccessResult;
-              if (!pageData.content) return;
-
-              try {
-                // Create document in documents table
-                const doc = await documentModel.create({
-                  content: pageData.content,
-                  description: pageData.description || `Crawled from ${pageData.url}`,
-                  fileType: 'article',
-                  filename: pageData.title || pageData.url,
-                  source: pageData.url,
-                  sourceType: 'web',
-                  title: pageData.title || pageData.url,
-                  totalCharCount: pageData.content.length,
-                  totalLineCount: pageData.content.split('\n').length,
-                });
-
-                // Associate with agent
-                await agentDocumentsService.associateDocument(agentId, doc.id);
-              } catch (error) {
-                console.error(
-                  '[WebBrowsing] Failed to save crawl result to agent document:',
-                  error,
-                );
-              }
-            }),
-          );
-        }
-
-        return result;
-      };
-    }
-
-    return baseRuntime;
   },
   identifier: WebBrowsingManifest.identifier,
 };

--- a/src/services/agentDocument.ts
+++ b/src/services/agentDocument.ts
@@ -70,6 +70,13 @@ class AgentDocumentService {
     return result;
   };
 
+  associateDocument = async (params: { agentId: string; documentId: string }) => {
+    const result = await lambdaClient.agentDocument.associateDocument.mutate(params);
+    await revalidateAgentDocuments(params.agentId);
+
+    return result;
+  };
+
   createDocument = async (params: { agentId: string; content: string; title: string }) => {
     const result = await lambdaClient.agentDocument.createDocument.mutate(params);
     await revalidateAgentDocuments(params.agentId);

--- a/src/store/tool/slices/builtin/executors/lobe-web-browsing.ts
+++ b/src/store/tool/slices/builtin/executors/lobe-web-browsing.ts
@@ -4,22 +4,51 @@
  * Handles web search and page crawling tool calls.
  */
 import { WebBrowsingApiName, WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
-import { WebBrowsingExecutionRuntime } from '@lobechat/builtin-tool-web-browsing/executionRuntime';
+import {
+  type WebBrowsingDocumentService,
+  WebBrowsingExecutionRuntime,
+} from '@lobechat/builtin-tool-web-browsing/executionRuntime';
 import {
   type BuiltinToolContext,
   type BuiltinToolResult,
   type CrawlMultiPagesQuery,
-  type CrawlPluginState,
   type SearchQuery,
 } from '@lobechat/types';
 import { BaseExecutor, SEARCH_SEARXNG_NOT_CONFIG } from '@lobechat/types';
-import { type CrawlSuccessResult } from '@lobechat/web-crawler';
 
 import { agentDocumentService } from '@/services/agentDocument';
 import { notebookService } from '@/services/notebook';
 import { searchService } from '@/services/search';
 
-const runtime = new WebBrowsingExecutionRuntime({ searchService });
+const baseRuntime = new WebBrowsingExecutionRuntime({ searchService });
+
+const createDocumentService = (ctx: BuiltinToolContext): WebBrowsingDocumentService | undefined => {
+  if (!ctx.topicId && !ctx.agentId) return undefined;
+
+  return {
+    associateDocument: async (documentId) => {
+      if (!ctx.agentId) return;
+
+      await agentDocumentService.associateDocument({
+        agentId: ctx.agentId,
+        documentId,
+      });
+    },
+    createDocument: async ({ content, description, title, url }) => {
+      if (!ctx.topicId) throw new Error('topicId is required');
+
+      return notebookService.createDocument({
+        content,
+        description: description || `Crawled from ${url}`,
+        source: url,
+        sourceType: 'web',
+        title,
+        topicId: ctx.topicId,
+        type: 'article',
+      });
+    },
+  };
+};
 
 class WebBrowsingExecutor extends BaseExecutor<typeof WebBrowsingApiName> {
   readonly identifier = WebBrowsingManifest.identifier;
@@ -35,7 +64,7 @@ class WebBrowsingExecutor extends BaseExecutor<typeof WebBrowsingApiName> {
         return { stop: true, success: false };
       }
 
-      const result = await runtime.search(params, { signal: ctx.signal });
+      const result = await baseRuntime.search(params, { signal: ctx.signal });
 
       if (result.success) {
         return {
@@ -108,78 +137,18 @@ class WebBrowsingExecutor extends BaseExecutor<typeof WebBrowsingApiName> {
         return { stop: true, success: false };
       }
 
+      // Create a runtime with document service bound to this call's context
+      const documentService = createDocumentService(ctx);
+      const runtime = documentService
+        ? new WebBrowsingExecutionRuntime({ documentService, searchService })
+        : baseRuntime;
+
       const result = await runtime.crawlMultiPages(params);
 
       if (result.success) {
-        // Save crawled pages as documents if topicId is available
-        const savedDocuments: Array<{ id: string; title: string; url: string }> = [];
-
-        if (ctx.topicId) {
-          const crawlState = result.state as CrawlPluginState;
-
-          // Create documents for each successfully crawled page
-          await Promise.all(
-            crawlState.results.map(async (crawlResult) => {
-              // Skip if there's an error
-              if ('errorMessage' in crawlResult.data) return;
-
-              const pageData = crawlResult.data as CrawlSuccessResult;
-              if (!pageData.content) return;
-
-              try {
-                const document = await notebookService.createDocument({
-                  content: pageData.content,
-                  description: pageData.description || `Crawled from ${pageData.url}`,
-                  source: pageData.url,
-                  sourceType: 'web',
-                  title: pageData.title || pageData.url,
-                  topicId: ctx.topicId!,
-                  type: 'article',
-                });
-
-                savedDocuments.push({
-                  id: document.id,
-                  title: document.title || pageData.url,
-                  url: pageData.url,
-                });
-              } catch {
-                // Silently ignore document creation errors to not block the main flow
-              }
-            }),
-          );
-        }
-
-        // Associate saved notebook documents with the agent if agentId is available
-        if (ctx.agentId && savedDocuments.length > 0) {
-          await Promise.all(
-            savedDocuments.map(async (doc) => {
-              try {
-                await agentDocumentService.associateDocument({
-                  agentId: ctx.agentId!,
-                  documentId: doc.id,
-                });
-              } catch (error) {
-                console.error('[WebBrowsing] Failed to associate document with agent:', error);
-              }
-            }),
-          );
-        }
-
-        // Append saved documents info to content
-        let content = result.content;
-        if (savedDocuments.length > 0) {
-          const savedDocsInfo = savedDocuments
-            .map((doc) => `- "${doc.title}" (ID: ${doc.id})`)
-            .join('\n');
-          content += `\n\n<saved_documents>\nThe crawled content has been saved as documents for future reference:\n${savedDocsInfo}\n</saved_documents>`;
-        }
-
         return {
-          content,
-          state: {
-            ...result.state,
-            savedDocuments,
-          },
+          content: result.content,
+          state: result.state,
           success: true,
         };
       }

--- a/src/store/tool/slices/builtin/executors/lobe-web-browsing.ts
+++ b/src/store/tool/slices/builtin/executors/lobe-web-browsing.ts
@@ -15,6 +15,7 @@ import {
 import { BaseExecutor, SEARCH_SEARXNG_NOT_CONFIG } from '@lobechat/types';
 import { type CrawlSuccessResult } from '@lobechat/web-crawler';
 
+import { agentDocumentService } from '@/services/agentDocument';
 import { notebookService } from '@/services/notebook';
 import { searchService } from '@/services/search';
 
@@ -143,6 +144,22 @@ class WebBrowsingExecutor extends BaseExecutor<typeof WebBrowsingApiName> {
                 });
               } catch {
                 // Silently ignore document creation errors to not block the main flow
+              }
+            }),
+          );
+        }
+
+        // Associate saved notebook documents with the agent if agentId is available
+        if (ctx.agentId && savedDocuments.length > 0) {
+          await Promise.all(
+            savedDocuments.map(async (doc) => {
+              try {
+                await agentDocumentService.associateDocument({
+                  agentId: ctx.agentId!,
+                  documentId: doc.id,
+                });
+              } catch {
+                // Silently ignore association errors to not block the main flow
               }
             }),
           );

--- a/src/store/tool/slices/builtin/executors/lobe-web-browsing.ts
+++ b/src/store/tool/slices/builtin/executors/lobe-web-browsing.ts
@@ -4,7 +4,10 @@
  * Handles web search and page crawling tool calls.
  */
 import { WebBrowsingApiName, WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
-import { WebBrowsingExecutionRuntime } from '@lobechat/builtin-tool-web-browsing/executionRuntime';
+import {
+  type WebBrowsingDocumentService,
+  WebBrowsingExecutionRuntime,
+} from '@lobechat/builtin-tool-web-browsing/executionRuntime';
 import {
   type BuiltinToolContext,
   type BuiltinToolResult,
@@ -17,31 +20,25 @@ import { agentDocumentService } from '@/services/agentDocument';
 import { notebookService } from '@/services/notebook';
 import { searchService } from '@/services/search';
 
-const runtime = new WebBrowsingExecutionRuntime({
-  documentService: {
-    associateDocument: async (documentId, context) => {
-      if (!context.agentId) return;
+const searchRuntime = new WebBrowsingExecutionRuntime({ searchService });
 
-      await agentDocumentService.associateDocument({
-        agentId: context.agentId,
-        documentId,
-      });
-    },
-    createDocument: async ({ content, description, title, url }, context) => {
-      if (!context.topicId) throw new Error('topicId is required');
-
-      return notebookService.createDocument({
-        content,
-        description: description || `Crawled from ${url}`,
-        source: url,
-        sourceType: 'web',
-        title,
-        topicId: context.topicId,
-        type: 'article',
-      });
-    },
+const createDocumentService = (ctx: BuiltinToolContext): WebBrowsingDocumentService => ({
+  associateDocument: async (documentId) => {
+    if (!ctx.agentId) return;
+    await agentDocumentService.associateDocument({ agentId: ctx.agentId, documentId });
   },
-  searchService,
+  createDocument: async ({ content, description, title, url }) => {
+    if (!ctx.topicId) throw new Error('topicId is required to save document');
+    return notebookService.createDocument({
+      content,
+      description: description || `Crawled from ${url}`,
+      source: url,
+      sourceType: 'web',
+      title,
+      topicId: ctx.topicId,
+      type: 'article',
+    });
+  },
 });
 
 class WebBrowsingExecutor extends BaseExecutor<typeof WebBrowsingApiName> {
@@ -53,22 +50,16 @@ class WebBrowsingExecutor extends BaseExecutor<typeof WebBrowsingApiName> {
    */
   search = async (params: SearchQuery, ctx: BuiltinToolContext): Promise<BuiltinToolResult> => {
     try {
-      // Check if aborted
       if (ctx.signal?.aborted) {
         return { stop: true, success: false };
       }
 
-      const result = await runtime.search(params, { signal: ctx.signal });
+      const result = await searchRuntime.search(params, { signal: ctx.signal });
 
       if (result.success) {
-        return {
-          content: result.content,
-          state: result.state,
-          success: true,
-        };
+        return { content: result.content, state: result.state, success: true };
       }
 
-      // Handle specific error cases
       const error = result.error as Error;
       if (error?.message === SEARCH_SEARXNG_NOT_CONFIG) {
         return {
@@ -91,18 +82,11 @@ class WebBrowsingExecutor extends BaseExecutor<typeof WebBrowsingApiName> {
       };
     } catch (e) {
       const err = e as Error;
-
-      // Handle abort error
       if (err.name === 'AbortError' || err.message.includes('The user aborted a request.')) {
         return { stop: true, success: false };
       }
-
       return {
-        error: {
-          body: e,
-          message: err.message,
-          type: 'PluginServerError',
-        },
+        error: { body: e, message: err.message, type: 'PluginServerError' },
         success: false,
       };
     }
@@ -126,22 +110,21 @@ class WebBrowsingExecutor extends BaseExecutor<typeof WebBrowsingApiName> {
     ctx: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
     try {
-      // Check if aborted
       if (ctx.signal?.aborted) {
         return { stop: true, success: false };
       }
 
-      const result = await runtime.crawlMultiPages(params, {
+      const runtime = new WebBrowsingExecutionRuntime({
         agentId: ctx.agentId,
+        documentService: ctx.topicId ? createDocumentService(ctx) : undefined,
+        searchService,
         topicId: ctx.topicId ?? undefined,
       });
 
+      const result = await runtime.crawlMultiPages(params);
+
       if (result.success) {
-        return {
-          content: result.content,
-          state: result.state,
-          success: true,
-        };
+        return { content: result.content, state: result.state, success: true };
       }
 
       return {
@@ -155,18 +138,11 @@ class WebBrowsingExecutor extends BaseExecutor<typeof WebBrowsingApiName> {
       };
     } catch (e) {
       const err = e as Error;
-
-      // Handle abort error
       if (err.name === 'AbortError' || err.message.includes('The user aborted a request.')) {
         return { stop: true, success: false };
       }
-
       return {
-        error: {
-          body: e,
-          message: err.message,
-          type: 'PluginServerError',
-        },
+        error: { body: e, message: err.message, type: 'PluginServerError' },
         success: false,
       };
     }

--- a/src/store/tool/slices/builtin/executors/lobe-web-browsing.ts
+++ b/src/store/tool/slices/builtin/executors/lobe-web-browsing.ts
@@ -158,8 +158,8 @@ class WebBrowsingExecutor extends BaseExecutor<typeof WebBrowsingApiName> {
                   agentId: ctx.agentId!,
                   documentId: doc.id,
                 });
-              } catch {
-                // Silently ignore association errors to not block the main flow
+              } catch (error) {
+                console.error('[WebBrowsing] Failed to associate document with agent:', error);
               }
             }),
           );

--- a/src/store/tool/slices/builtin/executors/lobe-web-browsing.ts
+++ b/src/store/tool/slices/builtin/executors/lobe-web-browsing.ts
@@ -4,10 +4,7 @@
  * Handles web search and page crawling tool calls.
  */
 import { WebBrowsingApiName, WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
-import {
-  type WebBrowsingDocumentService,
-  WebBrowsingExecutionRuntime,
-} from '@lobechat/builtin-tool-web-browsing/executionRuntime';
+import { WebBrowsingExecutionRuntime } from '@lobechat/builtin-tool-web-browsing/executionRuntime';
 import {
   type BuiltinToolContext,
   type BuiltinToolResult,
@@ -20,22 +17,18 @@ import { agentDocumentService } from '@/services/agentDocument';
 import { notebookService } from '@/services/notebook';
 import { searchService } from '@/services/search';
 
-const baseRuntime = new WebBrowsingExecutionRuntime({ searchService });
-
-const createDocumentService = (ctx: BuiltinToolContext): WebBrowsingDocumentService | undefined => {
-  if (!ctx.topicId && !ctx.agentId) return undefined;
-
-  return {
-    associateDocument: async (documentId) => {
-      if (!ctx.agentId) return;
+const runtime = new WebBrowsingExecutionRuntime({
+  documentService: {
+    associateDocument: async (documentId, context) => {
+      if (!context.agentId) return;
 
       await agentDocumentService.associateDocument({
-        agentId: ctx.agentId,
+        agentId: context.agentId,
         documentId,
       });
     },
-    createDocument: async ({ content, description, title, url }) => {
-      if (!ctx.topicId) throw new Error('topicId is required');
+    createDocument: async ({ content, description, title, url }, context) => {
+      if (!context.topicId) throw new Error('topicId is required');
 
       return notebookService.createDocument({
         content,
@@ -43,12 +36,13 @@ const createDocumentService = (ctx: BuiltinToolContext): WebBrowsingDocumentServ
         source: url,
         sourceType: 'web',
         title,
-        topicId: ctx.topicId,
+        topicId: context.topicId,
         type: 'article',
       });
     },
-  };
-};
+  },
+  searchService,
+});
 
 class WebBrowsingExecutor extends BaseExecutor<typeof WebBrowsingApiName> {
   readonly identifier = WebBrowsingManifest.identifier;
@@ -64,7 +58,7 @@ class WebBrowsingExecutor extends BaseExecutor<typeof WebBrowsingApiName> {
         return { stop: true, success: false };
       }
 
-      const result = await baseRuntime.search(params, { signal: ctx.signal });
+      const result = await runtime.search(params, { signal: ctx.signal });
 
       if (result.success) {
         return {
@@ -137,13 +131,10 @@ class WebBrowsingExecutor extends BaseExecutor<typeof WebBrowsingApiName> {
         return { stop: true, success: false };
       }
 
-      // Create a runtime with document service bound to this call's context
-      const documentService = createDocumentService(ctx);
-      const runtime = documentService
-        ? new WebBrowsingExecutionRuntime({ documentService, searchService })
-        : baseRuntime;
-
-      const result = await runtime.crawlMultiPages(params);
+      const result = await runtime.crawlMultiPages(params, {
+        agentId: ctx.agentId,
+        topicId: ctx.topicId ?? undefined,
+      });
 
       if (result.success) {
         return {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] ✅ test

#### 🔗 Related Issue

Fixes LOBE-7242

#### 🔀 Description of Change

When web browsing crawls pages, the crawled documents are now also associated with the current agent's document workspace via the `agentDocuments` junction table. This enables cross-topic persistence and agent document load rules for crawled content.

**Key changes:**

- **`AgentDocumentModel.associate()`** — New method to link an existing `documents` row to an agent via the `agentDocuments` table. Uses `onConflictDoNothing` for idempotency. Accepts object params `{ agentId, documentId, policyLoad? }`.
- **`AgentDocumentsService.associateDocument()`** — Service-layer wrapper.
- **TRPC `associateDocument` endpoint** — New mutation for client-side usage.
- **Client `AgentDocumentService.associateDocument()`** — Client service method with SWR revalidation.
- **Client executor** (`lobe-web-browsing.ts`) — After notebook save, associates each crawled document with the agent.
- **Server-side runtime** (`webBrowsing.ts`) — Converted from singleton to per-request factory. Creates documents and associates them with the agent when `userId + serverDB + agentId` context is available.
- **`DocumentModel.findOrCreateFolder()`** — New utility for folder hierarchy support.
- **`DOCUMENT_FOLDER_TYPE` constant** — Extracted `'custom/folder'` string into a shared constant used across models and repositories.

#### 🧪 How to Test

- [x] Added/updated tests

**Tests added:**
- `AgentDocumentModel.associate` — 3 integration tests (link, idempotency, no duplicate documents row)
- `DocumentModel.findOrCreateFolder` — 5 integration tests (create, idempotency, user isolation, nested, same-name-different-parent)
- `AgentDocumentsService.associateDocument` — 1 unit test

🤖 Generated with [Claude Code](https://claude.com/claude-code)