### PR TITLE
🔨 chore: split test-app shards and deprecate `isOnboarded`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,8 +97,8 @@ jobs:
     if: needs.check-duplicate-run.outputs.should_skip != 'true'
     strategy:
       matrix:
-        shard: [1, 2]
-    name: Test App (shard ${{ matrix.shard }}/2)
+        shard: [1, 2, 3]
+    name: Test App (shard ${{ matrix.shard }}/3)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -110,7 +110,7 @@ jobs:
         run: pnpm install
 
       - name: Run tests
-        run: bunx vitest --coverage --silent='passed-only' --reporter=default --reporter=blob --shard=${{ matrix.shard }}/2
+        run: bunx vitest --coverage --silent='passed-only' --reporter=default --reporter=blob --shard=${{ matrix.shard }}/3
 
       - name: Upload blob report
         if: ${{ !cancelled() }}

--- a/packages/database/src/schemas/user.ts
+++ b/packages/database/src/schemas/user.ts
@@ -25,6 +25,7 @@ export const users = pgTable(
     fullName: text('full_name'),
     interests: varchar('interests', { length: 64 }).array(),
 
+    /** @deprecated */
     isOnboarded: boolean('is_onboarded').default(false),
     agentOnboarding: jsonb('agent_onboarding').$type<UserAgentOnboarding>(),
     onboarding: jsonb('onboarding').$type<UserOnboarding>(),


### PR DESCRIPTION
#### 💻 Change Type

- [x] 👷 build
- [x] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Two small unrelated cleanups bundled together per author preference:

1. **CI** — Split the `test-app` job matrix from 2 shards to 3 shards to cut per-job wall time. The `merge-app-coverage` job already matches blob artifacts via the `blob-report-*` pattern, so no other workflow changes are needed.
2. **Schema** — Add a JSDoc `@deprecated` marker to the `isOnboarded` column on `users` so IDE/TypeScript users get a strikethrough and in-editor hint when referencing it. No runtime behavior change — the column and default are preserved. The `onboarding` / `agentOnboarding` JSONB columns below appear to be the newer onboarding model; the migration/replacement story is left to a follow-up.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

CI will run the new 3-shard matrix automatically on this PR. Deprecation is purely editor-surface; TS compilation/runtime is unaffected.

#### 📝 Additional Information

If we later want to drop the `isOnboarded` column, that should be a separate PR with a migration.