### PR TITLE
🔨 chore: mark `isOnboarded` user column as deprecated

### DIFF
--- a/packages/database/src/schemas/user.ts
+++ b/packages/database/src/schemas/user.ts
@@ -25,6 +25,7 @@ export const users = pgTable(
     fullName: text('full_name'),
     interests: varchar('interests', { length: 64 }).array(),
 
+    /** @deprecated */
     isOnboarded: boolean('is_onboarded').default(false),
     agentOnboarding: jsonb('agent_onboarding').$type<UserAgentOnboarding>(),
     onboarding: jsonb('onboarding').$type<UserOnboarding>(),


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Add a JSDoc `@deprecated` marker to the `isOnboarded` column on `users` so IDE/TypeScript users get a strikethrough and in-editor hint when referencing it. No runtime behavior change — the column and default are preserved.

The `onboarding` / `agentOnboarding` JSONB columns below it appear to be the newer onboarding model; leaving the migration/replacement story to a follow-up.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

TS compilation/runtime is unaffected; only editor tooling surfaces the deprecation.

#### 📝 Additional Information

No schema migration needed. If we later want to drop the column, that should be a separate PR with a migration.