### PR TITLE
🐛 fix(conversation): restore markdown animation for first assistant group block

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
@@ -16,20 +16,9 @@ import MessageContent from './MessageContent';
 interface ContentBlockProps extends AssistantContentBlock {
   assistantId: string;
   disableEditing?: boolean;
-  isFirstBlock?: boolean;
 }
 const ContentBlock = memo<ContentBlockProps>(
-  ({
-    id,
-    tools,
-    content,
-    imageList,
-    reasoning,
-    error,
-    assistantId,
-    disableEditing,
-    isFirstBlock,
-  }) => {
+  ({ id, tools, content, imageList, reasoning, error, assistantId, disableEditing }) => {
     const errorContent = useErrorContent(error);
     const showImageItems = !!imageList && imageList.length > 0;
     const [isReasoning, deleteMessage, continueGeneration] = useConversationStore((s) => [
@@ -84,12 +73,7 @@ const ContentBlock = memo<ContentBlockProps>(
 
         {showMessageContent && (
           <SafeBoundary variant="alert">
-            <MessageContent
-              content={content}
-              hasTools={hasTools}
-              id={id}
-              isFirstBlock={isFirstBlock}
-            />
+            <MessageContent content={content} hasTools={hasTools} id={id} />
           </SafeBoundary>
         )}
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -175,12 +175,6 @@ const Group = memo<GroupChildrenProps>(
 
     const workflowChromeComplete = !isGenerating || postToolTailPromoted;
 
-    /** First non-placeholder in the answer column (pre-tool + post-tool when finalized). */
-    const firstSubstantiveAnswerIndex = useMemo(
-      () => answerBlocks.findIndex((b) => !isEmptyBlock(b)),
-      [answerBlocks],
-    );
-
     if (isCollapsed) {
       return (
         content && (
@@ -203,7 +197,7 @@ const Group = memo<GroupChildrenProps>(
               workflowChromeComplete={workflowChromeComplete}
             />
           )}
-          {answerBlocks.map((item, index) => {
+          {answerBlocks.map((item) => {
             if (!isGenerating && isEmptyBlock(item)) return null;
 
             return (
@@ -214,9 +208,6 @@ const Group = memo<GroupChildrenProps>(
                 disableEditing={disableEditing}
                 key={id + '.' + item.id}
                 messageIndex={messageIndex}
-                isFirstBlock={
-                  firstSubstantiveAnswerIndex >= 0 && index === firstSubstantiveAnswerIndex
-                }
               />
             );
           })}

--- a/src/features/Conversation/Messages/AssistantGroup/components/GroupItem.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/GroupItem.tsx
@@ -11,12 +11,11 @@ interface GroupItemProps extends AssistantContentBlock {
   assistantId: string;
   contentId?: string;
   disableEditing?: boolean;
-  isFirstBlock?: boolean;
   messageIndex: number;
 }
 
 const GroupItem = memo<GroupItemProps>(
-  ({ contentId, disableEditing, error, assistantId, isFirstBlock, ...item }) => {
+  ({ contentId, disableEditing, error, assistantId, ...item }) => {
     const toggleMessageEditing = useConversationStore((s) => s.toggleMessageEditing);
 
     return item.id === contentId ? (
@@ -31,7 +30,6 @@ const GroupItem = memo<GroupItemProps>(
           assistantId={assistantId}
           disableEditing={disableEditing}
           error={error}
-          isFirstBlock={isFirstBlock}
         />
       </Flexbox>
     ) : (
@@ -40,7 +38,6 @@ const GroupItem = memo<GroupItemProps>(
         assistantId={assistantId}
         disableEditing={disableEditing}
         error={error}
-        isFirstBlock={isFirstBlock}
       />
     );
   },

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
@@ -19,10 +19,9 @@ interface ContentBlockProps {
   content: string;
   hasTools?: boolean;
   id: string;
-  isFirstBlock?: boolean;
 }
 
-const MessageContent = memo<ContentBlockProps>(({ content, hasTools, id, isFirstBlock }) => {
+const MessageContent = memo<ContentBlockProps>(({ content, hasTools, id }) => {
   const message = normalizeThinkTags(processWithArtifact(content));
   const markdownProps = useMarkdown(id);
 
@@ -37,11 +36,7 @@ const MessageContent = memo<ContentBlockProps>(({ content, hasTools, id, isFirst
 
   return (
     content && (
-      <MarkdownMessage
-        {...markdownProps}
-        animated={isFirstBlock ? false : markdownProps.animated}
-        className={cx(isToolSingleLine && styles.pWithTool)}
-      >
+      <MarkdownMessage {...markdownProps} className={cx(isToolSingleLine && styles.pWithTool)}>
         {message}
       </MarkdownMessage>
     )


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Removed the `isFirstBlock` prop chain from Assistant Group rendering (`Group` → `GroupItem` → `ContentBlock` → `MessageContent`). That flag forced `animated={false}` on the first substantive answer block’s Markdown, which disabled the stream/typing animation for the first visible body text after reasoning (e.g. the first heading line).

Markdown now always receives `useMarkdown` props as-is (`{...markdownProps}`), so animation behavior is consistent across all answer blocks.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Trigger an assistant reply in **Assistant Group** mode (assistant message with tools).
2. Confirm the first answer Markdown block (including the first line below expanded reasoning) uses the same animation as subsequent blocks when streaming is enabled.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| First answer block often had no stream animation | Consistent animation on first block |

#### 📝 Additional Information

None.

Made with [Cursor](https://cursor.com)