### PR TITLE
🐛 fix: strip temperature/top_p for Claude Opus 4.7

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
@@ -106,6 +106,7 @@ export const anthropicChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2026-04-16',
     settings: {
+      disabledParams: ['temperature', 'top_p'],
       extendParams: ['disableContextCaching', 'enableAdaptiveThinking', 'opus47Effort'],
     },
     type: 'chat',

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -270,7 +270,15 @@ export type ExtendParamsType =
   | 'imageResolution2'
   | 'urlContext';
 
+export type DisabledParamType = 'temperature' | 'top_p' | 'frequency_penalty' | 'presence_penalty';
+
 export interface AiModelSettings {
+  /**
+   * Chat params that should be hidden from the agent config UI and stripped from
+   * outbound requests. Use this for models whose API rejects specific sampling
+   * params (e.g. Claude Opus 4.7 returns 400 on any non-default temperature / top_p).
+   */
+  disabledParams?: DisabledParamType[];
   extendParams?: ExtendParamsType[];
   /**
    * How the model layer implements search
@@ -312,7 +320,15 @@ export const ExtendParamsTypeSchema = z.enum([
 
 export const ModelSearchImplementTypeSchema = z.enum(['tool', 'params', 'internal']);
 
+export const DisabledParamTypeSchema = z.enum([
+  'temperature',
+  'top_p',
+  'frequency_penalty',
+  'presence_penalty',
+]);
+
 export const AiModelSettingsSchema = z.object({
+  disabledParams: z.array(DisabledParamTypeSchema).optional(),
   extendParams: z.array(ExtendParamsTypeSchema).optional(),
   searchImpl: ModelSearchImplementTypeSchema.optional(),
   searchProvider: z.string().optional(),

--- a/packages/model-runtime/src/const/models.ts
+++ b/packages/model-runtime/src/const/models.ts
@@ -113,3 +113,24 @@ export const temperatureTopPConflictModelPatterns: RegExp[] = [
 export const hasTemperatureTopPConflict = (model: string): boolean => {
   return temperatureTopPConflictModelPatterns.some((pattern) => pattern.test(model));
 };
+
+/**
+ * Regex patterns for models that reject any non-default temperature / top_p / top_k.
+ * These sampling parameters must be omitted from the request payload entirely;
+ * otherwise the API returns a 400 error.
+ *
+ * Ref: https://platform.claude.com/docs/en/about-claude/models/migration-guide
+ */
+export const omitSamplingParamsModelPatterns: RegExp[] = [
+  // Claude Opus 4.7 - Anthropic API (also LobeHub provider pass-through)
+  /^claude-opus-4-7/,
+  // OpenRouter formats
+  /^anthropic\/claude-opus-4-7/,
+  /^anthropic\/claude-4-7-opus/,
+  // AWS Bedrock formats (e.g. anthropic.claude-opus-4-7, us.anthropic.claude-opus-4-7-v1)
+  /anthropic\.claude-opus-4-7/,
+];
+
+export const shouldOmitSamplingParams = (model: string): boolean => {
+  return omitSamplingParamsModelPatterns.some((pattern) => pattern.test(model));
+};

--- a/packages/model-runtime/src/const/models.ts
+++ b/packages/model-runtime/src/const/models.ts
@@ -124,9 +124,9 @@ export const hasTemperatureTopPConflict = (model: string): boolean => {
 export const omitSamplingParamsModelPatterns: RegExp[] = [
   // Claude Opus 4.7 - Anthropic API (also LobeHub provider pass-through)
   /^claude-opus-4-7/,
-  // OpenRouter formats
-  /^anthropic\/claude-opus-4-7/,
-  /^anthropic\/claude-4-7-opus/,
+  // OpenRouter formats use dot notation (e.g. anthropic/claude-opus-4.7)
+  /^anthropic\/claude-opus-4\.7/,
+  /^anthropic\/claude-4\.7-opus/,
   // AWS Bedrock formats (e.g. anthropic.claude-opus-4-7, us.anthropic.claude-opus-4-7-v1)
   /anthropic\.claude-opus-4-7/,
 ];

--- a/packages/model-runtime/src/core/parameterResolver.test.ts
+++ b/packages/model-runtime/src/core/parameterResolver.test.ts
@@ -385,9 +385,15 @@ describe('shouldOmitSamplingParams', () => {
     expect(shouldOmitSamplingParams('us.anthropic.claude-opus-4-7-v1')).toBe(true);
   });
 
-  it('should return true for Claude Opus 4.7 on OpenRouter', () => {
-    expect(shouldOmitSamplingParams('anthropic/claude-opus-4-7')).toBe(true);
-    expect(shouldOmitSamplingParams('anthropic/claude-4-7-opus')).toBe(true);
+  it('should return true for Claude Opus 4.7 on OpenRouter (dot notation)', () => {
+    expect(shouldOmitSamplingParams('anthropic/claude-opus-4.7')).toBe(true);
+    expect(shouldOmitSamplingParams('anthropic/claude-4.7-opus')).toBe(true);
+  });
+
+  it('should return false for hypothetical dash-form OpenRouter id', () => {
+    // OpenRouter uses dot notation; dash form is not a real id and must not match
+    // to avoid accidentally stripping params from unrelated future model ids.
+    expect(shouldOmitSamplingParams('anthropic/claude-opus-4-7')).toBe(false);
   });
 
   it('should return false for Claude Opus 4.6 and earlier', () => {

--- a/packages/model-runtime/src/core/parameterResolver.test.ts
+++ b/packages/model-runtime/src/core/parameterResolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { hasTemperatureTopPConflict } from '../const/models';
+import { hasTemperatureTopPConflict, shouldOmitSamplingParams } from '../const/models';
 import {
   createParameterResolver,
   resolveModelSamplingParameters,
@@ -277,6 +277,39 @@ describe('resolveModelSamplingParameters', () => {
     expect(result).not.toHaveProperty('temperature');
     expect(result).not.toHaveProperty('top_p');
   });
+
+  it('should omit temperature and top_p for models that reject sampling params', () => {
+    const result = resolveModelSamplingParameters(
+      'claude-opus-4-7',
+      { temperature: 0.7, top_p: 0.9 },
+      { normalizeTemperature: false, preferTemperature: true },
+    );
+
+    // Both keys present with undefined values so spreading clears any pre-set payload fields
+    expect(result).toEqual({ temperature: undefined, top_p: undefined });
+  });
+
+  it('should omit temperature and top_p for Bedrock Opus 4.7 id', () => {
+    const result = resolveModelSamplingParameters(
+      'us.anthropic.claude-opus-4-7-v1',
+      { temperature: 0.7, top_p: 0.9 },
+      { normalizeTemperature: false, preferTemperature: true },
+    );
+
+    expect(result).toEqual({ temperature: undefined, top_p: undefined });
+  });
+
+  it('should not add spurious keys when omit-model input has no sampling fields', () => {
+    const result = resolveModelSamplingParameters(
+      'claude-opus-4-7',
+      {},
+      { normalizeTemperature: false, preferTemperature: true },
+    );
+
+    expect(result).toEqual({});
+    expect(result).not.toHaveProperty('temperature');
+    expect(result).not.toHaveProperty('top_p');
+  });
 });
 
 describe('createParameterResolver', () => {
@@ -339,5 +372,32 @@ describe('hasTemperatureTopPConflict', () => {
     it('should return false for Bedrock Claude 3.x models', () => {
       expect(hasTemperatureTopPConflict('anthropic.claude-3-5-sonnet-20240620-v1:0')).toBe(false);
     });
+  });
+});
+
+describe('shouldOmitSamplingParams', () => {
+  it('should return true for Claude Opus 4.7 (Anthropic API id)', () => {
+    expect(shouldOmitSamplingParams('claude-opus-4-7')).toBe(true);
+  });
+
+  it('should return true for Claude Opus 4.7 on Bedrock (with and without region prefix)', () => {
+    expect(shouldOmitSamplingParams('anthropic.claude-opus-4-7')).toBe(true);
+    expect(shouldOmitSamplingParams('us.anthropic.claude-opus-4-7-v1')).toBe(true);
+  });
+
+  it('should return true for Claude Opus 4.7 on OpenRouter', () => {
+    expect(shouldOmitSamplingParams('anthropic/claude-opus-4-7')).toBe(true);
+    expect(shouldOmitSamplingParams('anthropic/claude-4-7-opus')).toBe(true);
+  });
+
+  it('should return false for Claude Opus 4.6 and earlier', () => {
+    expect(shouldOmitSamplingParams('claude-opus-4-6')).toBe(false);
+    expect(shouldOmitSamplingParams('claude-sonnet-4-5-20250929')).toBe(false);
+    expect(shouldOmitSamplingParams('anthropic.claude-opus-4-6-v1')).toBe(false);
+  });
+
+  it('should return false for non-Claude models', () => {
+    expect(shouldOmitSamplingParams('gpt-4o')).toBe(false);
+    expect(shouldOmitSamplingParams('gemini-2.5-pro')).toBe(false);
   });
 });

--- a/packages/model-runtime/src/core/parameterResolver.ts
+++ b/packages/model-runtime/src/core/parameterResolver.ts
@@ -1,4 +1,4 @@
-import { hasTemperatureTopPConflict } from '../const/models';
+import { hasTemperatureTopPConflict, shouldOmitSamplingParams } from '../const/models';
 
 /**
  * Chat completion parameter configuration
@@ -263,6 +263,16 @@ export const resolveModelSamplingParameters = (
 ): { temperature?: number; top_p?: number } => {
   const temperature = config.temperature ?? undefined;
   const top_p = config.top_p ?? undefined;
+
+  // Some models (e.g. Claude Opus 4.7) reject any non-default temperature / top_p
+  // and return a 400 error. Omit both parameters entirely — callers spread the
+  // returned object, so setting the key to undefined lets JSON.stringify drop it.
+  if (model && shouldOmitSamplingParams(model)) {
+    const result: { temperature?: number; top_p?: number } = {};
+    if (temperature !== undefined) result.temperature = undefined;
+    if (top_p !== undefined) result.top_p = undefined;
+    return result;
+  }
 
   const resolved = resolveParameters(
     { temperature, top_p },

--- a/src/features/AgentSetting/AgentModal/index.tsx
+++ b/src/features/AgentSetting/AgentModal/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { shouldOmitSamplingParams } from '@lobechat/model-runtime';
 import { type FormGroupItemType, type FormItemProps } from '@lobehub/ui';
 import { Flexbox, Form, Select, SliderWithInput } from '@lobehub/ui';
 import { Form as AntdForm, Switch } from 'antd';
@@ -225,7 +226,14 @@ const AgentModal = memo(() => {
     [form],
   );
 
-  const paramItems: FormItemProps[] = (Object.keys(PARAM_CONFIG) as ParamKey[]).map((key) => {
+  // Hide temperature / top_p when the selected model rejects them outright
+  // (e.g. Claude Opus 4.7 — see @lobechat/model-runtime shouldOmitSamplingParams).
+  const omitSampling = !!config.model && shouldOmitSamplingParams(config.model);
+  const visibleParamKeys = (Object.keys(PARAM_CONFIG) as ParamKey[]).filter(
+    (key) => !(omitSampling && (key === 'temperature' || key === 'top_p')),
+  );
+
+  const paramItems: FormItemProps[] = visibleParamKeys.map((key) => {
     const meta = PARAM_CONFIG[key];
     const enabled = enabledMap[key];
 

--- a/src/features/AgentSetting/AgentModal/index.tsx
+++ b/src/features/AgentSetting/AgentModal/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { shouldOmitSamplingParams } from '@lobechat/model-runtime';
 import { type FormGroupItemType, type FormItemProps } from '@lobehub/ui';
 import { Flexbox, Form, Select, SliderWithInput } from '@lobehub/ui';
 import { Form as AntdForm, Switch } from 'antd';
@@ -11,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 
 import InfoTooltip from '@/components/InfoTooltip';
 import { FORM_STYLE } from '@/const/layoutTokens';
+import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
 
 import { selectors, useStore } from '../store';
 
@@ -226,11 +226,13 @@ const AgentModal = memo(() => {
     [form],
   );
 
-  // Hide temperature / top_p when the selected model rejects them outright
-  // (e.g. Claude Opus 4.7 — see @lobechat/model-runtime shouldOmitSamplingParams).
-  const omitSampling = !!config.model && shouldOmitSamplingParams(config.model);
+  // Hide params the selected model rejects outright (e.g. Claude Opus 4.7 drops
+  // temperature / top_p). Declared via `settings.disabledParams` on the model card.
+  const disabledParams = useAiInfraStore(
+    aiModelSelectors.modelDisabledParams(config.model, config.provider ?? ''),
+  );
   const visibleParamKeys = (Object.keys(PARAM_CONFIG) as ParamKey[]).filter(
-    (key) => !(omitSampling && (key === 'temperature' || key === 'top_p')),
+    (key) => !disabledParams?.includes(key),
   );
 
   const paramItems: FormItemProps[] = visibleParamKeys.map((key) => {

--- a/src/store/aiInfra/slices/aiModel/selectors.test.ts
+++ b/src/store/aiInfra/slices/aiModel/selectors.test.ts
@@ -47,6 +47,9 @@ describe('aiModelSelectors', () => {
           reasoning: true,
         },
         contextWindowTokens: 4000,
+        settings: {
+          disabledParams: ['temperature', 'top_p'],
+        },
         type: 'chat',
       },
       {
@@ -225,6 +228,27 @@ describe('aiModelSelectors', () => {
       );
       expect(
         aiModelSelectors.modelContextWindowTokens('model4', 'provider2')(mockState),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('modelDisabledParams', () => {
+    it('should return disabledParams when declared on the model card', () => {
+      expect(aiModelSelectors.modelDisabledParams('model1', 'provider1')(mockState)).toEqual([
+        'temperature',
+        'top_p',
+      ]);
+    });
+
+    it('should return undefined when the model has no settings', () => {
+      expect(
+        aiModelSelectors.modelDisabledParams('model4', 'provider2')(mockState),
+      ).toBeUndefined();
+    });
+
+    it('should return undefined for an unknown model', () => {
+      expect(
+        aiModelSelectors.modelDisabledParams('missing', 'provider1')(mockState),
       ).toBeUndefined();
     });
   });

--- a/src/store/aiInfra/slices/aiModel/selectors.ts
+++ b/src/store/aiInfra/slices/aiModel/selectors.ts
@@ -93,6 +93,12 @@ const modelExtendParams = (id: string, provider: string) => (s: AIProviderStoreS
   return model?.settings?.extendParams;
 };
 
+const modelDisabledParams = (id: string, provider: string) => (s: AIProviderStoreState) => {
+  const model = getEnabledModelById(id, provider)(s);
+
+  return model?.settings?.disabledParams;
+};
+
 const isModelHasExtendParams = (id: string, provider: string) => (s: AIProviderStoreState) => {
   const controls = modelExtendParams(id, provider)(s);
 
@@ -155,6 +161,7 @@ export const aiModelSelectors = {
   isModelSupportVision,
   modelBuiltinSearchImpl,
   modelContextWindowTokens,
+  modelDisabledParams,
   modelExtendParams,
   totalAiProviderModelList,
 };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] 💄 style

#### 🔀 Description of Change

Claude Opus 4.7 rejects any non-default `temperature`, `top_p`, or `top_k` with HTTP 400 — a documented breaking change relative to Opus 4.6 per the Anthropic [migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide). The safest fix is to omit these parameters entirely from the request payload.

This showed up in production right after the Opus 4.7 launch: Bedrock returned `temperature is deprecated for this model` on every request that didn't enable adaptive thinking (the thinking branch skips sampling params, which masked the bug during launch verification).

Two commits:

**1. 🐛 Runtime strip** — `packages/model-runtime`

- New `omitSamplingParamsModelPatterns` + `shouldOmitSamplingParams(model)` in `src/const/models.ts`, mirroring the existing `temperatureTopPConflictModelPatterns` / `hasTemperatureTopPConflict` shape.
- Short-circuit inside `resolveModelSamplingParameters` — when the model matches, return placeholder `undefined` values for any keys the caller provided so spreading onto a payload clears them (`JSON.stringify` drops `undefined`).
- Covered id shapes: Anthropic API (`claude-opus-4-7`), AWS Bedrock (`anthropic.claude-opus-4-7`, `us.anthropic.claude-opus-4-7-v1`), OpenRouter (`anthropic/claude-opus-4-7`, `anthropic/claude-4-7-opus`).
- Both the Bedrock provider and the Anthropic-compatible factory already delegate to `resolveModelSamplingParameters`, so no direct edits to those files are needed.

**2. 💄 UI hide** — `src/features/AgentSetting/AgentModal`

- When `shouldOmitSamplingParams(config.model)` returns true, filter `temperature` and `top_p` out of the visible param sliders so users don't waste time tweaking parameters that the API rejects. Other sliders (penalties, max tokens) are unchanged.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Run the parameter resolver suite:

```bash
cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/core/parameterResolver.test.ts'
```

New test cases cover:

- `claude-opus-4-7` (Anthropic API id) → both keys returned as `undefined`
- `us.anthropic.claude-opus-4-7-v1` (Bedrock id) → both keys returned as `undefined`
- `claude-opus-4-7` with no sampling input → empty object, no spurious keys
- `shouldOmitSamplingParams` matches Opus 4.7 across Anthropic / Bedrock / OpenRouter id shapes and does **not** match Opus 4.6 / Sonnet 4.5 / non-Claude models

#### 📝 Additional Information

Pattern is intentionally narrow (Opus 4.7 only). Future Sonnet/Haiku 4.7 or Opus 5.x will require an additive change — we don't want to strip sampling params from models that still accept them.