### PR TITLE
✨ feat: add Claude Opus 4.7 with xhigh effort tier

### DIFF
--- a/locales/en-US/modelProvider.json
+++ b/locales/en-US/modelProvider.json
@@ -230,6 +230,7 @@
   "providerModels.item.modelConfig.extendParams.options.imageAspectRatio2.hint": "For Nano Banana 2; controls aspect ratio of generated images (supports extra-wide 1:4, 4:1, 1:8, 8:1).",
   "providerModels.item.modelConfig.extendParams.options.imageResolution.hint": "For Gemini 3 image generation models; controls resolution of generated images.",
   "providerModels.item.modelConfig.extendParams.options.imageResolution2.hint": "For Gemini 3.1 Flash Image models; controls resolution of generated images (supports 512px).",
+  "providerModels.item.modelConfig.extendParams.options.opus47Effort.hint": "For Claude Opus 4.7; controls effort level (low/medium/high/xhigh/max).",
   "providerModels.item.modelConfig.extendParams.options.reasoningBudgetToken.hint": "For Claude, Qwen3 and similar; controls token budget for reasoning.",
   "providerModels.item.modelConfig.extendParams.options.reasoningBudgetToken32k.hint": "For GLM-5 and GLM-4.7; controls token budget for reasoning (max 32k).",
   "providerModels.item.modelConfig.extendParams.options.reasoningBudgetToken80k.hint": "For Qwen3 series; controls token budget for reasoning (max 80k).",

--- a/locales/zh-CN/modelProvider.json
+++ b/locales/zh-CN/modelProvider.json
@@ -230,6 +230,7 @@
   "providerModels.item.modelConfig.extendParams.options.imageAspectRatio2.hint": "适用于 Nano Banana 2；控制生成图像的宽高比（支持超宽 1:4、4:1、1:8、8:1）。",
   "providerModels.item.modelConfig.extendParams.options.imageResolution.hint": "适用于 Gemini 3 图像生成模型；控制生成图像的分辨率。",
   "providerModels.item.modelConfig.extendParams.options.imageResolution2.hint": "适用于 Gemini 3.1 Flash Image 模型；控制生成图像的分辨率（支持 512px）。",
+  "providerModels.item.modelConfig.extendParams.options.opus47Effort.hint": "适用于 Claude Opus 4.7；控制努力程度（低/中/高/超高/最大）。",
   "providerModels.item.modelConfig.extendParams.options.reasoningBudgetToken.hint": "适用于 Claude、Qwen3 等模型；控制用于推理的 Token 预算。",
   "providerModels.item.modelConfig.extendParams.options.reasoningBudgetToken32k.hint": "适用于GLM-5和GLM-4.7；控制推理的令牌预算（最大32k）。",
   "providerModels.item.modelConfig.extendParams.options.reasoningBudgetToken80k.hint": "适用于Qwen3系列；控制推理的令牌预算（最大80k）。",

--- a/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
@@ -91,6 +91,33 @@ export const anthropicChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_000_000,
     description:
