### PR TITLE
✨ feat(cc-topic): folder chip + unify cwd into workingDirectory

### DIFF
--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -50,16 +50,11 @@ export interface ChatTopicMetadata {
   bot?: ChatTopicBotContext;
   boundDeviceId?: string;
   /**
-   * Working directory that was active when `ccSessionId` was created.
-   * CC CLI stores sessions per-cwd under `~/.claude/projects/<encoded-cwd>/`,
-   * so a sessionId is only resumable while the process runs in the same cwd.
-   * Compare against the current agent cwd before passing `--resume`.
-   */
-  ccSessionCwd?: string;
-  /**
    * CC session ID for multi-turn resume (desktop only).
    * Persisted after each CC execution so the next message in the same topic
    * can use `--resume <sessionId>` to continue the conversation.
+   * CC CLI stores sessions per-cwd under `~/.claude/projects/<encoded-cwd>/`,
+   * so resume requires the current cwd to equal `workingDirectory`.
    */
   ccSessionId?: string;
   /**
@@ -87,8 +82,10 @@ export interface ChatTopicMetadata {
   userMemoryExtractRunState?: TopicUserMemoryExtractRunState;
   userMemoryExtractStatus?: 'pending' | 'completed' | 'failed';
   /**
-   * Local System working directory (desktop only)
-   * Priority is higher than Agent-level settings
+   * Topic-level working directory (desktop only).
+   * Priority is higher than Agent-level settings. Also serves as the
+   * binding cwd for a CC session — written on first CC execution and
+   * checked on subsequent turns to decide whether `--resume` is safe.
    */
   workingDirectory?: string;
 }

