### PR TITLE
🐛 fix(auth): clear OIDC sessions when user signs out via better-auth

### DIFF
--- a/src/app/(backend)/oidc/clear-session/route.ts
+++ b/src/app/(backend)/oidc/clear-session/route.ts
@@ -1,0 +1,69 @@
+import { serverDB } from '@lobechat/database';
+import { oidcSessions } from '@lobechat/database/schemas';
+import { getUserAuth } from '@lobechat/utils/server';
+import debug from 'debug';
+import { eq } from 'drizzle-orm';
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+const log = debug('lobe-oidc:clear-session');
+
+/**
+ * POST /oidc/clear-session
+ *
+ * Clears the OIDC Provider session for the **current browser** only.
+ *
+ * Called by the frontend before `signOut()` so that when the user signs in
+ * as a different account and an OIDC client later triggers `/authorize`,
+ * the provider won't silently reuse the stale session that still points to
+ * the old accountId.
+ *
+ * How it works:
+ * 1. Read the `_session` cookie that `oidc-provider` sets in the browser.
+ *    This cookie value is the primary key of the `oidc_sessions` table.
+ * 2. Delete that single row from the database.
+ * 3. Remove the `_session` and `_session.sig` cookies from the response so
+ *    the browser no longer presents them.
+ */
+export async function POST() {
+  try {
+    // Ensure the caller is authenticated (still has a valid better-auth session)
+    const { userId } = await getUserAuth();
+    if (!userId) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get('_session');
+
+    if (!sessionCookie?.value) {
+      log('No _session cookie found, nothing to clear');
+      return NextResponse.json({ ok: true, cleared: false });
+    }
+
+    const sessionId = sessionCookie.value;
+    log('Clearing OIDC session %s for user %s', sessionId, userId);
+
+    // Delete the OIDC session row from the database
+    await serverDB.delete(oidcSessions).where(eq(oidcSessions.id, sessionId));
+
+    // Build a response that also expires the browser cookies
+    const response = NextResponse.json({ ok: true, cleared: true });
+
+    // Clear both the session cookie and its signature cookie
+    for (const name of ['_session', '_session.sig', '_session.legacy', '_session.legacy.sig']) {
+      response.cookies.set(name, '', {
+        expires: new Date(0),
+        httpOnly: true,
+        path: '/',
+      });
+    }
+
+    log('OIDC session cleared successfully');
+    return response;
+  } catch (error) {
+    log('Error clearing OIDC session: %O', error);
+    // Non-fatal — don't block the sign-out flow
+    return NextResponse.json({ ok: true, cleared: false, error: 'internal' });
+  }
+}

--- a/src/store/user/slices/auth/action.ts
+++ b/src/store/user/slices/auth/action.ts
@@ -60,6 +60,16 @@ export class UserAuthActionImpl {
   };
 
   logout = async (): Promise<void> => {
+    // Clear the OIDC Provider session for the current browser *before*
+    // destroying the better-auth session. This prevents a stale OIDC session
+    // from silently issuing tokens for the old account after the user signs
+    // in as someone else.
+    try {
+      await fetch('/oidc/clear-session', { method: 'POST' });
+    } catch {
+      // Best-effort: don't block sign-out if the cleanup request fails
+    }
+
     const { signOut } = await import('@/libs/better-auth/auth-client');
     await signOut({
       fetchOptions: {


### PR DESCRIPTION
## Problem

When a user signs out on the web and signs back in as a different account, the OIDC Provider session (`_session` cookie → `oidc_sessions` DB row) still references the old `accountId`. The next OIDC `/authorize` flow silently reuses this stale session and issues tokens for the **wrong** user.

### Root Cause

better-auth and `oidc-provider` manage sessions independently:

1. **better-auth** `signOut()` → deletes its own session ✅
2. **oidc-provider** → its `_session` cookie and `oidc_sessions` DB row persist because nothing triggers cleanup ❌

### Why not delete all sessions by userId?

That would log the user out of **every** device (desktop, CLI, mobile) — not acceptable. We need to clear only the **current browser's** OIDC session.

## Fix

### 1. New API route: `POST /oidc/clear-session`

```
src/app/(backend)/oidc/clear-session/route.ts
```

- Reads the `_session` cookie from the current request (this is the `oidc_sessions` primary key)
- Deletes that single row from the database
- Expires `_session` / `_session.sig` / legacy variants in the response

### 2. Frontend: call before `signOut()`

```ts
// src/store/user/slices/auth/action.ts
logout = async () => {
  // Clear OIDC session for current browser before destroying better-auth session
  try {
    await fetch('/oidc/clear-session', { method: 'POST' });
  } catch {
    // Best-effort
  }

  const { signOut } = await import('@/libs/better-auth/auth-client');
  await signOut({ ... });
};
```

Called **before** `signOut()` so `getUserAuth()` still returns the current userId (used to gate the endpoint behind auth).

### Properties

- ✅ Only affects the current browser — other devices keep their OIDC sessions
- ✅ Non-fatal — if the cleanup fails, sign-out still proceeds
- ✅ No schema changes needed — uses existing `oidc_sessions.id` primary key
- ✅ Cleans up both DB row and browser cookies

## Changed Files

- `src/app/(backend)/oidc/clear-session/route.ts` — new API route
- `src/store/user/slices/auth/action.ts` — call clear-session before signOut