+      "Claude Opus 4.7 is Anthropic's most capable generally available model for complex reasoning and agentic coding.",
+    displayName: 'Claude Opus 4.7',
+    enabled: true,
+    id: 'claude-opus-4-7',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 6.25, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-04-16',
+    settings: {
+      extendParams: ['disableContextCaching', 'enableAdaptiveThinking', 'opus47Effort'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
       "Claude Opus 4.6 is Anthropic's most intelligent model for building agents and coding.",
     displayName: 'Claude Opus 4.6',
     enabled: true,

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -255,6 +255,7 @@ export type ExtendParamsType =
   | 'gpt5_2ProReasoningEffort'
   | 'grok4_20ReasoningEffort'
   | 'codexMaxReasoningEffort'
+  | 'opus47Effort'
   | 'textVerbosity'
   | 'thinking'
   | 'thinkingBudget'
@@ -293,6 +294,7 @@ export const ExtendParamsTypeSchema = z.enum([
   'gpt5_2ProReasoningEffort',
   'grok4_20ReasoningEffort',
   'codexMaxReasoningEffort',
+  'opus47Effort',
   'textVerbosity',
   'thinking',
   'thinkingBudget',

--- a/packages/model-runtime/src/providers/anthropic/index.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.test.ts
@@ -795,6 +795,35 @@ describe('LobeAnthropicAI', () => {
         });
       });
 
+      it('should correctly build payload for Claude Opus 4.7 with xhigh effort', async () => {
+        const payload: ChatStreamPayload = {
+          max_tokens: 16000,
+          messages: [{ content: 'Solve this problem', role: 'user' }],
+          model: 'claude-opus-4-7',
+          effort: 'xhigh',
+          thinking: { type: 'adaptive', budget_tokens: 0 },
+        };
+
+        const result = await buildDefaultAnthropicPayload(payload);
+
+        expect(result).toEqual({
+          max_tokens: 16000,
+          messages: [
+            {
+              content: [
+                { cache_control: { type: 'ephemeral' }, text: 'Solve this problem', type: 'text' },
+              ],
+              role: 'user',
+            },
+          ],
+          model: 'claude-opus-4-7',
+          output_config: { effort: 'xhigh' },
+          system: undefined,
+          thinking: { type: 'adaptive' },
+          tools: undefined,
+        });
+      });
+
       it('should respect max_tokens in thinking mode when provided', async () => {
         const payload: ChatStreamPayload = {
           max_tokens: 1000,

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -7,13 +7,13 @@ export type LLMRoleType = 'user' | 'system' | 'assistant' | 'function' | 'tool';
 export type ChatResponseFormat =
   | { type: 'json_object' }
   | {
-    json_schema: {
-      name: string;
-      schema: Record<string, any>;
-      strict?: boolean;
+      json_schema: {
+        name: string;
+        schema: Record<string, any>;
+        strict?: boolean;
+      };
+      type: 'json_schema';
     };
-    type: 'json_schema';
-  };
 
 interface UserMessageContentPartThinking {
   signature: string;
@@ -61,7 +61,7 @@ export interface OpenAIChatMessage {
  */
 export interface ChatStreamPayload {
   apiMode?: 'chatCompletion' | 'responses';
-  effort?: 'low' | 'medium' | 'high' | 'max';
+  effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
   /**
    * Enable context caching
    */

--- a/packages/types/src/agent/chatConfig.ts
+++ b/packages/types/src/agent/chatConfig.ts
@@ -95,6 +95,10 @@ export interface LobeAgentChatConfig extends AgentMemoryChatConfig {
    */
   imageResolution2?: '512px' | '1K' | '2K' | '4K';
   inputTemplate?: string;
+  /**
+   * Effort level for Claude Opus 4.7 (adds xhigh tier between high and max)
+   */
+  opus47Effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
   reasoningBudgetToken?: number;
   /**
    * Reasoning budget token for models with 32k max (GLM-5/GLM-4.7)
@@ -192,6 +196,7 @@ export const AgentChatConfigSchema = z
     imageAspectRatio2: z.string().optional(),
     imageResolution: z.enum(['1K', '2K', '4K']).optional(),
     imageResolution2: z.enum(['512px', '1K', '2K', '4K']).optional(),
+    opus47Effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
     runtimeEnv: RuntimeEnvConfigSchema.optional(),
     reasoningBudgetToken: z.number().optional(),
     reasoningBudgetToken32k: z.number().optional(),

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
@@ -23,6 +23,7 @@ import ImageAspectRatio2Select from './ImageAspectRatio2Select';
 import ImageAspectRatioSelect from './ImageAspectRatioSelect';
 import ImageResolution2Slider from './ImageResolution2Slider';
 import ImageResolutionSlider from './ImageResolutionSlider';
+import Opus47EffortSlider from './Opus47EffortSlider';
 import ReasoningEffortSlider from './ReasoningEffortSlider';
 import ReasoningTokenSlider from './ReasoningTokenSlider';
 import ReasoningTokenSlider32k from './ReasoningTokenSlider32k';
@@ -182,6 +183,21 @@ const ControlsForm = memo<ControlsFormProps>(({ model: modelProp, provider: prov
       layout: 'horizontal',
       minWidth: undefined,
       name: 'effort',
+      style: {
+        paddingBottom: 0,
+      },
+    },
+    {
+      children: <Opus47EffortSlider />,
+      desc: isNarrow ? (
+        <span style={descNarrow}>{t('extendParams.effort.desc')}</span>
+      ) : (
+        t('extendParams.effort.desc')
+      ),
+      label: t('extendParams.effort.title'),
+      layout: 'horizontal',
+      minWidth: undefined,
+      name: 'opus47Effort',
       style: {
         paddingBottom: 0,
       },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/Opus47EffortSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/Opus47EffortSlider.tsx
@@ -1,0 +1,16 @@
+import { type CreatedLevelSliderProps, createLevelSliderComponent } from './createLevelSlider';
+
+const OPUS47_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+
+type Opus47Effort = (typeof OPUS47_EFFORT_LEVELS)[number];
+
+export type Opus47EffortSliderProps = CreatedLevelSliderProps<Opus47Effort>;
+
+const Opus47EffortSlider = createLevelSliderComponent<Opus47Effort>({
+  configKey: 'opus47Effort',
+  defaultValue: 'high',
+  levels: OPUS47_EFFORT_LEVELS,
+  style: { minWidth: 200 },
+});
+
+export default Opus47EffortSlider;

--- a/src/locales/default/modelProvider.ts
+++ b/src/locales/default/modelProvider.ts
@@ -274,6 +274,8 @@ export default {
     'For Gemini 3 image generation models; controls resolution of generated images.',
   'providerModels.item.modelConfig.extendParams.options.imageResolution2.hint':
     'For Gemini 3.1 Flash Image models; controls resolution of generated images (supports 512px).',
+  'providerModels.item.modelConfig.extendParams.options.opus47Effort.hint':
+    'For Claude Opus 4.7; controls effort level (low/medium/high/xhigh/max).',
   'providerModels.item.modelConfig.extendParams.options.reasoningBudgetToken.hint':
     'For Claude, Qwen3 and similar; controls token budget for reasoning.',
   'providerModels.item.modelConfig.extendParams.options.reasoningBudgetToken32k.hint':

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -16,6 +16,7 @@ import ImageAspectRatio2Select from '@/features/ModelSwitchPanel/components/Cont
 import ImageAspectRatioSelect from '@/features/ModelSwitchPanel/components/ControlsForm/ImageAspectRatioSelect';
 import ImageResolution2Slider from '@/features/ModelSwitchPanel/components/ControlsForm/ImageResolution2Slider';
 import ImageResolutionSlider from '@/features/ModelSwitchPanel/components/ControlsForm/ImageResolutionSlider';
+import Opus47EffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Opus47EffortSlider';
 import ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/ReasoningEffortSlider';
 import ReasoningTokenSlider from '@/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider';
 import ReasoningTokenSlider32k from '@/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider32k';
@@ -62,6 +63,10 @@ const EXTEND_PARAMS_OPTIONS: ExtendParamsOption[] = [
   {
     hintKey: 'providerModels.item.modelConfig.extendParams.options.effort.hint',
     key: 'effort',
+  },
+  {
+    hintKey: 'providerModels.item.modelConfig.extendParams.options.opus47Effort.hint',
+    key: 'opus47Effort',
   },
   {
     hintKey: 'providerModels.item.modelConfig.extendParams.options.reasoningEffort.hint',
@@ -155,6 +160,7 @@ const TITLE_KEY_ALIASES: Partial<Record<ExtendParamsType, ExtendParamsType>> = {
   gpt5_2ReasoningEffort: 'reasoningEffort',
   grok4_20ReasoningEffort: 'reasoningEffort',
   imageAspectRatio2: 'imageAspectRatio',
+  opus47Effort: 'effort',
   reasoningBudgetToken32k: 'reasoningBudgetToken',
   reasoningBudgetToken80k: 'reasoningBudgetToken',
   thinkingLevel2: 'thinkingLevel',
@@ -201,6 +207,7 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
   imageAspectRatio2: { labelSuffix: ' (Nano Banana 2)', previewWidth: 350, tag: 'aspect_ratio' },
   imageResolution: { labelSuffix: '', previewWidth: 250, tag: 'resolution' },
   imageResolution2: { labelSuffix: ' (512px+)', previewWidth: 280, tag: 'resolution' },
+  opus47Effort: { labelSuffix: ' (Opus 4.7)', previewWidth: 280, tag: 'output_config.effort' },
   reasoningBudgetToken: { previewWidth: 350, tag: 'thinking.budget_tokens' },
   reasoningBudgetToken32k: {
     labelSuffix: ' (32k)',
@@ -329,6 +336,7 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
       imageAspectRatio2: <ImageAspectRatio2Select value="1:1" />,
       imageResolution: <ImageResolutionSlider value="1K" />,
       imageResolution2: <ImageResolution2Slider value="1K" />,
+      opus47Effort: <Opus47EffortSlider value="high" />,
       reasoningBudgetToken: <ReasoningTokenSlider defaultValue={1 * 1024} />,
       reasoningBudgetToken32k: <ReasoningTokenSlider32k defaultValue={1 * 1024} />,
       reasoningBudgetToken80k: <ReasoningTokenSlider80k defaultValue={1 * 1024} />,

--- a/src/services/chat/mecha/modelParamsResolver.ts
+++ b/src/services/chat/mecha/modelParamsResolver.ts
@@ -171,6 +171,10 @@ export const resolveModelExtendParams = (ctx: ModelParamsContext): ModelExtendPa
     extendParams.effort = chatConfig.effort;
   }
 
+  if (modelExtendParams.includes('opus47Effort') && chatConfig.opus47Effort) {
+    extendParams.effort = chatConfig.opus47Effort;
+  }
+
   // Text verbosity
   if (modelExtendParams.includes('textVerbosity') && chatConfig.textVerbosity) {
     extendParams.verbosity = chatConfig.textVerbosity;


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Related: https://www.anthropic.com/news/claude-opus-4-7

#### 🔀 Description of Change

Adds Claude Opus 4.7 model support to the LobeHub-hosted Anthropic provider.

**Model card** (`packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts`):

- `id: claude-opus-4-7`, `displayName: Claude Opus 4.7`
- Context 1M / max output 128K
- Pricing (USD/MTok): input $5, output $25, cache-read $0.5, cache-write 5m $6.25
- Abilities: `functionCall`, `reasoning`, `vision`
- `extendParams: ['disableContextCaching', 'enableAdaptiveThinking', 'opus47Effort']`
- `enabled: true`, `releasedAt: '2026-04-16'`

**New `opus47Effort` extendParam** (following the `gpt5_1ReasoningEffort` precedent):

Opus 4.7 introduces a new `xhigh` effort tier between `high` and `max`. To avoid polluting the existing `effort` slider shared by Opus 4.6 (which does not support `xhigh`), this PR adds a dedicated `opus47Effort` param with five levels: `low / medium / high / xhigh / max` (default `high`).

Changes:

- `packages/model-bank/src/types/aiModel.ts` — add `opus47Effort` to `ExtendParamsType` union + zod schema
- `packages/types/src/agent/chatConfig.ts` — add `opus47Effort` field + zod
- `packages/model-runtime/src/types/chat.ts` — extend `ChatStreamPayload['effort']` to include `xhigh`
- `src/features/ModelSwitchPanel/components/ControlsForm/Opus47EffortSlider.tsx` — new slider (five-level)
- `src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx` — register slider
- `src/routes/.../ExtendParamsSelect.tsx` — `EXTEND_PARAMS_OPTIONS`, `TITLE_KEY_ALIASES`, `PREVIEW_META`, preview render
- `src/locales/default/modelProvider.ts` + `locales/{en-US,zh-CN}/modelProvider.json` — hint i18n
- `src/services/chat/mecha/modelParamsResolver.ts` — resolve `opus47Effort → extendParams.effort`

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- Unit test: added `should correctly build payload for Claude Opus 4.7 with xhigh effort` covering `effort: 'xhigh'` + adaptive thinking path.
- Local dev (`bun run dev:spa`): selected "Claude Opus 4.7", toggled `xhigh` tier, verified request body carries `output_config.effort: 'xhigh'` and the cloud LobeHub provider completes a chat turn end-to-end.

#### 📝 Additional Information

- Only updates the **LobeHub-hosted** Anthropic model list. Anthropic direct / Bedrock / AiHubMix model cards are intentionally untouched — the cloud's RouterRuntime handles multi-channel routing.
- Opus 4.7 ships a new tokenizer (~1.0–1.35× token consumption vs Opus 4.6). Pricing unchanged vs Opus 4.6; users should budget for the tokenizer difference.
- The `xhigh` tier is Opus 4.7 only — existing Opus 4.6 sliders remain a four-level `low/medium/high/max`.