--- a/src/routes/(main)/agent/features/Conversation/Header/Tags/FolderTag.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/Tags/FolderTag.tsx
@@ -1,0 +1,79 @@
+import { Github } from '@lobehub/icons';
+import { Icon, Tooltip } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { FolderIcon, GitBranchIcon } from 'lucide-react';
+import { memo, type ReactNode, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { isDesktop } from '@/const/version';
+import { getRecentDirs } from '@/features/ChatInput/RuntimeConfig/recentDirs';
+import { localFileService } from '@/services/electron/localFileService';
+import { useChatStore } from '@/store/chat';
+import { topicSelectors } from '@/store/chat/selectors';
+
+const styles = createStaticStyles(({ css }) => ({
+  chip: css`
+    cursor: pointer;
+
+    display: inline-flex;
+    gap: 4px;
+    align-items: center;
+
+    height: 22px;
+    padding-inline: 8px;
+    border-radius: 4px;
+
+    font-size: 12px;
+    color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorFillQuaternary};
+
+    transition: all 0.2s;
+
+    &:hover {
+      color: ${cssVar.colorText};
+      background: ${cssVar.colorFillSecondary};
+    }
+  `,
+  label: css`
+    overflow: hidden;
+    max-width: 200px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+}));
+
+const FolderTag = memo(() => {
+  const { t } = useTranslation('tool');
+
+  const topicBoundDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
+
+  const iconNode = useMemo((): ReactNode => {
+    if (!topicBoundDirectory) return null;
+    const match = getRecentDirs().find((d) => d.path === topicBoundDirectory);
+    if (match?.repoType === 'github') return <Github size={12} />;
+    if (match?.repoType === 'git') return <Icon icon={GitBranchIcon} size={12} />;
+    return <Icon icon={FolderIcon} size={12} />;
+  }, [topicBoundDirectory]);
+
+  if (!isDesktop || !topicBoundDirectory) return null;
+
+  const displayName = topicBoundDirectory.split('/').findLast(Boolean) || topicBoundDirectory;
+
+  const handleOpen = () => {
+    void localFileService.openLocalFolder({ isDirectory: true, path: topicBoundDirectory });
+  };
+
+  return (
+    <Tooltip title={`${topicBoundDirectory} · ${t('localFiles.openFolder')}`}>
+      <div className={styles.chip} onClick={handleOpen}>
+        {iconNode}
+        <span className={styles.label}>{displayName}</span>
+      </div>
+    </Tooltip>
+  );
+});
+
+FolderTag.displayName = 'TopicFolderTag';
+
+export default FolderTag;

--- a/src/routes/(main)/agent/features/Conversation/Header/Tags/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/Tags/index.tsx
@@ -6,6 +6,7 @@ import { topicSelectors } from '@/store/chat/selectors';
 import { useSessionStore } from '@/store/session';
 import { sessionSelectors } from '@/store/session/selectors';
 
+import FolderTag from './FolderTag';
 import MemberCountTag from './MemberCountTag';
 
 const TitleTags = memo(() => {
@@ -20,22 +21,23 @@ const TitleTags = memo(() => {
     );
   }
 
-  if (!topicTitle) return null;
-
   return (
-    <Flexbox horizontal align={'center'} gap={4}>
-      <span
-        style={{
-          fontSize: 14,
-          marginLeft: 8,
-          opacity: 0.6,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {topicTitle}
-      </span>
+    <Flexbox horizontal align={'center'} gap={8}>
+      {topicTitle && (
+        <span
+          style={{
+            fontSize: 14,
+            marginLeft: 8,
+            opacity: 0.6,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {topicTitle}
+        </span>
+      )}
+      <FolderTag />
     </Flexbox>
   );
 });

--- a/src/server/routers/lambda/topic.ts
+++ b/src/server/routers/lambda/topic.ts
@@ -557,7 +557,6 @@ export const topicRouter = router({
         id: z.string(),
         metadata: z.object({
           boundDeviceId: z.string().optional(),
-          ccSessionCwd: z.string().optional(),
           ccSessionId: z.string().optional(),
           model: z.string().optional(),
           onboardingFeedback: z

--- a/src/store/chat/slices/aiChat/actions/__tests__/ccResume.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/ccResume.test.ts
@@ -6,8 +6,8 @@ import { resolveCcResume } from '../ccResume';
 describe('resolveCcResume', () => {
   it('resumes when saved cwd matches current cwd', () => {
     const metadata: ChatTopicMetadata = {
-      ccSessionCwd: '/Users/me/projA',
       ccSessionId: 'session-123',
+      workingDirectory: '/Users/me/projA',
     };
 
     expect(resolveCcResume(metadata, '/Users/me/projA')).toEqual({
@@ -18,8 +18,8 @@ describe('resolveCcResume', () => {
 
   it('skips resume when saved cwd differs from current cwd', () => {
     const metadata: ChatTopicMetadata = {
-      ccSessionCwd: '/Users/me/projA',
       ccSessionId: 'session-123',
+      workingDirectory: '/Users/me/projA',
     };
 
     expect(resolveCcResume(metadata, '/Users/me/projB')).toEqual({
@@ -30,8 +30,8 @@ describe('resolveCcResume', () => {
 
   it('treats undefined current cwd as empty string (matches saved empty cwd)', () => {
     const metadata: ChatTopicMetadata = {
-      ccSessionCwd: '',
       ccSessionId: 'session-123',
+      workingDirectory: '',
     };
 
     expect(resolveCcResume(metadata, undefined)).toEqual({
@@ -42,8 +42,8 @@ describe('resolveCcResume', () => {
 
   it('flags mismatch when saved cwd is non-empty but current cwd is undefined', () => {
     const metadata: ChatTopicMetadata = {
-      ccSessionCwd: '/Users/me/projA',
       ccSessionId: 'session-123',
+      workingDirectory: '/Users/me/projA',
     };
 
     expect(resolveCcResume(metadata, undefined)).toEqual({
@@ -53,7 +53,7 @@ describe('resolveCcResume', () => {
   });
 
   it('resets legacy sessions that have no saved cwd', () => {
-    // Legacy topics created before ccSessionCwd was persisted are unverifiable.
+    // Legacy topics created before workingDirectory was persisted are unverifiable.
     // Passing the stale id through was the original bug — reset instead, and
     // let the next turn rebuild the session with a recorded cwd.
     const metadata: ChatTopicMetadata = {
@@ -84,7 +84,7 @@ describe('resolveCcResume', () => {
     // cwd field lingering without a sessionId shouldn't trigger the toast;
     // there's nothing to skip resuming.
     const metadata: ChatTopicMetadata = {
-      ccSessionCwd: '/Users/me/projA',
+      workingDirectory: '/Users/me/projA',
     };
 
     expect(resolveCcResume(metadata, '/Users/me/projB')).toEqual({

--- a/src/store/chat/slices/aiChat/actions/ccResume.ts
+++ b/src/store/chat/slices/aiChat/actions/ccResume.ts
@@ -13,17 +13,18 @@ export interface CcResumeDecision {
  * `~/.claude/projects/<encoded-cwd>/`, so resuming from a different cwd
  * blows up with "No conversation found with session ID".
  *
- * Strict rule: only resume when the stored cwd is present AND equals the
- * current cwd. Legacy topics (sessionId present, cwd missing) are reset —
- * we have no way to verify them, and silently passing a stale id is exactly
- * what caused the original failure.
+ * Strict rule: only resume when the topic's bound `workingDirectory` is
+ * present AND equals the current cwd. Legacy topics (sessionId present,
+ * workingDirectory missing) are reset — we have no way to verify them,
+ * and silently passing a stale id is exactly what caused the original
+ * failure.
  */
 export const resolveCcResume = (
   metadata: ChatTopicMetadata | undefined,
   currentWorkingDirectory: string | undefined,
 ): CcResumeDecision => {
   const savedSessionId = metadata?.ccSessionId;
-  const savedCwd = metadata?.ccSessionCwd;
+  const savedCwd = metadata?.workingDirectory;
   const cwd = currentWorkingDirectory ?? '';
 
   const canResume = !!savedSessionId && savedCwd !== undefined && savedCwd === cwd;

--- a/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
@@ -648,10 +648,12 @@ export const executeHeterogeneousAgent = async (
     // Persist CC session ID + the cwd it was created under, for multi-turn
     // resume. CC stores sessions per-cwd (`~/.claude/projects/<encoded-cwd>/`),
     // so the next turn must verify the cwd hasn't changed before `--resume`.
+    // Reuses `workingDirectory` as the topic-level binding — pinning the
+    // topic to this cwd once CC has executed here.
     if (adapter.sessionId && context.topicId) {
       get().updateTopicMetadata(context.topicId, {
-        ccSessionCwd: workingDirectory ?? '',
         ccSessionId: adapter.sessionId,
+        workingDirectory: workingDirectory ?? '',
       });
     }
   } catch (error) {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Stacked on top of #13942 (depends on `ccResume.ts` introduced there). Retarget to `canary` once #13942 merges.

#### 🔀 Description of Change

Two related changes for Claude Code desktop topics:

1. **Folder chip in topic header.** New `FolderTag` component renders next to the topic title when the active topic has a bound working directory. Desktop-only, non-group sessions only. Shows folder basename with a git/github-aware icon; tooltip displays the full path; clicking opens the folder in Finder/Explorer via `localFileService.openLocalFolder`. Falls back to the existing reusable primitives (`getRecentDirs`, `cssVar`, `createStaticStyles`).

2. **Unify `ccSessionCwd` → `workingDirectory`.** Previously a CC topic persisted two cwd-shaped fields: `metadata.workingDirectory` (user override) and `metadata.ccSessionCwd` (cwd captured at CC execution for resume safety). These diverged in semantics but covered the same concept. This PR removes `ccSessionCwd` entirely:
   - `heterogeneousAgentExecutor` now writes `workingDirectory` after each CC run (binding the topic to that cwd on first execution)
   - `resolveCcResume` reads `metadata?.workingDirectory` for the cwd-match guard
   - `ChatTopicMetadata` and the zod schema on `updateTopicMetadata` drop the `ccSessionCwd` field
   - `ccResume.test.ts` updated accordingly

**Behavior change**: once CC has executed in a topic, that topic is pinned to the cwd it ran in — later changes to the agent-level cwd won't affect it. This is the correct semantic for CC resume safety (CC CLI stores sessions under `~/.claude/projects/<encoded-cwd>/`, so resuming from a different cwd is unsafe).

**Migration**: existing topics with only `ccSessionCwd` set will lose resume capability on their next turn and will start a fresh CC session. Per project owner: acceptable since this flow is still in lab.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bunx vitest run src/store/chat/slices/aiChat/actions/__tests__/ccResume.test.ts` — 8/8 pass
- `bun run type-check` — clean
- Manual: open a CC topic with a bound folder; verify the chip appears next to the title with the folder name; hover to see full path; click to open Finder.
- Manual: verify the chip does not render for non-CC agents, mobile/web, group sessions, or topics without `workingDirectory`.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Topic title only | Topic title + clickable folder chip (desktop, bound topics) |

#### 📝 Additional Information

The zod schema entry for `ccSessionCwd` in `src/server/routers/lambda/topic.ts` is also removed — per reviewer feedback, it's no longer needed alongside the type change.