### PR TITLE
🔨 chore: persist `ccSessionId` in topic metadata for CC multi-turn resume

### DIFF
--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -44,6 +44,12 @@ export interface ChatTopicMetadata {
   bot?: ChatTopicBotContext;
   boundDeviceId?: string;
   /**
+   * CC session ID for multi-turn resume (desktop only).
+   * Persisted after each CC execution so the next message in the same topic
+   * can use `--resume <sessionId>` to continue the conversation.
+   */
+  ccSessionId?: string;
+  /**
    * Cron job ID that triggered this topic creation (if created by scheduled task)
    */
   cronJobId?: string;

--- a/src/server/routers/lambda/topic.ts
+++ b/src/server/routers/lambda/topic.ts
@@ -557,6 +557,7 @@ export const topicRouter = router({
         id: z.string(),
         metadata: z.object({
           boundDeviceId: z.string().optional(),
+          ccSessionId: z.string().optional(),
           model: z.string().optional(),
           provider: z.string().optional(),
           runningOperation: z


### PR DESCRIPTION
## Summary

- `updateTopicMetadata` zod schema didn't list `ccSessionId`, so the field was silently stripped by zod before reaching the model — every CC turn spawned a fresh session and lost prior context.
- Adds `ccSessionId?: string` to the `ChatTopicMetadata` type and to the tRPC input schema so the renderer's post-execution `updateTopicMetadata({ ccSessionId })` call can actually persist and be used as `--resume <id>` on the next turn.

Related: extracted from the ACP / heterogeneous-agent work on `feat/acp`. This is the minimum backend change needed for CC session resume to function; the renderer/main-process pieces (executor + IPC) will ship in the follow-up branch.

## Test plan

- [x] Reproduced before the fix via automated UI test: turn 1 "remember token X" → turn 2 "what is the token?" → CC answered "I don't remember" (new session). After the fix, topic metadata carries `ccSessionId` and `--resume` is used.
- [ ] CI type-check
- [ ] Manual verification once renderer-side changes land on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)